### PR TITLE
fix: include plugin entry points in list mode

### DIFF
--- a/crates/cli/src/list.rs
+++ b/crates/cli/src/list.rs
@@ -33,8 +33,9 @@ pub fn run_list(opts: &ListOptions<'_>) -> ExitCode {
 
     let show_all = should_show_all(opts);
 
-    // Run plugin detection to find active plugins (including workspace packages)
-    let plugin_result = if opts.plugins || show_all {
+    // Run plugin detection when plugin output is requested or when entry-point
+    // discovery needs plugin-provided entry points.
+    let plugin_result = if opts.plugins || opts.entry_points || show_all {
         let disc = fallow_core::discover::discover_files(&config);
         let file_paths: Vec<std::path::PathBuf> = disc.iter().map(|f| f.path.clone()).collect();
         let registry = fallow_core::plugins::PluginRegistry::new(config.external_plugins.clone());

--- a/crates/cli/tests/list_tests.rs
+++ b/crates/cli/tests/list_tests.rs
@@ -271,27 +271,28 @@ fn list_plugin_discovered_entry_points_in_show_all_mode() {
     }
 }
 
-/// BUG: When --entry-points is used without --plugins, plugin detection
-/// is skipped, so plugin-discovered entry points are missing.
-/// `fallow list --entry-points` returns fewer entry points than
-/// `fallow list` (show_all mode) for projects with framework plugins.
 #[test]
-fn list_entry_points_only_missing_plugin_entries_bug() {
+fn list_entry_points_only_includes_plugin_entries() {
     // show_all mode includes plugin-detected entry points
     let all_output = run_list("external-plugins", &["--format", "json"]);
     let all_json = parse_json(&all_output);
     let all_eps = all_json["entry_points"].as_array().unwrap();
 
-    // --entry-points only mode is missing plugin entries (this is a bug)
+    // --entry-points only mode should include the same plugin-discovered entries
     let ep_output = run_list("external-plugins", &["--entry-points", "--format", "json"]);
     let ep_json = parse_json(&ep_output);
     let ep_only = ep_json["entry_points"].as_array().unwrap();
 
-    // show_all has more entry points because it includes plugin-discovered ones
     assert!(
-        all_eps.len() > ep_only.len(),
-        "BUG: show_all mode ({}) has more entry points than --entry-points only ({}) \
-         because plugin detection is skipped when --entry-points is used alone",
+        ep_only
+            .iter()
+            .any(|ep| ep["source"].as_str().is_some_and(|s| s == "my-framework")),
+        "--entry-points output should include plugin-discovered entry points",
+    );
+    assert_eq!(
+        all_eps.len(),
+        ep_only.len(),
+        "show_all mode ({}) and --entry-points only mode ({}) should report the same entry points",
         all_eps.len(),
         ep_only.len(),
     );


### PR DESCRIPTION
## What

Make `fallow list --entry-points` include plugin-discovered entry points.

This updates the list command to:
- run plugin detection when `--entry-points` is requested
- keep `--entry-points` output consistent with the default `fallow list` output
- rename and update the regression test to assert the fixed behavior

## Why

`fallow list` already included plugin-discovered entry points in show-all mode, but `fallow list --entry-points` skipped plugin detection and returned fewer results for projects with framework plugins.

That made the dedicated entry-point mode inconsistent with the default list output.

## Test plan

- `cargo test -p fallow-cli list_entry_points_only_includes_plugin_entries`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo check --workspace`
- `cargo test --workspace --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items`
- `bash action/tests/run.sh`
- `bash ci/tests/run.sh`
