### PR TITLE
fix(extract): resolve chained member access through class field assignments

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -956,6 +956,64 @@ mod tests {
     }
 
     #[test]
+    fn this_field_chained_access_not_flagged() {
+        // `this.service = new MyService()` then `this.service.doWork()`
+        // should recognize doWork as a used member of MyService.
+        // The visitor emits MemberAccess { object: "MyService", member: "doWork" }
+        // after resolving the `this.service` binding via instance_binding_names.
+        let mut graph = build_graph(&[("/src/main.ts", true), ("/src/service.ts", false)]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "MyService",
+            vec![
+                make_member("doWork", MemberKind::ClassMethod),
+                make_member("unusedMethod", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        // Consumer imports MyService, stores in a field, and calls through it.
+        // The visitor resolves `this.service.doWork()` → `MyService.doWork`.
+        let resolved_modules = vec![ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/src/main.ts"),
+            exports: vec![],
+            re_exports: vec![],
+            resolved_imports: vec![ResolvedImport {
+                info: ImportInfo {
+                    source: "./service".to_string(),
+                    imported_name: ImportedName::Named("MyService".to_string()),
+                    local_name: "MyService".to_string(),
+                    is_type_only: false,
+                    span: Span::new(0, 30),
+                    source_span: Span::default(),
+                },
+                target: ResolveResult::InternalModule(FileId(1)),
+            }],
+            resolved_dynamic_imports: vec![],
+            resolved_dynamic_patterns: vec![],
+            member_accesses: vec![MemberAccess {
+                // Already resolved by visitor from `this.service.doWork()` → `MyService.doWork`
+                object: "MyService".to_string(),
+                member: "doWork".to_string(),
+            }],
+            whole_object_uses: vec![],
+            has_cjs_exports: false,
+            unused_import_bindings: FxHashSet::default(),
+        }];
+
+        let (_, class_members) = find_unused_members(
+            &graph,
+            &resolved_modules,
+            &FxHashMap::default(),
+            &FxHashMap::default(),
+        );
+        // Only unusedMethod should be flagged; doWork is used via this.service.doWork()
+        assert_eq!(class_members.len(), 1);
+        assert_eq!(class_members[0].member_name, "unusedMethod");
+    }
+
+    #[test]
     fn export_with_no_members_skipped() {
         let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/utils.ts", false)]);
         graph.modules[1].set_reachable(true);

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -460,6 +460,86 @@ fn multiple_instances_same_class() {
     );
 }
 
+// ── this.field chained member access ────────────────────────
+
+#[test]
+fn this_field_new_assignment_enables_chained_access() {
+    let info = parse(
+        r"
+            import { MyService } from './service';
+            class App {
+                constructor() {
+                    this.service = new MyService();
+                }
+                run() {
+                    this.service.doWork();
+                }
+            }
+            ",
+    );
+    // this.service.doWork() should be mapped to MyService.doWork
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "MyService" && a.member == "doWork"),
+        "this.service.doWork() should be mapped to MyService.doWork, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn this_field_chained_access_without_new_not_mapped() {
+    let info = parse(
+        r"
+            class App {
+                run() {
+                    this.config.getValue();
+                }
+            }
+            ",
+    );
+    // No `this.config = new Config()` assignment, so no class mapping.
+    // The raw `this.config.getValue` access should exist but not be resolved to a class.
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "this.config" && a.member == "getValue"),
+        "raw this.config.getValue access should be recorded, found: {:?}",
+        info.member_accesses
+    );
+    // No class-level mapping should exist
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Config" && a.member == "getValue"),
+        "without assignment, no class mapping should exist, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn this_field_builtin_constructor_not_tracked() {
+    let info = parse(
+        r"
+            class App {
+                constructor() {
+                    this.cache = new Map();
+                }
+                run() {
+                    this.cache.get('key');
+                }
+            }
+            ",
+    );
+    // Built-in constructors should not create this.field bindings
+    assert!(
+        !info.member_accesses.iter().any(|a| a.object == "Map"),
+        "new Map() should not create this.field instance binding, found: {:?}",
+        info.member_accesses
+    );
+}
+
 // ── CJS export patterns ──────────────────────────────────────
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -469,6 +469,19 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     object: "this".to_string(),
                     member: member.property.name.to_string(),
                 });
+                // Track `this.field = new ClassName(...)` for chained member access
+                // resolution. Enables `this.field.method()` to count as usage of
+                // `ClassName.method`. Uses the `instance_binding_names` map with a
+                // synthetic `"this.field"` key (safe: dots are invalid in identifiers).
+                if let Expression::NewExpression(new_expr) = &expr.right
+                    && let Expression::Identifier(callee) = &new_expr.callee
+                    && !super::helpers::is_builtin_constructor(callee.name.as_str())
+                {
+                    self.instance_binding_names.insert(
+                        format!("this.{}", member.property.name),
+                        callee.name.to_string(),
+                    );
+                }
             }
         }
         walk::walk_assignment_expression(self, expr);
@@ -486,6 +499,17 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         if matches!(expr.object, Expression::ThisExpression(_)) {
             self.member_accesses.push(MemberAccess {
                 object: "this".to_string(),
+                member: expr.property.name.to_string(),
+            });
+        }
+        // Capture `this.field.member` patterns — chained access through a class field.
+        // Recorded as `MemberAccess { object: "this.field", member }` which is later
+        // resolved via `instance_binding_names` when `this.field = new ClassName(...)`.
+        if let Expression::StaticMemberExpression(inner) = &expr.object
+            && matches!(inner.object, Expression::ThisExpression(_))
+        {
+            self.member_accesses.push(MemberAccess {
+                object: format!("this.{}", inner.property.name),
                 member: expr.property.name.to_string(),
             });
         }


### PR DESCRIPTION
## What

Track `this.field = new ClassName()` assignments and resolve chained `this.field.method()` accesses as usage of `ClassName.method`, eliminating false positives in `unused-class-members`.

## Why

When a class method is called through a class field reference (e.g., `this.service.doWork()`), fallow did not recognize it as usage and falsely reported the method as an unused class member. The visitor only handled direct patterns (`Identifier.member` and `this.member`) but not the chained `this.field.member` pattern.

## Test plan

- `cargo test --workspace --all-targets` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Verified fix against a minimal reproduction project
- Benchmarked with hyperfine against excalidraw (625 files): no measurable regression (181.2ms → 182.4ms, within noise)