### PR TITLE
docs: refresh roadmap update marker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Fallow Roadmap
 
-> Last updated: 2026-04-05
+> Last updated: 2026-04-06
 
 AI agents write more code than ever. They rarely clean up after themselves. Every generated file, every scaffolded export, every copied utility accumulates until your codebase is half dead weight.
 


### PR DESCRIPTION
## What
- Refresh the roadmap's `Last updated` marker so it matches the current document state.

## Why
The roadmap content was already current on `main`, but the top-of-file update marker had drifted behind.

## Impact
The roadmap's status marker stays consistent with the latest docs refresh.

## Validation
- Verified the rebased diff against current `upstream/main`
