### PR TITLE
fix: resolve root-relative HTML asset paths from project root

### DIFF
--- a/crates/graph/src/resolve/specifier.rs
+++ b/crates/graph/src/resolve/specifier.rs
@@ -61,6 +61,28 @@ pub(super) fn resolve_specifier(
         return ResolveResult::ExternalFile(PathBuf::from(specifier));
     }
 
+    // In HTML files, root-relative paths (`/src/main.tsx`) are a web convention meaning
+    // "relative to the project root". Vite, Parcel, and other dev servers resolve them
+    // this way. Use `resolve(directory, specifier)` with the project root as the base
+    // directory, so resolution works regardless of where the HTML file lives (e.g.,
+    // `public/index.html` referencing `/src/main.tsx`).
+    // Scoped to HTML files only — in JS/TS, `/foo` is an absolute filesystem path.
+    if specifier.starts_with('/') && from_file.extension().is_some_and(|e| e == "html") {
+        let relative = format!(".{specifier}");
+        if let Ok(resolved) = ctx.resolver.resolve(ctx.root, &relative) {
+            let resolved_path = resolved.path();
+            if let Some(&file_id) = ctx.raw_path_to_id.get(resolved_path) {
+                return ResolveResult::InternalModule(file_id);
+            }
+            if let Ok(canonical) = dunce::canonicalize(resolved_path)
+                && let Some(&file_id) = ctx.path_to_id.get(canonical.as_path())
+            {
+                return ResolveResult::InternalModule(file_id);
+            }
+        }
+        return ResolveResult::Unresolvable(specifier.to_string());
+    }
+
     // Bare specifier classification (used for fallback logic below).
     let is_bare = is_bare_specifier(specifier);
     let is_alias = is_path_alias(specifier);


### PR DESCRIPTION
## What

Resolve root-relative paths (`/src/main.tsx`) in HTML files against the project root using `resolver.resolve(root, specifier)` instead of `resolver.resolve_file(from_file, specifier)`.

## Why

In Vite, Parcel, and other dev servers, `<script src="/src/main.tsx">` means "relative to the project root", not an absolute filesystem path. The existing HTML parser correctly extracts these references, but the resolver couldn't resolve them — reporting false-positive unresolved imports, which cascaded into false-positive unused files.

This handles the `public/index.html` case correctly too, since resolution is always anchored to the project root regardless of where the HTML file lives.

Scoped to HTML files only — in JS/TS, `/foo` is an absolute filesystem path with different semantics.

## Test plan

- `cargo test --workspace --all-targets` — all tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Tested against 5 scenarios:
  1. Root-relative HTML at project root — resolves correctly
  2. Root-relative HTML in subdirectory (`public/index.html`) — resolves correctly
  3. Relative path HTML (`./src/main.ts`) — no regression
  4. JS file with `/absolute/path` import — correctly left unresolved (HTML guard works)
  5. Mixed Vite project — only genuinely unused file flagged, HTML-referenced files reachable