### PR TITLE
feat: improve GitHub Action with caching, validation, and test coverage

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -160,6 +160,104 @@ jobs:
           fi
           echo "Clean project reported 0 issues"
 
+  test-dupes:
+    name: Test dupes command
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run action with dupes command
+        id: fallow
+        uses: ./
+        with:
+          command: dupes
+          root: tests/fixtures/duplicate-code
+          format: json
+          fail-on-issues: false
+
+      - name: Verify dupes JSON results
+        env:
+          RESULTS_PATH: ${{ steps.fallow.outputs.results }}
+          ISSUES: ${{ steps.fallow.outputs.issues }}
+        run: |
+          if [ ! -f "$RESULTS_PATH" ]; then
+            echo "::error::Results output file not found"
+            exit 1
+          fi
+
+          # Validate JSON
+          jq empty "$RESULTS_PATH"
+
+          # Verify dupes-specific fields
+          jq -e '.stats.clone_groups' "$RESULTS_PATH" > /dev/null
+          jq -e '.stats.total_files' "$RESULTS_PATH" > /dev/null
+          echo "Dupes JSON structure validated"
+
+          # Issues output should match clone_groups
+          JSON_GROUPS=$(jq -r '.stats.clone_groups' "$RESULTS_PATH")
+          if [ "$ISSUES" != "$JSON_GROUPS" ]; then
+            echo "::error::Output issues ($ISSUES) does not match stats.clone_groups ($JSON_GROUPS)"
+            exit 1
+          fi
+          echo "Clone groups: $ISSUES"
+
+  test-fix:
+    name: Test fix command (dry-run)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run action with fix command
+        id: fallow
+        uses: ./
+        with:
+          command: fix
+          root: tests/fixtures/basic-project
+          format: json
+          fail-on-issues: false
+          dry-run: true
+
+      - name: Verify fix JSON results
+        env:
+          RESULTS_PATH: ${{ steps.fallow.outputs.results }}
+          ISSUES: ${{ steps.fallow.outputs.issues }}
+        run: |
+          if [ ! -f "$RESULTS_PATH" ]; then
+            echo "::error::Results output file not found"
+            exit 1
+          fi
+
+          # Validate JSON
+          jq empty "$RESULTS_PATH"
+
+          # Verify fix-specific fields
+          jq -e '.fixes' "$RESULTS_PATH" > /dev/null
+          jq -e '.dry_run' "$RESULTS_PATH" > /dev/null
+          echo "Fix JSON structure validated (dry_run=$(jq -r '.dry_run' "$RESULTS_PATH"))"
+
+          # Verify dry_run is true
+          DRY_RUN=$(jq -r '.dry_run' "$RESULTS_PATH")
+          if [ "$DRY_RUN" != "true" ]; then
+            echo "::error::Expected dry_run=true, got: $DRY_RUN"
+            exit 1
+          fi
+
   test-comment:
     name: Test PR comment
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,26 @@ fallow check --format json --quiet --changed-since main
 - `--baseline <path>` -- compare against a saved baseline
 - `--save-baseline <path>` -- save current results as a baseline
 - `--production` -- exclude test/story/dev files, only start/build scripts, report type-only dependencies
+- `--workspace <name>` -- scope output to a single workspace package (monorepo support)
 - Issue type filters: `--unused-files`, `--unused-exports`, `--unused-deps`, `--unused-types`, `--unused-enum-members`, `--unused-class-members`, `--unresolved-imports`, `--unlisted-deps`, `--duplicate-exports`
+
+### `dupes`
+
+Find code duplication / clones across the project.
+
+```bash
+fallow dupes --format json --quiet
+fallow dupes --format json --quiet --mode semantic
+fallow dupes --format json --quiet --threshold 5
+```
+
+**Flags:**
+- `--mode strict|mild|weak|semantic` -- detection mode (default: mild)
+- `--min-tokens <N>` -- minimum token count for a clone (default: 50)
+- `--min-lines <N>` -- minimum line count for a clone (default: 5)
+- `--threshold <PCT>` -- fail if duplication exceeds this percentage (0 = no limit)
+- `--skip-local` -- only report cross-directory duplicates
+- `--baseline <path>` / `--save-baseline <path>` -- incremental CI adoption
 
 ### `fix`
 
@@ -130,6 +149,19 @@ fallow check --format json --quiet --changed-since main --fail-on-issues
 
 ```bash
 fallow check --format json --quiet --production
+```
+
+### Analyze a single workspace package (monorepo)
+
+```bash
+fallow check --format json --quiet --workspace my-package
+```
+
+### Find code duplication
+
+```bash
+fallow dupes --format json --quiet
+fallow dupes --format json --quiet --mode semantic --threshold 5
 ```
 
 ### Safe auto-fix cycle

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,6 @@ Fallow is a Rust-native dead code and duplication analyzer for JavaScript/TypeSc
 
 ### Known Limitations
 
-- **No cross-workspace resolution**: Monorepo packages are analyzed independently. Exports used by sibling packages get flagged as unused.
 - **Syntactic analysis only**: No TypeScript type information. Projects using `isolatedModules: true` (required for esbuild/swc/vite) are well-served; legacy tsc-only projects may see false positives on type-only imports.
 - **Config parsing ceiling**: AST-based extraction covers static object literals, string arrays, and simple wrappers like `defineConfig(...)`. Computed values (`getPlugins()`), conditionals (`process.env.NODE_ENV`), and nested config factories are out of reach without JS eval.
 - **Dupes: no cross-language semantic matching yet**: Semantic mode works within JS/TS but doesn't yet detect clones between `.ts` and `.tsx` variants or across language boundaries.
@@ -69,13 +68,15 @@ Add benchmarks on 1,000+ and 5,000+ file projects for both `check` and `dupes`. 
 
 Reach developers where they are: CI, editors, AI tools.
 
-### 2.1 GitHub Action
+### 2.1 GitHub Action ✅
 
-Publish `fallow-action` to the GitHub Marketplace. This is the highest-leverage adoption driver — it's largely a wrapper around existing capabilities:
-- Run `check` and `dupes` on PRs with SARIF upload to Code Scanning
-- Inline annotations on changed lines for both dead code and duplication
-- Configurable: fail on new issues, duplication threshold, report-only mode
-- Cache the fallow binary and analysis cache
+Published as a composite action with multi-command support (`check`, `dupes`, `fix`):
+- SARIF upload to GitHub Code Scanning with inline annotations
+- PR comments with markdown summaries (create or update)
+- Configurable: fail on new issues, duplication threshold, report-only mode, workspace scoping
+- Analysis cache via `actions/cache` for the `.fallow/` incremental cache
+- Job summaries with detailed breakdowns per command
+- Baseline support for incremental CI adoption
 
 ### 2.2 MCP Server
 
@@ -171,7 +172,7 @@ Extend import extraction to `.astro`, `.mdx`, and improve existing `.vue`/`.svel
 - [x] Production mode for CI pipelines
 - [ ] Stable config format with backwards compatibility promise
 - [ ] Stable JSON output schema for CI consumers
-- [ ] GitHub Action published
+- [x] GitHub Action published
 - [ ] MCP server published
 - [ ] VS Code extension published
 - [x] Duplication detection with clone families and baseline tracking

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     description: 'Only report cross-directory duplicates (dupes command)'
     required: false
     default: 'false'
+  # Workspace
+  workspace:
+    description: 'Scope output to a single workspace package by name (monorepo support)'
+    required: false
   # Fix-specific inputs
   dry-run:
     description: 'Preview changes without modifying files (fix command, default: true for CI safety)'
@@ -130,7 +134,8 @@ runs:
             table_row("Unused class members"; "unused_class_members"),
             table_row("Unresolved imports"; "unresolved_imports"),
             table_row("Unlisted dependencies"; "unlisted_dependencies"),
-            table_row("Duplicate exports"; "duplicate_exports")
+            table_row("Duplicate exports"; "duplicate_exports"),
+            table_row("Type-only dependencies"; "type_only_dependencies")
           ] | join("\n")) +
           "\n\n<details>\n<summary>View details</summary>\n\n" +
           detail_section("Unused files"; "unused_files";
@@ -153,6 +158,8 @@ runs:
             "- `\(.package_name)`\(if (.imported_from | length) > 0 then " (used in \(.imported_from[:3] | join(", ")))" else "" end)") +
           detail_section("Duplicate exports"; "duplicate_exports";
             "- `\(.export_name)` in \(.locations[:5] | join(", "))\(if (.locations | length) > 5 then " *(+\((.locations | length) - 5) more)*" else "" end)") +
+          detail_section("Type-only dependencies"; "type_only_dependencies";
+            "- `\(.package_name)` (move to devDependencies)") +
           "\n\n</details>"
         end
         JQEOF
@@ -241,6 +248,14 @@ runs:
         fi
         echo "Installed fallow $(fallow --version 2>/dev/null || echo 'unknown version')"
 
+    - name: Cache analysis results
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.root }}/.fallow
+        key: fallow-cache-${{ runner.os }}-${{ hashFiles(format('{0}/**/package.json', inputs.root)) }}
+        restore-keys: |
+          fallow-cache-${{ runner.os }}-
+
     - name: Run analysis
       id: analyze
       shell: bash
@@ -260,12 +275,24 @@ runs:
         INPUT_THRESHOLD: ${{ inputs.threshold }}
         INPUT_SKIP_LOCAL: ${{ inputs.skip-local }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_WORKSPACE: ${{ inputs.workspace }}
       run: |
         # Validate command
         case "$INPUT_COMMAND" in
           check|dupes|fix) ;;
           *) echo "::error::Invalid command: ${INPUT_COMMAND}. Must be check, dupes, or fix."; exit 2 ;;
         esac
+
+        # Validate numeric inputs
+        for name_val in "min-tokens:$INPUT_MIN_TOKENS" "min-lines:$INPUT_MIN_LINES"; do
+          name="${name_val%%:*}"; val="${name_val#*:}"
+          if [ -n "$val" ] && ! [[ "$val" =~ ^[0-9]+$ ]]; then
+            echo "::error::${name} must be a positive integer, got: ${val}"; exit 2
+          fi
+        done
+        if [ -n "$INPUT_THRESHOLD" ] && ! [[ "$INPUT_THRESHOLD" =~ ^[0-9]+\.?[0-9]*$ ]]; then
+          echo "::error::threshold must be a number, got: ${INPUT_THRESHOLD}"; exit 2
+        fi
 
         # Check for --sarif-file support (check command only)
         HAS_SARIF_FILE=false
@@ -286,6 +313,7 @@ runs:
         [ -n "$INPUT_CHANGED_SINCE" ] && ARGS+=(--changed-since "$INPUT_CHANGED_SINCE")
         [ -n "$INPUT_BASELINE" ] && ARGS+=(--baseline "$INPUT_BASELINE")
         [ -n "$INPUT_SAVE_BASELINE" ] && ARGS+=(--save-baseline "$INPUT_SAVE_BASELINE")
+        [ -n "$INPUT_WORKSPACE" ] && ARGS+=(--workspace "$INPUT_WORKSPACE")
 
         # Command-specific arguments
         case "$INPUT_COMMAND" in
@@ -324,12 +352,15 @@ runs:
         fi
 
         # Fallback SARIF generation (separate run when --sarif-file not available)
-        if [ "$INPUT_FORMAT" = "sarif" ] && [ "$INPUT_COMMAND" != "fix" ] && [ ! -f fallow-results.sarif ]; then
+        if [ "$INPUT_FORMAT" = "sarif" ] && [ "$INPUT_COMMAND" != "fix" ] && \
+           { [ ! -f fallow-results.sarif ] || ! jq -e '.' fallow-results.sarif > /dev/null 2>&1; }; then
           SARIF_ARGS=("$INPUT_COMMAND" --root "$INPUT_ROOT" --quiet --format sarif)
           [ -n "$INPUT_CONFIG" ] && SARIF_ARGS+=(--config "$INPUT_CONFIG")
           [ "$INPUT_PRODUCTION" = "true" ] && SARIF_ARGS+=(--production)
           [ -n "$INPUT_CHANGED_SINCE" ] && SARIF_ARGS+=(--changed-since "$INPUT_CHANGED_SINCE")
           [ -n "$INPUT_BASELINE" ] && SARIF_ARGS+=(--baseline "$INPUT_BASELINE")
+          [ -n "$INPUT_SAVE_BASELINE" ] && SARIF_ARGS+=(--save-baseline "$INPUT_SAVE_BASELINE")
+          [ -n "$INPUT_WORKSPACE" ] && SARIF_ARGS+=(--workspace "$INPUT_WORKSPACE")
 
           # Carry over dupes-specific args for SARIF run
           if [ "$INPUT_COMMAND" = "dupes" ]; then
@@ -428,9 +459,12 @@ runs:
         esac
 
         # Generate comment body
-        COMMENT_BODY="$(jq -r -f "$JQ_FILE" fallow-results.json)
+        if ! COMMENT_BODY="$(jq -r -f "$JQ_FILE" fallow-results.json)
 
-        <!-- fallow-results -->"
+        <!-- fallow-results -->"; then
+          echo "::warning::Failed to generate PR comment body"
+          exit 0
+        fi
 
         # Find existing fallow comment to update (avoids spam on busy PRs)
         COMMENT_ID=$(gh api \
@@ -440,19 +474,25 @@ runs:
           2>/dev/null | head -1)
 
         if [ -n "$COMMENT_ID" ]; then
-          gh api \
+          if ! gh api \
             "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" \
             --method PATCH \
             --field body="$COMMENT_BODY" \
-            > /dev/null
-          echo "Updated existing PR comment"
+            > /dev/null; then
+            echo "::warning::Failed to update PR comment"
+          else
+            echo "Updated existing PR comment"
+          fi
         else
-          gh api \
+          if ! gh api \
             "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
             --method POST \
             --field body="$COMMENT_BODY" \
-            > /dev/null
-          echo "Created new PR comment"
+            > /dev/null; then
+            echo "::warning::Failed to create PR comment"
+          else
+            echo "Created new PR comment"
+          fi
         fi
 
     - name: Check threshold


### PR DESCRIPTION
## Summary

- Add `workspace` input for monorepo scoping (`--workspace` flag, added in v0.3.0)
- Add `actions/cache@v4` for `.fallow/` incremental analysis cache between CI runs
- Add `type_only_dependencies` to check summary jq template (was missing from table + details)
- Add input validation for `min-tokens`, `min-lines`, `threshold` (fail early with clear errors)
- Fix SARIF fallback: validate file is valid JSON before skipping, pass `--save-baseline`
- Add error handling for `gh api` calls in PR comment step
- Add `test-dupes` and `test-fix` jobs to test-action workflow
- Add `dupes` command and `--workspace` docs to AGENTS.md
- Mark GitHub Action as delivered in ROADMAP.md

## Test plan

- [ ] `test-sarif` job passes (existing)
- [ ] `test-json` job passes (existing)
- [ ] `test-zero-issues` job passes (existing)
- [ ] `test-dupes` job passes (new — validates dupes JSON structure)
- [ ] `test-fix` job passes (new — validates fix dry-run JSON structure)
- [ ] `test-comment` job passes on PR trigger (existing)