### PR TITLE
fix: use dunce::canonicalize to avoid \?\ path prefix on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +623,7 @@ version = "2.14.0"
 dependencies = [
  "clap",
  "colored",
+ "dunce",
  "fallow-config",
  "fallow-core",
  "fallow-types",
@@ -641,6 +648,7 @@ dependencies = [
 name = "fallow-config"
 version = "2.14.0"
 dependencies = [
+ "dunce",
  "glob",
  "globset",
  "json_comments",
@@ -662,6 +670,7 @@ version = "2.14.0"
 dependencies = [
  "criterion",
  "dhat",
+ "dunce",
  "fallow-config",
  "fallow-extract",
  "fallow-graph",
@@ -712,6 +721,7 @@ dependencies = [
 name = "fallow-graph"
 version = "2.14.0"
 dependencies = [
+ "dunce",
  "fallow-config",
  "fallow-types",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ schemars = "1"
 rayon = "1"
 
 # File system
+dunce = "1"
 ignore = "0.4"
 glob = "0.3"
 globset = { version = "0.4", features = ["serde1"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,7 @@ fallow-core = { workspace = true }
 fallow-config = { workspace = true }
 fallow-types = { workspace = true }
 clap = { workspace = true }
+dunce = { workspace = true }
 globset = { workspace = true }
 colored = { workspace = true }
 serde = { workspace = true }

--- a/crates/cli/src/validate.rs
+++ b/crates/cli/src/validate.rs
@@ -30,8 +30,7 @@ pub fn validate_git_ref(s: &str) -> Result<&str, String> {
 }
 
 pub fn validate_root(root: &std::path::Path) -> Result<PathBuf, String> {
-    let canonical = root
-        .canonicalize()
+    let canonical = dunce::canonicalize(root)
         .map_err(|e| format!("invalid root path '{}': {e}", root.display()))?;
     if !canonical.is_dir() {
         return Err(format!("root path '{}' is not a directory", root.display()));

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,6 +12,7 @@ description = "Configuration types for the fallow TypeScript/JavaScript codebase
 readme = "../../README.md"
 
 [dependencies]
+dunce = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 json_comments = { workspace = true }

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -101,10 +101,9 @@ fn resolve_confined(
     context: &str,
     source_config: &Path,
 ) -> Result<PathBuf, miette::Report> {
-    let canonical_base = base_dir
-        .canonicalize()
+    let canonical_base = dunce::canonicalize(base_dir)
         .map_err(|e| miette::miette!("Failed to resolve base dir {}: {}", base_dir.display(), e))?;
-    let canonical_file = resolved.canonicalize().map_err(|e| {
+    let canonical_file = dunce::canonicalize(resolved).map_err(|e| {
         miette::miette!(
             "Config file not found: {} ({}, referenced from {}): {}",
             resolved.display(),
@@ -531,7 +530,7 @@ fn resolve_extends_file(
         ));
     }
 
-    let canonical = path.canonicalize().map_err(|e| {
+    let canonical = dunce::canonicalize(path).map_err(|e| {
         miette::miette!(
             "Config file not found or unresolvable: {}: {}",
             path.display(),

--- a/crates/config/src/external_plugin.rs
+++ b/crates/config/src/external_plugin.rs
@@ -212,7 +212,7 @@ pub fn discover_external_plugins(
     let mut seen_names = rustc_hash::FxHashSet::default();
 
     // All paths are checked against the canonical root to prevent symlink escapes
-    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canonical_root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
 
     // 1. Explicit paths from config
     for path_str in config_plugin_paths {
@@ -257,7 +257,7 @@ pub fn discover_external_plugins(
 
 /// Check if a path resolves within the canonical root (follows symlinks).
 fn is_within_root(path: &Path, canonical_root: &Path) -> bool {
-    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let canonical = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     canonical.starts_with(canonical_root)
 }
 

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -47,7 +47,7 @@ pub struct WorkspaceDiagnostic {
 #[must_use]
 pub fn discover_workspaces(root: &Path) -> Vec<WorkspaceInfo> {
     let patterns = collect_workspace_patterns(root);
-    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canonical_root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
 
     let mut workspaces = expand_patterns_to_workspaces(root, &patterns, &canonical_root);
     workspaces.extend(collect_tsconfig_workspaces(root, &canonical_root));
@@ -78,10 +78,10 @@ pub fn find_undeclared_workspaces(
 
     let declared_roots: rustc_hash::FxHashSet<PathBuf> = declared
         .iter()
-        .map(|w| w.root.canonicalize().unwrap_or_else(|_| w.root.clone()))
+        .map(|w| dunce::canonicalize(&w.root).unwrap_or_else(|_| w.root.clone()))
         .collect();
 
-    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canonical_root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
 
     let mut undeclared = Vec::new();
 
@@ -152,7 +152,7 @@ fn check_undeclared(
     if !dir.join("package.json").exists() {
         return;
     }
-    let canonical = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    let canonical = dunce::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
     // Skip the project root itself
     if canonical == *canonical_root {
         return;
@@ -293,7 +293,7 @@ fn collect_tsconfig_workspaces(
     let mut workspaces = Vec::new();
 
     for dir in parse_tsconfig_references(root) {
-        let canonical_dir = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+        let canonical_dir = dunce::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
         // Security: skip references pointing to project root or outside it
         if canonical_dir == *canonical_root || !canonical_dir.starts_with(canonical_root) {
             continue;
@@ -338,7 +338,7 @@ fn mark_internal_dependencies(workspaces: &mut Vec<(WorkspaceInfo, Vec<String>)>
     {
         let mut seen = rustc_hash::FxHashSet::default();
         workspaces.retain(|(ws, _)| {
-            let canonical = ws.root.canonicalize().unwrap_or_else(|_| ws.root.clone());
+            let canonical = dunce::canonicalize(&ws.root).unwrap_or_else(|_| ws.root.clone());
             seen.insert(canonical)
         });
     }

--- a/crates/config/src/workspace/parsers.rs
+++ b/crates/config/src/workspace/parsers.rs
@@ -160,7 +160,7 @@ pub(super) fn expand_workspace_glob(
             .filter(|p| p.join("package.json").exists())
             .filter_map(|p| {
                 // Security: ensure workspace directory is within project root
-                p.canonicalize()
+                dunce::canonicalize(&p)
                     .ok()
                     .filter(|cp| cp.starts_with(canonical_root))
                     .map(|cp| (p, cp))
@@ -455,7 +455,7 @@ mod tests {
         )
         .unwrap();
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         let results = expand_workspace_glob(&temp_dir, "packages/core", &canonical_root);
         assert_eq!(results.len(), 1);
         assert!(results[0].0.ends_with("packages/core"));
@@ -474,7 +474,7 @@ mod tests {
         std::fs::write(temp_dir.join("packages/b/package.json"), r#"{"name": "b"}"#).unwrap();
         // c has no package.json — should be excluded
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         let results = expand_workspace_glob(&temp_dir, "packages/*", &canonical_root);
         assert_eq!(results.len(), 2);
 
@@ -498,7 +498,7 @@ mod tests {
         )
         .unwrap();
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         let results = expand_workspace_glob(&temp_dir, "packages/**/*", &canonical_root);
         assert_eq!(results.len(), 2);
 
@@ -619,7 +619,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).unwrap();
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         let results = expand_workspace_glob(&temp_dir, "nonexistent/*", &canonical_root);
         assert!(results.is_empty());
 
@@ -694,7 +694,7 @@ mod tests {
         std::fs::create_dir_all(temp_dir.join("packages/a")).unwrap();
         std::fs::write(temp_dir.join("packages/a/package.json"), r#"{"name": "a"}"#).unwrap();
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         // Trailing slash pattern gets `*` appended -> `packages/*`
         let results = expand_workspace_glob(&temp_dir, "packages/*", &canonical_root);
         assert_eq!(results.len(), 1);
@@ -718,7 +718,7 @@ mod tests {
         let ws_pkg = temp_dir.join("packages/foo");
         std::fs::write(ws_pkg.join("package.json"), r#"{"name":"foo"}"#).unwrap();
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         let results = expand_workspace_glob(&temp_dir, "packages/**", &canonical_root);
 
         assert!(results.iter().any(|(_orig, canon)| {
@@ -752,7 +752,7 @@ mod tests {
         .unwrap();
         // packages/without-pkg has no package.json
 
-        let canonical_root = temp_dir.canonicalize().unwrap();
+        let canonical_root = dunce::canonicalize(&temp_dir).unwrap();
         let results = expand_workspace_glob(&temp_dir, "packages/*", &canonical_root);
         assert_eq!(results.len(), 1);
         assert!(

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,6 +32,7 @@ oxc_syntax = { workspace = true }
 rayon = { workspace = true }
 
 # File system
+dunce = { workspace = true }
 ignore = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }

--- a/crates/core/src/discover/entry_points.rs
+++ b/crates/core/src/discover/entry_points.rs
@@ -95,7 +95,7 @@ pub fn resolve_entry_path(
 ) -> Option<EntryPoint> {
     let resolved = base.join(entry);
     // Security: ensure resolved path stays within the allowed root
-    let canonical_resolved = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+    let canonical_resolved = dunce::canonicalize(&resolved).unwrap_or_else(|_| resolved.clone());
     if !canonical_resolved.starts_with(canonical_root) {
         tracing::warn!(path = %entry, "Skipping entry point outside project root");
         return None;
@@ -107,7 +107,7 @@ pub fn resolve_entry_path(
     // fallow ignores dist/ by default, so we need the source file instead.
     if let Some(source_path) = try_output_to_source_path(base, entry) {
         // Security: ensure the mapped source path stays within the project root
-        if let Ok(canonical_source) = source_path.canonicalize()
+        if let Ok(canonical_source) = dunce::canonicalize(&source_path)
             && canonical_source.starts_with(canonical_root)
         {
             return Some(EntryPoint {
@@ -271,10 +271,7 @@ pub fn discover_entry_points(config: &ResolvedConfig, files: &[DiscoveredFile]) 
 
     // 2. Package.json entries
     // Pre-compute canonical root once for all resolve_entry_path calls
-    let canonical_root = config
-        .root
-        .canonicalize()
-        .unwrap_or_else(|_| config.root.clone());
+    let canonical_root = dunce::canonicalize(&config.root).unwrap_or_else(|_| config.root.clone());
     let pkg_path = config.root.join("package.json");
     if let Ok(pkg) = PackageJson::load(&pkg_path) {
         for entry_path in pkg.entry_points() {
@@ -396,9 +393,8 @@ pub fn discover_workspace_entry_points(
 
     let pkg_path = ws_root.join("package.json");
     if let Ok(pkg) = PackageJson::load(&pkg_path) {
-        let canonical_ws_root = ws_root
-            .canonicalize()
-            .unwrap_or_else(|_| ws_root.to_path_buf());
+        let canonical_ws_root =
+            dunce::canonicalize(ws_root).unwrap_or_else(|_| ws_root.to_path_buf());
         for entry_path in pkg.entry_points() {
             if let Some(ep) = resolve_entry_path(
                 ws_root,
@@ -813,7 +809,7 @@ mod tests {
             std::fs::create_dir_all(&src).unwrap();
             std::fs::write(src.join("index.ts"), "export const a = 1;").unwrap();
 
-            let canonical = dir.path().canonicalize().unwrap();
+            let canonical = dunce::canonicalize(dir.path()).unwrap();
             let result = resolve_entry_path(
                 dir.path(),
                 "src/index.ts",
@@ -828,7 +824,7 @@ mod tests {
         fn resolves_with_extension_fallback() {
             let dir = tempfile::tempdir().expect("create temp dir");
             // Use canonical base to avoid macOS /var → /private/var symlink mismatch
-            let canonical = dir.path().canonicalize().unwrap();
+            let canonical = dunce::canonicalize(dir.path()).unwrap();
             let src = canonical.join("src");
             std::fs::create_dir_all(&src).unwrap();
             std::fs::write(src.join("index.ts"), "export const a = 1;").unwrap();
@@ -854,7 +850,7 @@ mod tests {
         #[test]
         fn returns_none_for_nonexistent_file() {
             let dir = tempfile::tempdir().expect("create temp dir");
-            let canonical = dir.path().canonicalize().unwrap();
+            let canonical = dunce::canonicalize(dir.path()).unwrap();
             let result = resolve_entry_path(
                 dir.path(),
                 "does/not/exist.ts",
@@ -876,7 +872,7 @@ mod tests {
             std::fs::create_dir_all(&dist).unwrap();
             std::fs::write(dist.join("utils.js"), "// compiled").unwrap();
 
-            let canonical = dir.path().canonicalize().unwrap();
+            let canonical = dunce::canonicalize(dir.path()).unwrap();
             let result = resolve_entry_path(
                 dir.path(),
                 "./dist/utils.js",
@@ -898,7 +894,7 @@ mod tests {
         fn maps_build_output_to_src() {
             let dir = tempfile::tempdir().expect("create temp dir");
             // Use canonical base to avoid macOS /var → /private/var symlink mismatch
-            let canonical = dir.path().canonicalize().unwrap();
+            let canonical = dunce::canonicalize(dir.path()).unwrap();
             let src = canonical.join("src");
             std::fs::create_dir_all(&src).unwrap();
             std::fs::write(src.join("index.tsx"), "export default () => {};").unwrap();
@@ -925,7 +921,7 @@ mod tests {
             let dir = tempfile::tempdir().expect("create temp dir");
             std::fs::write(dir.path().join("index.ts"), "export const a = 1;").unwrap();
 
-            let canonical = dir.path().canonicalize().unwrap();
+            let canonical = dunce::canonicalize(dir.path()).unwrap();
             let result = resolve_entry_path(
                 dir.path(),
                 "index.ts",

--- a/crates/core/src/discover/infrastructure.rs
+++ b/crates/core/src/discover/infrastructure.rs
@@ -56,7 +56,7 @@ pub fn discover_infrastructure_entry_points(root: &Path) -> Vec<EntryPoint> {
     }
 
     // Resolve file references against project root
-    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canonical_root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let mut entries: Vec<EntryPoint> = file_refs
         .iter()
         .filter_map(|file_ref| {

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -15,7 +15,7 @@ fn path_matches(module_path: &Path, root: &Path, user_path: &str) -> bool {
     if rel_str == user_path || module_path.to_string_lossy() == user_path {
         return true;
     }
-    if root.canonicalize().is_ok_and(|canonical_root| {
+    if dunce::canonicalize(root).is_ok_and(|canonical_root| {
         module_path
             .strip_prefix(&canonical_root)
             .is_ok_and(|rel| rel.to_string_lossy() == user_path)

--- a/crates/graph/Cargo.toml
+++ b/crates/graph/Cargo.toml
@@ -19,6 +19,7 @@ fallow-types = { workspace = true }
 fallow-config = { workspace = true }
 
 # Resolution
+dunce = { workspace = true }
 oxc_resolver = { workspace = true }
 oxc_span = { workspace = true }
 

--- a/crates/graph/src/graph/mod.rs
+++ b/crates/graph/src/graph/mod.rs
@@ -80,8 +80,7 @@ impl ModuleGraph {
             .iter()
             .filter_map(|ep| {
                 path_to_id.get(&ep.path).copied().or_else(|| {
-                    ep.path
-                        .canonicalize()
+                    dunce::canonicalize(&ep.path)
                         .ok()
                         .and_then(|path| path_to_id.get(&path).copied())
                 })

--- a/crates/graph/src/resolve/fallbacks.rs
+++ b/crates/graph/src/resolve/fallbacks.rs
@@ -45,7 +45,7 @@ pub(super) fn try_path_alias_fallback(
                 return Some(ResolveResult::InternalModule(file_id));
             }
             // Fall back to canonical path lookup
-            if let Ok(canonical) = resolved_path.canonicalize() {
+            if let Ok(canonical) = dunce::canonicalize(resolved_path) {
                 if let Some(&file_id) = ctx.path_to_id.get(canonical.as_path()) {
                     return Some(ResolveResult::InternalModule(file_id));
                 }

--- a/crates/graph/src/resolve/mod.rs
+++ b/crates/graph/src/resolve/mod.rs
@@ -63,7 +63,7 @@ pub fn resolve_all_imports(
     // cause workspace roots to mismatch canonical file paths.
     let canonical_ws_roots: Vec<PathBuf> = workspaces
         .par_iter()
-        .map(|ws| ws.root.canonicalize().unwrap_or_else(|_| ws.root.clone()))
+        .map(|ws| dunce::canonicalize(&ws.root).unwrap_or_else(|_| ws.root.clone()))
         .collect();
     let workspace_roots: FxHashMap<&str, &Path> = workspaces
         .iter()
@@ -75,7 +75,7 @@ pub fn resolve_all_imports(
     // When true, raw paths == canonical paths for files under root, so we can skip
     // the upfront bulk canonicalize() of all source files (21k+ syscalls on large projects).
     // A lazy CanonicalFallback handles the rare intra-project symlink case.
-    let root_is_canonical = root.canonicalize().is_ok_and(|c| c == root);
+    let root_is_canonical = dunce::canonicalize(root).is_ok_and(|c| c == root);
 
     // Pre-compute canonical paths ONCE for all files in parallel (avoiding repeated syscalls).
     // Skipped when root is canonical — the lazy fallback below handles edge cases.
@@ -84,7 +84,7 @@ pub fn resolve_all_imports(
     } else {
         files
             .par_iter()
-            .map(|f| f.path.canonicalize().unwrap_or_else(|_| f.path.clone()))
+            .map(|f| dunce::canonicalize(&f.path).unwrap_or_else(|_| f.path.clone()))
             .collect()
     };
 

--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -98,7 +98,7 @@ pub(super) fn resolve_specifier(
             }
 
             // Fall back to canonical path lookup
-            match resolved_path.canonicalize() {
+            match dunce::canonicalize(resolved_path) {
                 Ok(canonical) => {
                     if let Some(&file_id) = ctx.path_to_id.get(canonical.as_path()) {
                         ResolveResult::InternalModule(file_id)

--- a/crates/graph/src/resolve/types.rs
+++ b/crates/graph/src/resolve/types.rs
@@ -112,8 +112,7 @@ impl<'a> CanonicalFallback<'a> {
             self.files
                 .iter()
                 .filter_map(|f| {
-                    f.path
-                        .canonicalize()
+                    dunce::canonicalize(&f.path)
                         .ok()
                         .map(|canonical| (canonical, f.id))
                 })
@@ -149,7 +148,7 @@ mod tests {
         }];
         let fallback = CanonicalFallback::new(&files);
 
-        let canonical = test_file.canonicalize().unwrap();
+        let canonical = dunce::canonicalize(&test_file).unwrap();
         assert_eq!(fallback.get(&canonical), Some(FileId(42)));
 
         // Second call uses cached map (OnceLock)


### PR DESCRIPTION
## What

Replace all `std::fs::canonicalize()` calls with `dunce::canonicalize()` across cli, config, core, and graph crates.

## Why

On Windows, `std::fs::canonicalize()` returns extended-length paths with a `\?\` prefix (e.g., `\?\C:\Users\...`). This prefix prevents `oxc_resolver`'s `TsconfigDiscovery::Auto` from walking up the directory tree to find `tsconfig.json`, causing all tsconfig `paths` aliases (e.g., `@/* → ./src/*`) to fail resolution.

This results in all path-aliased imports being reported as unresolved, which in turn causes false positives in unused file and unused dependency detection.

`dunce::canonicalize()` is the standard Rust ecosystem solution for this (see rust-lang/rust#42869). It strips the `\?\` prefix when safe to do so, and is a no-op on non-Windows platforms.

## Test plan

- `cargo test --workspace --all-targets` — all existing tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Manually tested on a Windows project with `@/*` tsconfig path aliases: 57 false-positive unresolved imports eliminated, unused file count now matches knip