### PR TITLE
fix: harden ecosystem runner output

### DIFF
--- a/tests/ecosystem/README.md
+++ b/tests/ecosystem/README.md
@@ -4,7 +4,7 @@ Tests fallow against real-world open-source TypeScript/JavaScript projects to ca
 
 ## What this tests
 
-The script clones popular JS/TS projects (shallow, depth=1), optionally installs their dependencies, and runs `fallow dead-code --format json` against each one. It distinguishes between:
+The script clones popular JS/TS projects (shallow, depth=1), optionally installs their dependencies, and runs `fallow dead-code --format json --quiet` against each one. It distinguishes between:
 
 - **Exit 0** — fallow ran successfully, no issues found (rare for large projects)
 - **Exit 1** — fallow ran successfully, issues found (expected and normal)
@@ -76,6 +76,6 @@ The `ecosystem-full.yml` workflow runs:
 - **Weekly** on Sundays at 04:00 UTC (cron schedule)
 - **On demand** via manual workflow_dispatch trigger
 
-It builds fallow in release mode, clones all projects, runs the test script, and uploads JSON results as artifacts. The workflow fails if any project causes a crash.
+It builds fallow in release mode, clones all projects, runs the test script, and uploads JSON results plus per-project stderr logs as artifacts. The workflow fails if any project causes a crash.
 
 There is also a lighter `ecosystem.yml` workflow that runs on push/PR with a smaller set of projects.

--- a/tests/ecosystem/run.sh
+++ b/tests/ecosystem/run.sh
@@ -111,30 +111,41 @@ clone_project() {
 
 install_deps() {
     local dir="$1" cmd="$2"
+    local install_log
+    install_log="$(mktemp)"
 
     if [[ "$cmd" == "-" ]]; then
         return 0
     fi
 
     echo "    Installing dependencies..."
-    (cd "$dir" && eval "$cmd") 2>&1 | tail -5 || true
+    if (cd "$dir" && eval "$cmd") >"$install_log" 2>&1; then
+        tail -5 "$install_log"
+        rm -f "$install_log"
+        return 0
+    fi
+
+    tail -5 "$install_log"
+    rm -f "$install_log"
+    return 1
 }
 
 run_fallow() {
     local project_dir="$1" name="$2" output_file="$3"
     local exit_code=0
+    local stderr_file="${output_file%.json}.stderr.log"
 
     # Run fallow with a timeout (5 minutes per project)
     if command -v timeout &>/dev/null; then
-        timeout 300 "$FALLOW_BIN" dead-code --format json --root "$project_dir" \
-            > "$output_file" 2>&1 || exit_code=$?
+        timeout 300 "$FALLOW_BIN" dead-code --format json --quiet --root "$project_dir" \
+            > "$output_file" 2> "$stderr_file" || exit_code=$?
     elif command -v gtimeout &>/dev/null; then
-        gtimeout 300 "$FALLOW_BIN" dead-code --format json --root "$project_dir" \
-            > "$output_file" 2>&1 || exit_code=$?
+        gtimeout 300 "$FALLOW_BIN" dead-code --format json --quiet --root "$project_dir" \
+            > "$output_file" 2> "$stderr_file" || exit_code=$?
     else
         # No timeout command available, run without timeout
-        "$FALLOW_BIN" dead-code --format json --root "$project_dir" \
-            > "$output_file" 2>&1 || exit_code=$?
+        "$FALLOW_BIN" dead-code --format json --quiet --root "$project_dir" \
+            > "$output_file" 2> "$stderr_file" || exit_code=$?
     fi
 
     # timeout returns 124 on timeout, treat as crash


### PR DESCRIPTION
## What
- Preserve dependency install failures so the ecosystem runner can actually skip projects whose installs fail.
- Keep per-project result artifacts machine-readable by writing JSON to the `.json` file and stderr to a sidecar log.
- Use the canonical quiet `dead-code` invocation in the runner and align the README with the actual behavior.

## Why
The previous shell pipeline always returned success from `install_deps()`, so the caller's `SKIP: install failed` branch could never fire. The runner also merged stderr into files with a `.json` extension, which made those artifacts unreliable for machine consumption.

## Impact
Ecosystem runs now distinguish install failures from successful installs correctly, and the saved result files stay valid JSON while still preserving stderr for debugging.

## Validation
- bash -n tests/ecosystem/run.sh
- cargo fmt --all -- --check
- cargo build --workspace
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- bash action/tests/run.sh
