### PR TITLE
feat: harden Vue and Nuxt framework edge cases

### DIFF
--- a/crates/core/src/discover/entry_points.rs
+++ b/crates/core/src/discover/entry_points.rs
@@ -475,7 +475,10 @@ pub fn discover_plugin_entry_point_sets(
     let mut builder = globset::GlobSetBuilder::new();
     let mut glob_meta: Vec<(&str, EntryPointRole)> = Vec::new();
     for (pattern, pname) in &plugin_result.entry_patterns {
-        if let Ok(glob) = globset::Glob::new(pattern) {
+        if let Ok(glob) = globset::GlobBuilder::new(pattern)
+            .literal_separator(true)
+            .build()
+        {
             builder.add(glob);
             let role = plugin_result
                 .entry_point_roles
@@ -491,7 +494,10 @@ pub fn discover_plugin_entry_point_sets(
         .chain(plugin_result.always_used.iter())
         .chain(plugin_result.fixture_patterns.iter())
     {
-        if let Ok(glob) = globset::Glob::new(pattern) {
+        if let Ok(glob) = globset::GlobBuilder::new(pattern)
+            .literal_separator(true)
+            .build()
+        {
             builder.add(glob);
             glob_meta.push((pname, EntryPointRole::Support));
         }
@@ -619,7 +625,10 @@ pub fn compile_glob_set(patterns: &[String]) -> Option<globset::GlobSet> {
     }
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in patterns {
-        if let Ok(glob) = globset::Glob::new(pattern) {
+        if let Ok(glob) = globset::GlobBuilder::new(pattern)
+            .literal_separator(true)
+            .build()
+        {
             builder.add(glob);
         }
     }
@@ -685,6 +694,15 @@ mod tests {
         assert!(set.is_match("src/foo.ts"));
         assert!(set.is_match("src/bar.js"));
         assert!(!set.is_match("src/bar.py"));
+    }
+
+    #[test]
+    fn compile_glob_set_keeps_star_within_a_single_path_segment() {
+        let patterns = vec!["composables/*.{ts,js}".to_string()];
+        let set = compile_glob_set(&patterns).expect("pattern should compile");
+
+        assert!(set.is_match("composables/useFoo.ts"));
+        assert!(!set.is_match("composables/nested/useFoo.ts"));
     }
 
     #[test]

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -72,6 +72,8 @@ const SUPPORT_ENTRY_POINT_PLUGINS: &[&str] = &[
 pub struct PluginResult {
     /// Additional entry point glob patterns discovered from config.
     pub entry_patterns: Vec<String>,
+    /// Additional export-usage rules discovered from config.
+    pub used_exports: Vec<(String, Vec<String>)>,
     /// Dependencies referenced in config files (should not be flagged as unused).
     pub referenced_dependencies: Vec<String>,
     /// Additional files that are always considered used.
@@ -88,6 +90,7 @@ impl PluginResult {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.entry_patterns.is_empty()
+            && self.used_exports.is_empty()
             && self.referenced_dependencies.is_empty()
             && self.always_used_files.is_empty()
             && self.path_aliases.is_empty()

--- a/crates/core/src/plugins/nuxt.rs
+++ b/crates/core/src/plugins/nuxt.rs
@@ -20,10 +20,14 @@ const ENTRY_PATTERNS: &[&str] = &[
     "server/api/**/*.{ts,js}",
     "server/routes/**/*.{ts,js}",
     "server/middleware/**/*.{ts,js}",
+    "server/plugins/**/*.{ts,js}",
     "server/utils/**/*.{ts,js}",
-    "plugins/**/*.{ts,js}",
-    "composables/**/*.{ts,js}",
-    "utils/**/*.{ts,js}",
+    // Nuxt only auto-registers top-level plugins plus nested index files.
+    "plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    // Nuxt only scans the top level of composables/utils by default.
+    "composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "utils/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
     "components/**/*.{vue,ts,tsx,js,jsx}",
     // Nuxt auto-scans modules/ for custom modules
     "modules/**/*.{ts,js}",
@@ -31,9 +35,10 @@ const ENTRY_PATTERNS: &[&str] = &[
     "app/pages/**/*.{vue,ts,tsx,js,jsx}",
     "app/layouts/**/*.{vue,ts,tsx,js,jsx}",
     "app/middleware/**/*.{ts,js}",
-    "app/plugins/**/*.{ts,js}",
-    "app/composables/**/*.{ts,js}",
-    "app/utils/**/*.{ts,js}",
+    "app/plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "app/plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "app/composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "app/utils/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
     "app/components/**/*.{vue,ts,tsx,js,jsx}",
     "app/modules/**/*.{ts,js}",
 ];
@@ -42,9 +47,10 @@ const SRC_DIR_ENTRY_PATTERNS: &[&str] = &[
     "pages/**/*.{vue,ts,tsx,js,jsx}",
     "layouts/**/*.{vue,ts,tsx,js,jsx}",
     "middleware/**/*.{ts,js}",
-    "plugins/**/*.{ts,js}",
-    "composables/**/*.{ts,js}",
-    "utils/**/*.{ts,js}",
+    "plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "utils/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
     "components/**/*.{vue,ts,tsx,js,jsx}",
 ];
 
@@ -62,6 +68,9 @@ const ALWAYS_USED: &[&str] = &[
 ];
 
 const SRC_DIR_ALWAYS_USED: &[&str] = &["app.vue", "app.config.{ts,js}", "error.vue"];
+const COMPONENT_ENTRY_GLOB: &str = "vue,ts,tsx,js,jsx";
+const SCRIPT_ENTRY_GLOB: &str = "ts,js,mts,cts,mjs,cjs";
+const SCRIPT_ENTRY_EXTENSIONS: &[&str] = &["ts", "js", "mts", "cts", "mjs", "cjs"];
 
 /// Implicit dependencies that Nuxt provides — these should not be flagged as unlisted.
 const TOOLING_DEPENDENCIES: &[&str] = &[
@@ -96,6 +105,42 @@ const TOOLING_DEPENDENCIES: &[&str] = &[
 
 const USED_EXPORTS_SERVER_API: &[&str] = &["default", "defineEventHandler"];
 const USED_EXPORTS_MIDDLEWARE: &[&str] = &["default"];
+const USED_EXPORTS_DEFAULT: &[&str] = &["default"];
+
+const DEFAULT_EXPORT_ENTRY_PATTERNS: &[&str] = &[
+    "pages/**/*.{vue,ts,tsx,js,jsx}",
+    "layouts/**/*.{vue,ts,tsx,js,jsx}",
+    "components/**/*.{vue,ts,tsx,js,jsx}",
+    "modules/**/*.{ts,js}",
+    "plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "app/pages/**/*.{vue,ts,tsx,js,jsx}",
+    "app/layouts/**/*.{vue,ts,tsx,js,jsx}",
+    "app/components/**/*.{vue,ts,tsx,js,jsx}",
+    "app/modules/**/*.{ts,js}",
+    "app/plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "app/plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "server/routes/**/*.{ts,js}",
+    "middleware/**/*.{ts,js}",
+    "app/middleware/**/*.{ts,js}",
+    "server/middleware/**/*.{ts,js}",
+    "server/plugins/**/*.{ts,js}",
+    "app.vue",
+    "app.config.{ts,js}",
+    "error.vue",
+    "app/app.vue",
+    "app/app.config.{ts,js}",
+    "app/error.vue",
+];
+
+const SRC_DIR_DEFAULT_EXPORT_PATTERNS: &[&str] = &[
+    "pages/**/*.{vue,ts,tsx,js,jsx}",
+    "layouts/**/*.{vue,ts,tsx,js,jsx}",
+    "components/**/*.{vue,ts,tsx,js,jsx}",
+    "modules/**/*.{ts,js}",
+    "plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+];
 
 /// Virtual module prefixes provided by Nuxt at build time.
 const VIRTUAL_MODULE_PREFIXES: &[&str] = &["#"];
@@ -161,10 +206,17 @@ impl Plugin for NuxtPlugin {
     }
 
     fn used_exports(&self) -> Vec<(&'static str, &'static [&'static str])> {
-        vec![
-            ("server/api/**/*.{ts,js}", USED_EXPORTS_SERVER_API),
-            ("middleware/**/*.{ts,js}", USED_EXPORTS_MIDDLEWARE),
-        ]
+        let mut exports = Vec::with_capacity(DEFAULT_EXPORT_ENTRY_PATTERNS.len() + 3);
+        exports.push(("server/api/**/*.{ts,js}", USED_EXPORTS_SERVER_API));
+        exports.push(("middleware/**/*.{ts,js}", USED_EXPORTS_MIDDLEWARE));
+        exports.push(("app/middleware/**/*.{ts,js}", USED_EXPORTS_MIDDLEWARE));
+        exports.extend(
+            DEFAULT_EXPORT_ENTRY_PATTERNS
+                .iter()
+                .copied()
+                .map(|pattern| (pattern, USED_EXPORTS_DEFAULT)),
+        );
+        exports
     }
 
     fn resolve_config(&self, config_path: &Path, source: &str, root: &Path) -> PluginResult {
@@ -205,13 +257,9 @@ impl Plugin for NuxtPlugin {
         for entry in &css {
             if let Some(stripped) = entry.strip_prefix("~/") {
                 // ~ = srcDir: resolve to the configured source root, if any.
-                if src_dir.is_empty() {
-                    result.always_used_files.push(stripped.to_string());
-                } else {
-                    result
-                        .always_used_files
-                        .push(format!("{src_dir}/{stripped}"));
-                }
+                result
+                    .always_used_files
+                    .push(prefix_with_src_dir(&src_dir, stripped));
             } else if let Some(stripped) = entry.strip_prefix("~~/") {
                 // ~~ = rootDir: always relative to project root
                 result.always_used_files.push(stripped.to_string());
@@ -234,9 +282,22 @@ impl Plugin for NuxtPlugin {
                 .push(crate::resolve::extract_package_name(plugin));
         }
 
-        // plugins: [...] → entry patterns
-        let plugins = config_parser::extract_config_string_array(source, config_path, &["plugins"]);
-        result.entry_patterns.extend(plugins);
+        // plugins: [...] → entry patterns with default-export coverage
+        let mut plugins =
+            config_parser::extract_config_string_array(source, config_path, &["plugins"]);
+        plugins.extend(config_parser::extract_config_array_object_strings(
+            source,
+            config_path,
+            &["plugins"],
+            "src",
+        ));
+        for plugin in plugins {
+            if let Some(normalized) = normalize_nuxt_path(&plugin, config_path, root, &src_dir) {
+                let pattern = script_entry_pattern(&normalized);
+                add_default_used_export(&mut result, &pattern);
+                result.entry_patterns.push(pattern);
+            }
+        }
 
         // alias: { "@shared": "./shared" } → resolver path aliases
         for (find, replacement) in
@@ -252,20 +313,27 @@ impl Plugin for NuxtPlugin {
         for dir in
             config_parser::extract_config_string_array(source, config_path, &["imports", "dirs"])
         {
-            if let Some(normalized) = normalize_nuxt_path(&dir, config_path, root, &src_dir) {
-                result.entry_patterns.push(format!(
-                    "{normalized}/**/*.{{ts,tsx,js,jsx,mts,cts,mjs,cjs}}"
-                ));
+            if let Some(pattern) = normalize_imports_dir_pattern(&dir, config_path, root, &src_dir)
+            {
+                result.entry_patterns.push(pattern);
             }
         }
 
         // components config supports string arrays, object arrays, and object.dirs arrays.
-        let mut component_dirs = config_parser::extract_config_array_object_strings(
+        let mut component_dirs =
+            config_parser::extract_config_string_array(source, config_path, &["components"]);
+        component_dirs.extend(config_parser::extract_config_array_object_strings(
             source,
             config_path,
             &["components"],
             "path",
-        );
+        ));
+        component_dirs.extend(config_parser::extract_config_array_object_strings(
+            source,
+            config_path,
+            &["components", "dirs"],
+            "path",
+        ));
         component_dirs.extend(config_parser::extract_config_string_array(
             source,
             config_path,
@@ -273,9 +341,9 @@ impl Plugin for NuxtPlugin {
         ));
         for dir in component_dirs {
             if let Some(normalized) = normalize_nuxt_path(&dir, config_path, root, &src_dir) {
-                result
-                    .entry_patterns
-                    .push(format!("{normalized}/**/*.{{vue,ts,tsx,js,jsx}}"));
+                let pattern = component_dir_pattern(&normalized);
+                add_default_used_export(&mut result, &pattern);
+                result.entry_patterns.push(pattern);
             }
         }
 
@@ -324,15 +392,53 @@ fn add_src_dir_support(result: &mut PluginResult, src_dir: &str) {
         return;
     }
 
-    for pattern in SRC_DIR_ENTRY_PATTERNS {
-        result.entry_patterns.push(format!("{src_dir}/{pattern}"));
-    }
+    extend_prefixed_patterns(&mut result.entry_patterns, src_dir, SRC_DIR_ENTRY_PATTERNS);
+    extend_prefixed_patterns(&mut result.always_used_files, src_dir, SRC_DIR_ALWAYS_USED);
+    add_prefixed_default_used_exports(result, src_dir, SRC_DIR_DEFAULT_EXPORT_PATTERNS);
+    add_default_used_export(
+        result,
+        prefix_with_src_dir(src_dir, "middleware/**/*.{ts,js}"),
+    );
+    add_prefixed_default_used_exports(result, src_dir, SRC_DIR_ALWAYS_USED);
+}
 
-    for pattern in SRC_DIR_ALWAYS_USED {
-        result
-            .always_used_files
-            .push(format!("{src_dir}/{pattern}"));
+fn add_default_used_export(result: &mut PluginResult, pattern: impl Into<String>) {
+    result
+        .used_exports
+        .push((pattern.into(), vec!["default".to_string()]));
+}
+
+fn add_prefixed_default_used_exports(result: &mut PluginResult, prefix: &str, patterns: &[&str]) {
+    for pattern in patterns {
+        add_default_used_export(result, prefix_with_src_dir(prefix, pattern));
     }
+}
+
+fn extend_prefixed_patterns(target: &mut Vec<String>, prefix: &str, patterns: &[&str]) {
+    target.extend(
+        patterns
+            .iter()
+            .map(|pattern| prefix_with_src_dir(prefix, pattern)),
+    );
+}
+
+fn component_dir_pattern(dir: &str) -> String {
+    format!("{dir}/**/*.{{{COMPONENT_ENTRY_GLOB}}}")
+}
+
+fn script_entry_pattern(path: &str) -> String {
+    if has_supported_extension(path, SCRIPT_ENTRY_EXTENSIONS) {
+        path.to_string()
+    } else {
+        format!("{path}.{{{SCRIPT_ENTRY_GLOB}}}")
+    }
+}
+
+fn has_supported_extension(path: &str, supported_extensions: &[&str]) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| supported_extensions.contains(&ext))
 }
 
 fn normalize_nuxt_path(
@@ -342,11 +448,7 @@ fn normalize_nuxt_path(
     src_dir: &str,
 ) -> Option<String> {
     if let Some(stripped) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("@/")) {
-        return Some(if src_dir.is_empty() {
-            stripped.to_string()
-        } else {
-            format!("{src_dir}/{stripped}")
-        });
+        return Some(prefix_with_src_dir(src_dir, stripped));
     }
 
     if let Some(stripped) = raw.strip_prefix("~~/").or_else(|| raw.strip_prefix("@@/")) {
@@ -354,6 +456,52 @@ fn normalize_nuxt_path(
     }
 
     config_parser::normalize_config_path(raw, config_path, root)
+}
+
+fn normalize_imports_dir_pattern(
+    raw: &str,
+    config_path: &Path,
+    root: &Path,
+    src_dir: &str,
+) -> Option<String> {
+    let normalized = normalize_nuxt_path(raw, config_path, root, src_dir)?;
+    Some(imports_dir_pattern(&normalized))
+}
+
+fn imports_dir_pattern(normalized: &str) -> String {
+    let normalized = normalized.trim_end_matches('/');
+    if normalized.is_empty() {
+        return "*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}".to_string();
+    }
+
+    if has_glob_syntax(normalized) {
+        if path_looks_like_file_pattern(normalized) {
+            normalized.to_string()
+        } else {
+            format!("{normalized}/*.{{ts,tsx,js,jsx,mts,cts,mjs,cjs}}")
+        }
+    } else {
+        format!("{normalized}/*.{{ts,tsx,js,jsx,mts,cts,mjs,cjs}}")
+    }
+}
+
+fn has_glob_syntax(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[') || pattern.contains('{')
+}
+
+fn path_looks_like_file_pattern(pattern: &str) -> bool {
+    pattern
+        .rsplit('/')
+        .next()
+        .is_some_and(|segment| segment.contains('.'))
+}
+
+fn prefix_with_src_dir(src_dir: &str, path: &str) -> String {
+    if src_dir.is_empty() {
+        path.to_string()
+    } else {
+        format!("{src_dir}/{path}")
+    }
 }
 
 #[cfg(test)]
@@ -387,7 +535,7 @@ mod tests {
         assert!(patterns.iter().any(|p| p.starts_with("pages/")));
         assert!(patterns.iter().any(|p| p.starts_with("layouts/")));
         assert!(patterns.iter().any(|p| p.starts_with("server/api/")));
-        assert!(patterns.iter().any(|p| p.starts_with("composables/")));
+        assert!(patterns.contains(&"composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"));
         assert!(patterns.iter().any(|p| p.starts_with("components/")));
     }
 
@@ -426,6 +574,36 @@ mod tests {
         let (_, names) = api_entry.unwrap();
         assert!(names.contains(&"default"));
         assert!(names.contains(&"defineEventHandler"));
+    }
+
+    #[test]
+    fn used_exports_cover_runtime_default_exports() {
+        let plugin = NuxtPlugin;
+        let exports = plugin.used_exports();
+
+        for pattern in [
+            "pages/**/*.{vue,ts,tsx,js,jsx}",
+            "layouts/**/*.{vue,ts,tsx,js,jsx}",
+            "components/**/*.{vue,ts,tsx,js,jsx}",
+            "plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+            "plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+            "modules/**/*.{ts,js}",
+            "server/routes/**/*.{ts,js}",
+            "server/plugins/**/*.{ts,js}",
+            "app/components/**/*.{vue,ts,tsx,js,jsx}",
+            "app.vue",
+            "app.config.{ts,js}",
+            "app/app.vue",
+        ] {
+            let entry = exports
+                .iter()
+                .find(|(candidate, _)| *candidate == pattern)
+                .unwrap_or_else(|| panic!("missing used_exports rule for {pattern}"));
+            assert!(
+                entry.1.contains(&"default"),
+                "{pattern} should keep the default export alive"
+            );
+        }
     }
 
     // ── resolve_config tests ─────────────────────────────────────
@@ -639,9 +817,9 @@ mod tests {
                 .contains(&("@/".to_string(), "app".to_string()))
         );
         assert!(
-            result.entry_patterns.contains(
-                &"app/custom/composables/**/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}".to_string()
-            )
+            result
+                .entry_patterns
+                .contains(&"app/custom/composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}".to_string())
         );
         assert!(
             result
@@ -649,9 +827,84 @@ mod tests {
                 .contains(&"app/feature-components/**/*.{vue,ts,tsx,js,jsx}".to_string())
         );
         assert!(
+            result.used_exports.contains(&(
+                "app/feature-components/**/*.{vue,ts,tsx,js,jsx}".to_string(),
+                vec!["default".to_string()],
+            )),
+            "custom component dirs should contribute default-export used rules"
+        );
+        assert!(
             result
                 .always_used_files
                 .contains(&"app/app.config.{ts,js}".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_config_plugins_supports_string_and_object_entries() {
+        let source = r#"
+            export default defineNuxtConfig({
+                srcDir: "app/",
+                plugins: [
+                    "~/runtime/plain-plugin",
+                    { src: "@/runtime/object-plugin", mode: "client" }
+                ]
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
+
+        for pattern in [
+            "app/runtime/plain-plugin.{ts,js,mts,cts,mjs,cjs}",
+            "app/runtime/object-plugin.{ts,js,mts,cts,mjs,cjs}",
+        ] {
+            assert!(
+                result.entry_patterns.contains(&pattern.to_string()),
+                "expected configured plugin entry pattern {pattern}, got {:?}",
+                result.entry_patterns
+            );
+            assert!(
+                result
+                    .used_exports
+                    .contains(&(pattern.to_string(), vec!["default".to_string()])),
+                "configured plugin pattern {pattern} should keep default exports alive"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_config_components_dirs_supports_nested_object_entries() {
+        let source = r#"
+            export default defineNuxtConfig({
+                srcDir: "app/",
+                components: {
+                    dirs: [
+                        { path: "~/feature/ui" }
+                    ]
+                }
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
+
+        let expected = "app/feature/ui/**/*.{vue,ts,tsx,js,jsx}".to_string();
+        assert!(
+            result.entry_patterns.contains(&expected),
+            "nested components.dirs object entries should add entry patterns"
+        );
+        assert!(
+            result
+                .used_exports
+                .contains(&(expected, vec!["default".to_string()])),
+            "nested components.dirs object entries should keep default component exports alive"
         );
     }
 
@@ -715,15 +968,28 @@ mod tests {
             "srcDir should remap @/ to the configured source root"
         );
         assert!(
-            result.entry_patterns.contains(
-                &"src/custom/composables/**/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}".to_string()
-            )
+            result
+                .entry_patterns
+                .contains(&"src/custom/composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}".to_string())
         );
         assert!(
             result
                 .entry_patterns
                 .contains(&"src/feature-components/**/*.{vue,ts,tsx,js,jsx}".to_string())
         );
+        for expected in [
+            "src/middleware/**/*.{ts,js}",
+            "src/plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+            "src/plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+            "src/components/**/*.{vue,ts,tsx,js,jsx}",
+        ] {
+            assert!(
+                result
+                    .used_exports
+                    .contains(&(expected.to_string(), vec!["default".to_string()])),
+                "{expected} should keep default exports alive under srcDir"
+            );
+        }
         assert!(
             result
                 .always_used_files
@@ -742,5 +1008,30 @@ mod tests {
                 .contains(&"src/error.vue".to_string()),
             "srcDir should add error.vue under the configured source root"
         );
+    }
+
+    #[test]
+    fn imports_dirs_glob_can_scan_nested_files() {
+        assert_eq!(
+            imports_dir_pattern("app/composables"),
+            "app/composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"
+        );
+        assert_eq!(
+            imports_dir_pattern("app/composables/**"),
+            "app/composables/**/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"
+        );
+        assert_eq!(
+            imports_dir_pattern("app/composables/*/index.{ts,js,mjs,mts}"),
+            "app/composables/*/index.{ts,js,mjs,mts}"
+        );
+    }
+
+    #[test]
+    fn entry_patterns_keep_nested_plugin_index_only() {
+        let plugin = NuxtPlugin;
+        let patterns = plugin.entry_patterns();
+        assert!(patterns.contains(&"plugins/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"));
+        assert!(patterns.contains(&"plugins/**/index.{ts,tsx,js,jsx,mts,cts,mjs,cjs}"));
+        assert!(!patterns.contains(&"plugins/**/*.{ts,js}"));
     }
 }

--- a/crates/core/src/plugins/registry/helpers.rs
+++ b/crates/core/src/plugins/registry/helpers.rs
@@ -185,6 +185,7 @@ pub fn process_config_result(
             .into_iter()
             .map(|p| (p, pname.clone())),
     );
+    result.used_exports.extend(plugin_result.used_exports);
     result
         .referenced_dependencies
         .extend(plugin_result.referenced_dependencies);

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -787,6 +787,7 @@ fn process_config_result_merges_all_fields() {
     let mut aggregated = AggregatedPluginResult::default();
     let config_result = PluginResult {
         entry_patterns: vec!["src/routes/**/*.ts".to_string()],
+        used_exports: vec![("src/routes/**/*.ts".to_string(), vec!["loader".to_string()])],
         referenced_dependencies: vec!["lodash".to_string(), "axios".to_string()],
         always_used_files: vec!["setup.ts".to_string()],
         path_aliases: vec![],
@@ -798,6 +799,10 @@ fn process_config_result_merges_all_fields() {
     assert_eq!(aggregated.entry_patterns.len(), 1);
     assert_eq!(aggregated.entry_patterns[0].0, "src/routes/**/*.ts");
     assert_eq!(aggregated.entry_patterns[0].1, "test-plugin");
+
+    assert_eq!(aggregated.used_exports.len(), 1);
+    assert_eq!(aggregated.used_exports[0].0, "src/routes/**/*.ts");
+    assert_eq!(aggregated.used_exports[0].1, vec!["loader".to_string()]);
 
     assert_eq!(aggregated.referenced_dependencies.len(), 2);
     assert!(
@@ -829,6 +834,7 @@ fn process_config_result_accumulates_across_multiple_calls() {
 
     let result1 = PluginResult {
         entry_patterns: vec!["a.ts".to_string()],
+        used_exports: vec![("a.ts".to_string(), vec!["default".to_string()])],
         referenced_dependencies: vec!["dep-a".to_string()],
         always_used_files: vec![],
         path_aliases: vec![],
@@ -837,6 +843,7 @@ fn process_config_result_accumulates_across_multiple_calls() {
     };
     let result2 = PluginResult {
         entry_patterns: vec!["b.ts".to_string()],
+        used_exports: vec![("b.ts".to_string(), vec!["loader".to_string()])],
         referenced_dependencies: vec!["dep-b".to_string()],
         always_used_files: vec!["c.ts".to_string()],
         path_aliases: vec![],
@@ -853,6 +860,10 @@ fn process_config_result_accumulates_across_multiple_calls() {
     assert_eq!(aggregated.entry_patterns[0].1, "plugin-a");
     assert_eq!(aggregated.entry_patterns[1].0, "b.ts");
     assert_eq!(aggregated.entry_patterns[1].1, "plugin-b");
+
+    assert_eq!(aggregated.used_exports.len(), 2);
+    assert_eq!(aggregated.used_exports[0].0, "a.ts");
+    assert_eq!(aggregated.used_exports[1].0, "b.ts");
 
     // Verify referenced dependencies from both calls
     assert_eq!(aggregated.referenced_dependencies.len(), 2);
@@ -941,6 +952,10 @@ fn plugin_result_not_empty_when_any_field_set() {
     let fields: Vec<PluginResult> = vec![
         PluginResult {
             entry_patterns: vec!["src/**/*.ts".to_string()],
+            ..Default::default()
+        },
+        PluginResult {
+            used_exports: vec![("src/**/*.ts".to_string(), vec!["loader".to_string()])],
             ..Default::default()
         },
         PluginResult {

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -430,3 +430,173 @@ fn nuxt_src_dir_config_reduces_false_positives() {
         "reachable nuxt srcDir aliased module should still report unused exports: {unused_export_names:?}"
     );
 }
+
+#[test]
+fn nuxt_default_scan_keeps_nested_plugin_index_but_not_nested_helpers() {
+    let root = fixture_path("nuxt-default-scan");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+
+    for expected_unused in ["useHidden.ts", "format.ts", "helper.ts"] {
+        assert!(
+            unused_file_names.contains(&expected_unused.to_string()),
+            "{expected_unused} should stay unused because Nuxt does not scan nested helpers by default: {unused_file_names:?}"
+        );
+    }
+
+    assert!(
+        !unused_file_names.contains(&"index.ts".to_string()),
+        "nested plugin index.ts should stay reachable via Nuxt plugin scanning: {unused_file_names:?}"
+    );
+}
+
+#[test]
+fn nuxt_runtime_conventions_report_dead_named_exports_without_unused_file_noise() {
+    let root = fixture_path("nuxt-runtime-conventions");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    for expected_used in ["RootBadge.vue", "bootstrap.ts", "auth.ts", "logger.ts"] {
+        assert!(
+            !unused_file_names.contains(&expected_used.to_string()),
+            "{expected_used} should be kept alive by Nuxt runtime conventions: {unused_file_names:?}"
+        );
+    }
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.path.file_name().unwrap().to_string_lossy().to_string(),
+                e.export_name.clone(),
+            )
+        })
+        .collect();
+    for (file, export) in [
+        ("RootBadge.vue", "deadNamed"),
+        ("bootstrap.ts", "deadPluginHelper"),
+        ("auth.ts", "deadMiddlewareHelper"),
+        ("logger.ts", "deadServerMiddlewareHelper"),
+    ] {
+        assert!(
+            unused_exports
+                .iter()
+                .any(|(unused_file, unused_export)| unused_file == file && unused_export == export),
+            "{file}:{export} should be reported as unused, found: {unused_exports:?}"
+        );
+    }
+}
+
+#[test]
+fn nuxt_configured_runtime_paths_reduce_false_positives_and_keep_dead_exports_visible() {
+    let root = fixture_path("nuxt-config-runtime-paths");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.file_name().unwrap().to_string_lossy().to_string())
+        .collect();
+    for expected_used in [
+        "FeatureCard.vue",
+        "plain-plugin.ts",
+        "object-plugin.ts",
+        "auth.ts",
+    ] {
+        assert!(
+            !unused_file_names.contains(&expected_used.to_string()),
+            "{expected_used} should be kept alive by configured Nuxt runtime paths: {unused_file_names:?}"
+        );
+    }
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.path.file_name().unwrap().to_string_lossy().to_string(),
+                e.export_name.clone(),
+            )
+        })
+        .collect();
+    for (file, export) in [
+        ("FeatureCard.vue", "deadFeatureNamed"),
+        ("plain-plugin.ts", "deadPlainPluginHelper"),
+        ("object-plugin.ts", "deadObjectPluginHelper"),
+        ("auth.ts", "deadAppMiddlewareHelper"),
+    ] {
+        assert!(
+            unused_exports
+                .iter()
+                .any(|(unused_file, unused_export)| unused_file == file && unused_export == export),
+            "{file}:{export} should be reported as unused, found: {unused_exports:?}"
+        );
+    }
+}
+
+#[test]
+fn nuxt_convention_exports_preserve_defaults_but_report_dead_helpers() {
+    let root = fixture_path("nuxt-convention-exports");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.path.file_name().unwrap().to_string_lossy().to_string(),
+                e.export_name.clone(),
+            )
+        })
+        .collect();
+
+    for (file, export) in [
+        ("app.vue", "default"),
+        ("app.config.ts", "default"),
+        ("index.vue", "default"),
+        ("default.vue", "default"),
+        ("FancyCard.vue", "default"),
+        ("client.ts", "default"),
+        ("hello.ts", "default"),
+        ("custom.ts", "default"),
+    ] {
+        assert!(
+            !unused_exports
+                .iter()
+                .any(|(unused_file, unused_export)| unused_file == file && unused_export == export),
+            "{file}:{export} should be framework-used in Nuxt, found: {unused_exports:?}"
+        );
+    }
+
+    for (file, export) in [
+        ("app.vue", "unusedAppHelper"),
+        ("app.config.ts", "unusedConfigHelper"),
+        ("index.vue", "unusedPageHelper"),
+        ("default.vue", "unusedLayoutHelper"),
+        ("FancyCard.vue", "unusedCardHelper"),
+        ("client.ts", "unusedPluginHelper"),
+        ("hello.ts", "unusedRouteHelper"),
+        ("custom.ts", "unusedModuleHelper"),
+    ] {
+        assert!(
+            unused_exports
+                .iter()
+                .any(|(unused_file, unused_export)| unused_file == file && unused_export == export),
+            "{file}:{export} should still be reported as unused, found: {unused_exports:?}"
+        );
+    }
+}

--- a/crates/core/tests/integration_test/sfc_parsing.rs
+++ b/crates/core/tests/integration_test/sfc_parsing.rs
@@ -56,6 +56,14 @@ fn vue_imports_mark_exports_used() {
         !unused_export_names.contains(&"handlers"),
         "handlers should be used from Vue v-on object syntax, found: {unused_export_names:?}"
     );
+    assert!(
+        !unused_export_names.contains(&"dynamicAttr"),
+        "dynamicAttr should be used from a Vue dynamic v-bind argument, found: {unused_export_names:?}"
+    );
+    assert!(
+        !unused_export_names.contains(&"dynamicEvent"),
+        "dynamicEvent should be used from a Vue dynamic v-on argument, found: {unused_export_names:?}"
+    );
 
     // unusedUtil is not imported anywhere, should be unused
     assert!(
@@ -97,6 +105,53 @@ fn vue_component_tags_mark_component_exports_used() {
             .any(|(file, export)| file == "GreetingCard.vue" && export == "unusedNamed"),
         "GreetingCard named dead export should still be reported: {unused_exports:?}"
     );
+}
+
+#[test]
+fn vue_template_edge_cases_mark_exports_used() {
+    let root = fixture_path("vue-template-edges");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.path.file_name().unwrap().to_string_lossy().to_string(),
+                e.export_name.clone(),
+            )
+        })
+        .collect();
+
+    for (file, export) in [
+        ("utils.ts", "activeAttribute"),
+        ("utils.ts", "attributeSources"),
+        ("utils.ts", "fallbackItem"),
+        ("utils.ts", "message"),
+        ("utils.ts", "placement"),
+        ("utils.ts", "unusedImported"),
+        ("directives.ts", "vTooltip"),
+    ] {
+        assert!(
+            !unused_exports
+                .iter()
+                .any(|(unused_file, unused_export)| unused_file == file && unused_export == export),
+            "{file}:{export} should be preserved by Vue template usage, found: {unused_exports:?}"
+        );
+    }
+
+    for (file, export) in [
+        ("utils.ts", "unusedTemplateEdge"),
+        ("directives.ts", "unusedDirectiveHelper"),
+    ] {
+        assert!(
+            unused_exports
+                .iter()
+                .any(|(unused_file, unused_export)| unused_file == file && unused_export == export),
+            "{file}:{export} should still be reported as unused, found: {unused_exports:?}"
+        );
+    }
 }
 
 // ── Svelte SFC parsing ─────────────────────────────────────────

--- a/crates/extract/src/sfc_template/scanners.rs
+++ b/crates/extract/src/sfc_template/scanners.rs
@@ -4,13 +4,29 @@ pub(super) fn scan_curly_section(
     opening_len: usize,
     closing_len: usize,
 ) -> Option<(&str, usize)> {
-    debug_assert_eq!(source.as_bytes().get(start), Some(&b'{'));
     debug_assert!(opening_len == 1 || opening_len == 2);
     debug_assert!(closing_len == 1 || closing_len == 2);
 
+    scan_delimited_section(source, start, opening_len, closing_len, b'{', b'}')
+}
+
+pub(super) fn scan_bracket_section(source: &str, start: usize) -> Option<(&str, usize)> {
+    scan_delimited_section(source, start, 1, 1, b'[', b']')
+}
+
+fn scan_delimited_section(
+    source: &str,
+    start: usize,
+    opening_len: usize,
+    closing_len: usize,
+    open_byte: u8,
+    close_byte: u8,
+) -> Option<(&str, usize)> {
+    debug_assert_eq!(source.as_bytes().get(start), Some(&open_byte));
+
     let bytes = source.as_bytes();
     let mut index = start + opening_len;
-    let mut nested_braces = 0_u32;
+    let mut nested_delimiters = 0_u32;
     let mut in_single = false;
     let mut in_double = false;
     let mut in_backtick = false;
@@ -100,17 +116,17 @@ pub(super) fn scan_curly_section(
                 in_backtick = true;
                 index += 1;
             }
-            b'{' => nested_braces += 1,
-            b'}' => {
-                if nested_braces == 0 {
+            b if b == open_byte => nested_delimiters += 1,
+            b if b == close_byte => {
+                if nested_delimiters == 0 {
                     if closing_len == 1 {
                         return Some((&source[start + opening_len..index], index + 1));
                     }
-                    if bytes.get(index + 1) == Some(&b'}') {
+                    if bytes.get(index + 1) == Some(&close_byte) {
                         return Some((&source[start + opening_len..index], index + 2));
                     }
                 } else {
-                    nested_braces -= 1;
+                    nested_delimiters -= 1;
                 }
             }
             _ => {}
@@ -184,7 +200,7 @@ pub(super) fn scan_html_tag(source: &str, start: usize) -> Option<(&str, usize)>
 
 #[cfg(test)]
 mod tests {
-    use super::{scan_curly_section, scan_html_tag};
+    use super::{scan_bracket_section, scan_curly_section, scan_html_tag};
 
     #[test]
     fn scans_svelte_brace_section_with_nested_literals() {
@@ -207,6 +223,14 @@ mod tests {
         let source = r#"{format("}")}"#;
         let (inner, next_index) = scan_curly_section(source, 0, 1, 1).expect("expression");
         assert_eq!(inner, r#"format("}")"#);
+        assert_eq!(next_index, source.len());
+    }
+
+    #[test]
+    fn scans_bracket_sections_with_nested_indexing() {
+        let source = r#"[fieldMap[current["name"]]]"#;
+        let (inner, next_index) = scan_bracket_section(source, 0).expect("bracket section");
+        assert_eq!(inner, r#"fieldMap[current["name"]]"#);
         assert_eq!(next_index, source.len());
     }
 

--- a/crates/extract/src/sfc_template/shared.rs
+++ b/crates/extract/src/sfc_template/shared.rs
@@ -161,6 +161,75 @@ fn uppercase_first(source: &str) -> String {
     output
 }
 
+pub(super) fn merge_pattern_binding_usage(
+    usage: &mut TemplateUsage,
+    pattern: &str,
+    imported_bindings: &FxHashSet<String>,
+    locals: &[String],
+) -> Vec<String> {
+    let mut bindings = Vec::new();
+    collect_pattern_usage(usage, pattern, imported_bindings, locals, &mut bindings);
+    bindings
+}
+
+fn collect_pattern_usage(
+    usage: &mut TemplateUsage,
+    pattern: &str,
+    imported_bindings: &FxHashSet<String>,
+    locals: &[String],
+    bindings: &mut Vec<String>,
+) {
+    let pattern = trim_outer_parens(pattern.trim());
+    let pattern = pattern.strip_prefix("...").unwrap_or(pattern).trim();
+    if pattern.is_empty() {
+        return;
+    }
+
+    if let Some(inner) = strip_wrapping(pattern, '{', '}') {
+        for part in split_top_level(inner, ',') {
+            let part = part.trim();
+            if part.is_empty() || part == "..." {
+                continue;
+            }
+            if let Some((_, rhs)) = split_top_level_once(part, ':') {
+                collect_pattern_usage(usage, rhs, imported_bindings, locals, bindings);
+                continue;
+            }
+            if let Some((lhs, rhs)) = split_top_level_once(part, '=') {
+                merge_expression_usage(usage, rhs, imported_bindings, locals);
+                collect_pattern_usage(usage, lhs, imported_bindings, locals, bindings);
+                continue;
+            }
+            collect_pattern_usage(usage, part, imported_bindings, locals, bindings);
+        }
+        return;
+    }
+
+    if let Some(inner) = strip_wrapping(pattern, '[', ']') {
+        for part in split_top_level(inner, ',') {
+            collect_pattern_usage(usage, part.trim(), imported_bindings, locals, bindings);
+        }
+        return;
+    }
+
+    if pattern.contains(',') {
+        for part in split_top_level(pattern, ',') {
+            collect_pattern_usage(usage, part.trim(), imported_bindings, locals, bindings);
+        }
+        return;
+    }
+
+    if let Some((lhs, rhs)) = split_top_level_once(pattern, '=') {
+        merge_expression_usage(usage, rhs, imported_bindings, locals);
+        collect_pattern_usage(usage, lhs, imported_bindings, locals, bindings);
+        return;
+    }
+
+    if let Some(ident) = valid_identifier(pattern) {
+        bindings.push(ident.to_string());
+    }
+}
+
 pub(super) fn extract_pattern_binding_names(pattern: &str) -> Vec<String> {
     let pattern = trim_outer_parens(pattern.trim());
     let pattern = pattern.strip_prefix("...").unwrap_or(pattern).trim();
@@ -306,7 +375,9 @@ fn valid_identifier(source: &str) -> Option<&str> {
 mod tests {
     use rustc_hash::FxHashSet;
 
-    use super::{extract_pattern_binding_names, merge_component_tag_usage};
+    use super::{
+        extract_pattern_binding_names, merge_component_tag_usage, merge_pattern_binding_usage,
+    };
     use crate::template_usage::TemplateUsage;
 
     #[test]
@@ -331,6 +402,22 @@ mod tests {
             extract_pattern_binding_names("item, index = 0"),
             vec!["item", "index"],
         );
+    }
+
+    #[test]
+    fn pattern_usage_tracks_default_initializer_references() {
+        let mut usage = TemplateUsage::default();
+        let imported_bindings = FxHashSet::from_iter(["fallbackItem".to_string()]);
+
+        let locals = merge_pattern_binding_usage(
+            &mut usage,
+            "{ item = fallbackItem }",
+            &imported_bindings,
+            &[],
+        );
+
+        assert_eq!(locals, vec!["item"]);
+        assert!(usage.used_bindings.contains("fallbackItem"));
     }
 
     #[test]

--- a/crates/extract/src/sfc_template/vue.rs
+++ b/crates/extract/src/sfc_template/vue.rs
@@ -4,9 +4,9 @@ use rustc_hash::FxHashSet;
 
 use crate::template_usage::TemplateUsage;
 
-use super::scanners::{scan_curly_section, scan_html_tag};
+use super::scanners::{scan_bracket_section, scan_curly_section, scan_html_tag};
 use super::shared::{
-    extract_pattern_binding_names, merge_component_tag_usage, merge_expression_usage,
+    merge_component_tag_usage, merge_expression_usage, merge_pattern_binding_usage,
     merge_statement_usage,
 };
 
@@ -122,7 +122,8 @@ fn apply_tag(
     let parsed = parse_tag(trimmed);
     mark_tag_usage(&parsed.name, imported_bindings, &current, usage);
 
-    let mut element_locals = Vec::new();
+    let mut v_for_locals = Vec::new();
+    let mut slot_locals = Vec::new();
     if let Some(value) = parsed
         .attrs
         .iter()
@@ -133,7 +134,12 @@ fn apply_tag(
         let binding = captures.name("binding").map_or("", |m| m.as_str()).trim();
         let source_expr = captures.name("source").map_or("", |m| m.as_str()).trim();
         merge_expression_usage(usage, source_expr, imported_bindings, &current);
-        element_locals.extend(extract_pattern_binding_names(binding));
+        v_for_locals.extend(merge_pattern_binding_usage(
+            usage,
+            binding,
+            imported_bindings,
+            &current,
+        ));
     }
 
     if let Some(value) = parsed
@@ -146,14 +152,27 @@ fn apply_tag(
         })
         .and_then(|attr| attr.value.as_deref())
     {
-        element_locals.extend(extract_pattern_binding_names(value));
+        slot_locals.extend(merge_pattern_binding_usage(
+            usage,
+            value,
+            imported_bindings,
+            &current,
+        ));
     }
 
-    let mut attr_locals = current;
+    let mut element_locals = v_for_locals.clone();
+    element_locals.extend(slot_locals);
+
+    let mut attr_locals = current.clone();
     attr_locals.extend(element_locals.iter().cloned());
+    let mut arg_locals = current;
+    arg_locals.extend(v_for_locals);
 
     for attr in &parsed.attrs {
         mark_custom_directive_usage(&attr.name, imported_bindings, usage);
+        if let Some(expr) = dynamic_argument_expression(&attr.name) {
+            merge_expression_usage(usage, expr, imported_bindings, &arg_locals);
+        }
         if let Some(expr) = attr.value.as_deref() {
             if attr.name == "v-for"
                 || attr.name == "slot-scope"
@@ -165,7 +184,7 @@ fn apply_tag(
 
             if is_statement_attr(&attr.name) {
                 merge_statement_usage(usage, expr, imported_bindings, &attr_locals);
-            } else if is_expression_attr(&attr.name) {
+            } else if is_expression_attr(&attr.name) || is_custom_directive_attr(&attr.name) {
                 merge_expression_usage(usage, expr, imported_bindings, &attr_locals);
             }
         }
@@ -174,6 +193,13 @@ fn apply_tag(
     if !parsed.self_closing {
         scopes.push(element_locals);
     }
+}
+
+fn dynamic_argument_expression(attr_name: &str) -> Option<&str> {
+    let start = attr_name.find('[')?;
+    let (expr, _) = scan_bracket_section(attr_name, start)?;
+    let expr = expr.trim();
+    (!expr.is_empty()).then_some(expr)
 }
 
 fn current_locals(scopes: &[Vec<String>]) -> Vec<String> {
@@ -291,16 +317,7 @@ fn mark_custom_directive_usage(
     imported_bindings: &FxHashSet<String>,
     usage: &mut TemplateUsage,
 ) {
-    let Some(rest) = attr_name.strip_prefix("v-") else {
-        return;
-    };
-
-    let Some(directive_name) = rest
-        .split([':', '.'])
-        .next()
-        .map(str::trim)
-        .filter(|name| !name.is_empty())
-    else {
+    let Some(directive_name) = directive_name(attr_name) else {
         return;
     };
 
@@ -313,6 +330,19 @@ fn mark_custom_directive_usage(
     if imported_bindings.contains(binding.as_str()) {
         usage.used_bindings.insert(binding);
     }
+}
+
+fn directive_name(attr_name: &str) -> Option<&str> {
+    attr_name
+        .strip_prefix("v-")?
+        .split([':', '.'])
+        .next()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
+fn is_custom_directive_attr(name: &str) -> bool {
+    directive_name(name).is_some_and(|directive| !is_builtin_directive(directive))
 }
 
 fn to_pascal_case(name: &str) -> String {
@@ -521,5 +551,66 @@ mod tests {
         );
 
         assert!(usage.used_bindings.contains("vFocusTrap"));
+    }
+
+    #[test]
+    fn custom_directive_values_mark_imported_bindings_used() {
+        let usage = collect_template_usage(
+            "<script setup>import { tooltipText } from './utils';</script><template><div v-tooltip=\"tooltipText\" /></template>",
+            &imported(&["tooltipText"]),
+        );
+
+        assert!(usage.used_bindings.contains("tooltipText"));
+    }
+
+    #[test]
+    fn dynamic_v_bind_argument_marks_binding_used() {
+        let usage = collect_template_usage(
+            "<script setup>import { dynamicAttr } from './utils';</script><template><div v-bind:[dynamicAttr]=\"value\" /></template>",
+            &imported(&["dynamicAttr"]),
+        );
+
+        assert!(usage.used_bindings.contains("dynamicAttr"));
+    }
+
+    #[test]
+    fn nested_dynamic_v_bind_argument_marks_all_bindings_used() {
+        let usage = collect_template_usage(
+            "<script setup>import { activeField, fieldMap } from './utils';</script><template><div v-bind:[fieldMap[activeField]]=\"value\" /></template>",
+            &imported(&["activeField", "fieldMap"]),
+        );
+
+        assert!(usage.used_bindings.contains("activeField"));
+        assert!(usage.used_bindings.contains("fieldMap"));
+    }
+
+    #[test]
+    fn dynamic_v_on_argument_marks_binding_used() {
+        let usage = collect_template_usage(
+            "<script setup>import { dynamicEvent } from './utils';</script><template><button v-on:[dynamicEvent]=\"handleClick\" /></template>",
+            &imported(&["dynamicEvent"]),
+        );
+
+        assert!(usage.used_bindings.contains("dynamicEvent"));
+    }
+
+    #[test]
+    fn dynamic_v_slot_argument_ignores_slot_scope_shadowing() {
+        let usage = collect_template_usage(
+            "<script setup>import { slotName } from './utils';</script><template><List v-slot:[slotName]=\"{ slotName }\">{{ slotName }}</List></template>",
+            &imported(&["slotName"]),
+        );
+
+        assert!(usage.used_bindings.contains("slotName"));
+    }
+
+    #[test]
+    fn slot_default_initializers_mark_imported_bindings_used() {
+        let usage = collect_template_usage(
+            "<script setup>import { fallbackItem } from './utils';</script><template><List v-slot=\"{ item = fallbackItem }\">{{ item }}</List></template>",
+            &imported(&["fallbackItem"]),
+        );
+
+        assert!(usage.used_bindings.contains("fallbackItem"));
     }
 }

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -167,6 +167,27 @@ import { vFocusTrap } from './directives';
 }
 
 #[test]
+fn vue_custom_directive_value_clears_unused_import_binding() {
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+import { tooltipText } from './utils';
+</script>
+<template><input v-tooltip="tooltipText" /></template>
+"#,
+        "Comp.vue",
+    );
+
+    assert!(
+        !info
+            .unused_import_bindings
+            .contains(&"tooltipText".to_string()),
+        "custom directive values should mark tooltipText as used, got: {:?}",
+        info.unused_import_bindings
+    );
+}
+
+#[test]
 fn vue_v_on_object_syntax_clears_unused_import_binding() {
     let info = parse_sfc(
         r#"
@@ -183,6 +204,59 @@ import { handlers } from './utils';
             .unused_import_bindings
             .contains(&"handlers".to_string()),
         "v-on object syntax should mark handlers as used, got: {:?}",
+        info.unused_import_bindings
+    );
+}
+
+#[test]
+fn vue_dynamic_directive_arguments_clear_unused_import_bindings() {
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+import { activeField, dynamicAttr, dynamicEvent, fieldMap, slotName } from './utils';
+</script>
+<template>
+  <button v-on:[dynamicEvent]="handleClick" />
+  <div v-bind:[dynamicAttr]="value" />
+  <section v-bind:[fieldMap[activeField]]="value" />
+  <List v-slot:[slotName]="{ slotName }">{{ slotName }}</List>
+</template>
+"#,
+        "Comp.vue",
+    );
+
+    for binding in [
+        "activeField",
+        "dynamicAttr",
+        "dynamicEvent",
+        "fieldMap",
+        "slotName",
+    ] {
+        assert!(
+            !info.unused_import_bindings.contains(&binding.to_string()),
+            "{binding} should be marked used via a dynamic directive argument, got: {:?}",
+            info.unused_import_bindings
+        );
+    }
+}
+
+#[test]
+fn vue_slot_default_initializer_clears_unused_import_binding() {
+    let info = parse_sfc(
+        r#"
+<script setup lang="ts">
+import { fallbackItem } from './utils';
+</script>
+<template><List v-slot="{ item = fallbackItem }">{{ item }}</List></template>
+"#,
+        "Comp.vue",
+    );
+
+    assert!(
+        !info
+            .unused_import_bindings
+            .contains(&"fallbackItem".to_string()),
+        "slot default initializers should mark fallbackItem as used, got: {:?}",
         info.unused_import_bindings
     );
 }

--- a/tests/fixtures/nuxt-config-runtime-paths/app.vue
+++ b/tests/fixtures/nuxt-config-runtime-paths/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <FeatureCard />
+</template>

--- a/tests/fixtures/nuxt-config-runtime-paths/app/feature/ui/FeatureCard.vue
+++ b/tests/fixtures/nuxt-config-runtime-paths/app/feature/ui/FeatureCard.vue
@@ -1,0 +1,7 @@
+<script lang="ts">
+export const deadFeatureNamed = 1;
+</script>
+
+<template>
+  <div>Feature</div>
+</template>

--- a/tests/fixtures/nuxt-config-runtime-paths/app/middleware/auth.ts
+++ b/tests/fixtures/nuxt-config-runtime-paths/app/middleware/auth.ts
@@ -1,0 +1,3 @@
+export default defineNuxtRouteMiddleware(() => {});
+
+export const deadAppMiddlewareHelper = () => "dead";

--- a/tests/fixtures/nuxt-config-runtime-paths/app/runtime/object-plugin.ts
+++ b/tests/fixtures/nuxt-config-runtime-paths/app/runtime/object-plugin.ts
@@ -1,0 +1,3 @@
+export default defineNuxtPlugin(() => {});
+
+export const deadObjectPluginHelper = () => "dead";

--- a/tests/fixtures/nuxt-config-runtime-paths/app/runtime/plain-plugin.ts
+++ b/tests/fixtures/nuxt-config-runtime-paths/app/runtime/plain-plugin.ts
@@ -1,0 +1,3 @@
+export default defineNuxtPlugin(() => {});
+
+export const deadPlainPluginHelper = () => "dead";

--- a/tests/fixtures/nuxt-config-runtime-paths/nuxt.config.ts
+++ b/tests/fixtures/nuxt-config-runtime-paths/nuxt.config.ts
@@ -1,0 +1,9 @@
+export default defineNuxtConfig({
+  plugins: [
+    "~/runtime/plain-plugin",
+    { src: "~/runtime/object-plugin", mode: "client" },
+  ],
+  components: {
+    dirs: [{ path: "~/feature/ui" }],
+  },
+});

--- a/tests/fixtures/nuxt-config-runtime-paths/package.json
+++ b/tests/fixtures/nuxt-config-runtime-paths/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nuxt-config-runtime-paths",
+  "dependencies": {
+    "nuxt": "^3.0.0",
+    "vue": "^3.0.0"
+  }
+}

--- a/tests/fixtures/nuxt-convention-exports/app.config.ts
+++ b/tests/fixtures/nuxt-convention-exports/app.config.ts
@@ -1,0 +1,7 @@
+export default defineAppConfig({
+  theme: {
+    primaryColor: "green",
+  },
+});
+
+export const unusedConfigHelper = "still-unused";

--- a/tests/fixtures/nuxt-convention-exports/app.vue
+++ b/tests/fixtures/nuxt-convention-exports/app.vue
@@ -1,0 +1,13 @@
+<script lang="ts">
+export default {
+  name: "AppShell",
+};
+
+export const unusedAppHelper = "still-unused";
+</script>
+
+<template>
+  <main>
+    <NuxtPage />
+  </main>
+</template>

--- a/tests/fixtures/nuxt-convention-exports/components/FancyCard.vue
+++ b/tests/fixtures/nuxt-convention-exports/components/FancyCard.vue
@@ -1,0 +1,11 @@
+<script lang="ts">
+export default {
+  name: "FancyCard",
+};
+
+export const unusedCardHelper = "still-unused";
+</script>
+
+<template>
+  <div>Fancy card</div>
+</template>

--- a/tests/fixtures/nuxt-convention-exports/layouts/default.vue
+++ b/tests/fixtures/nuxt-convention-exports/layouts/default.vue
@@ -1,0 +1,13 @@
+<script lang="ts">
+export default {
+  name: "DefaultLayout",
+};
+
+export const unusedLayoutHelper = "still-unused";
+</script>
+
+<template>
+  <section>
+    <slot />
+  </section>
+</template>

--- a/tests/fixtures/nuxt-convention-exports/modules/custom.ts
+++ b/tests/fixtures/nuxt-convention-exports/modules/custom.ts
@@ -1,0 +1,7 @@
+export default defineNuxtModule({
+  meta: {
+    name: "custom-module",
+  },
+});
+
+export const unusedModuleHelper = "still-unused";

--- a/tests/fixtures/nuxt-convention-exports/package.json
+++ b/tests/fixtures/nuxt-convention-exports/package.json
@@ -1,0 +1,1 @@
+{"name": "nuxt-convention-exports", "dependencies": {"nuxt": "^3.0.0"}}

--- a/tests/fixtures/nuxt-convention-exports/pages/index.vue
+++ b/tests/fixtures/nuxt-convention-exports/pages/index.vue
@@ -1,0 +1,11 @@
+<script lang="ts">
+export default {
+  name: "IndexPage",
+};
+
+export const unusedPageHelper = "still-unused";
+</script>
+
+<template>
+  <div>Home</div>
+</template>

--- a/tests/fixtures/nuxt-convention-exports/plugins/client.ts
+++ b/tests/fixtures/nuxt-convention-exports/plugins/client.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin(() => ({
+  provide: {
+    greeting: () => "hello",
+  },
+}));
+
+export const unusedPluginHelper = "still-unused";

--- a/tests/fixtures/nuxt-convention-exports/server/routes/hello.ts
+++ b/tests/fixtures/nuxt-convention-exports/server/routes/hello.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => "hello");
+
+export const unusedRouteHelper = "still-unused";

--- a/tests/fixtures/nuxt-default-scan/app.vue
+++ b/tests/fixtures/nuxt-default-scan/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Nuxt default scan fixture</div>
+</template>

--- a/tests/fixtures/nuxt-default-scan/composables/nested/useHidden.ts
+++ b/tests/fixtures/nuxt-default-scan/composables/nested/useHidden.ts
@@ -1,0 +1,1 @@
+export const useHidden = () => 'hidden';

--- a/tests/fixtures/nuxt-default-scan/package.json
+++ b/tests/fixtures/nuxt-default-scan/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nuxt-default-scan",
+  "private": true,
+  "dependencies": {
+    "nuxt": "4.0.0"
+  }
+}

--- a/tests/fixtures/nuxt-default-scan/plugins/nested/helper.ts
+++ b/tests/fixtures/nuxt-default-scan/plugins/nested/helper.ts
@@ -1,0 +1,1 @@
+export const helper = () => 'helper';

--- a/tests/fixtures/nuxt-default-scan/plugins/nested/index.ts
+++ b/tests/fixtures/nuxt-default-scan/plugins/nested/index.ts
@@ -1,0 +1,1 @@
+export default defineNuxtPlugin(() => {});

--- a/tests/fixtures/nuxt-default-scan/utils/nested/format.ts
+++ b/tests/fixtures/nuxt-default-scan/utils/nested/format.ts
@@ -1,0 +1,1 @@
+export const formatHidden = () => 'hidden';

--- a/tests/fixtures/nuxt-runtime-conventions/app.vue
+++ b/tests/fixtures/nuxt-runtime-conventions/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <RootBadge />
+</template>

--- a/tests/fixtures/nuxt-runtime-conventions/components/RootBadge.vue
+++ b/tests/fixtures/nuxt-runtime-conventions/components/RootBadge.vue
@@ -1,0 +1,7 @@
+<script lang="ts">
+export const deadNamed = 1;
+</script>
+
+<template>
+  <div>Badge</div>
+</template>

--- a/tests/fixtures/nuxt-runtime-conventions/middleware/auth.ts
+++ b/tests/fixtures/nuxt-runtime-conventions/middleware/auth.ts
@@ -1,0 +1,3 @@
+export default defineNuxtRouteMiddleware(() => {});
+
+export const deadMiddlewareHelper = () => "dead";

--- a/tests/fixtures/nuxt-runtime-conventions/package.json
+++ b/tests/fixtures/nuxt-runtime-conventions/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nuxt-runtime-conventions",
+  "dependencies": {
+    "nuxt": "^3.0.0",
+    "vue": "^3.0.0"
+  }
+}

--- a/tests/fixtures/nuxt-runtime-conventions/plugins/bootstrap.ts
+++ b/tests/fixtures/nuxt-runtime-conventions/plugins/bootstrap.ts
@@ -1,0 +1,3 @@
+export default defineNuxtPlugin(() => {});
+
+export const deadPluginHelper = () => "dead";

--- a/tests/fixtures/nuxt-runtime-conventions/server/middleware/logger.ts
+++ b/tests/fixtures/nuxt-runtime-conventions/server/middleware/logger.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {});
+
+export const deadServerMiddlewareHelper = () => "dead";

--- a/tests/fixtures/vue-template-edges/package.json
+++ b/tests/fixtures/vue-template-edges/package.json
@@ -1,0 +1,1 @@
+{"name": "vue-template-edges", "main": "src/main.ts", "dependencies": {"vue": "^3.0.0"}}

--- a/tests/fixtures/vue-template-edges/src/App.vue
+++ b/tests/fixtures/vue-template-edges/src/App.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { vTooltip } from './directives';
+import {
+  activeAttribute,
+  attributeSources,
+  fallbackItem,
+  message,
+  placement,
+  unusedImported,
+} from './utils';
+</script>
+
+<template>
+  <List v-slot="{ item = fallbackItem }">{{ item }}</List>
+  <div v-tooltip:[placement]="message" />
+  <button v-bind:[attributeSources[activeAttribute]]="message">Apply</button>
+  <span>{{ unusedImported }}</span>
+</template>

--- a/tests/fixtures/vue-template-edges/src/directives.ts
+++ b/tests/fixtures/vue-template-edges/src/directives.ts
@@ -1,0 +1,5 @@
+export const vTooltip = {
+  mounted() {},
+};
+
+export const unusedDirectiveHelper = () => 'still-unused';

--- a/tests/fixtures/vue-template-edges/src/main.ts
+++ b/tests/fixtures/vue-template-edges/src/main.ts
@@ -1,0 +1,3 @@
+import App from './App.vue';
+
+export default App;

--- a/tests/fixtures/vue-template-edges/src/utils.ts
+++ b/tests/fixtures/vue-template-edges/src/utils.ts
@@ -1,0 +1,9 @@
+export const activeAttribute = 'primary';
+export const attributeSources = {
+  primary: 'data-primary',
+};
+export const fallbackItem = 'fallback';
+export const message = 'tooltip message';
+export const placement = 'top';
+export const unusedImported = 'still used from the template';
+export const unusedTemplateEdge = 'still-unused';


### PR DESCRIPTION
## What

- harden Nuxt convention coverage so runtime-managed files keep only their framework-used exports alive, including configured plugin paths, nested component dir objects, server plugins, and `srcDir`-prefixed runtime roots
- make plugin-derived glob matching segment-aware so top-level Nuxt plugin and composable patterns stop overmatching nested files
- harden Vue template extraction for dynamic directive arguments with nested indexing, custom directive values, and slot destructuring defaults
- refactor the template scanner to share balanced-section parsing and collapse repeated Nuxt `srcDir` prefix handling into helpers
- expand fixture-backed regressions for Nuxt convention files, configured runtime paths, default scan behavior, and Vue template edge cases

## Why

The last framework pass fixed most of the Vue and Nuxt noise, but a few sharp edges were still left behind.

Vue dynamic directive arguments were still parsed with a first-`]` heuristic, so nested indexing expressions could silently drop usage tracking and leave false positives behind.

Nuxt also still had some convention drift risk: the runtime/default-export rules had improved, but configured runtime paths and `srcDir` prefixing were spread across a few repeated code paths.

I wanted to tighten the remaining logic without turning the framework layer into another pile of special-case duplication.

## Impact

- reduces Vue false positives around dynamic directive arguments that use nested indexing or other bracketed expressions
- keeps Nuxt convention files and configured runtime roots alive while still reporting unrelated dead helpers in the same modules
- makes Nuxt top-level-only scans more accurate by preventing single-segment globs from leaking into nested directories
- leaves the framework and template layers in a cleaner, stricter state with strict `clippy`, full workspace tests, and shell CI checks all green

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace --all-targets`
- `bash action/tests/run.sh`
- `bash ci/tests/run.sh`
