### PR TITLE
fix(extract): normalize Angular templateUrl/styleUrl without ./ prefix

### DIFF
--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -7,7 +7,7 @@ use bitcode::{Decode, Encode};
 use crate::MemberKind;
 
 /// Cache version — bump when the cache format or cached extraction semantics change.
-pub(super) const CACHE_VERSION: u32 = 32;
+pub(super) const CACHE_VERSION: u32 = 33;
 
 /// Maximum cache file size to deserialize (256 MB).
 pub(super) const MAX_CACHE_SIZE: usize = 256 * 1024 * 1024;

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -23,6 +23,27 @@ pub struct AngularComponentMetadata {
     pub input_output_members: Vec<String>,
 }
 
+/// Normalize an Angular `templateUrl`/`styleUrl` value so bare filenames are
+/// treated as relative paths, not npm package specifiers.
+///
+/// Angular resolves both `'app.component.html'` and `'./app.component.html'`
+/// relative to the component file — the `./` prefix is optional. Downstream
+/// import resolution classifies any specifier without `./`, `../`, or `/` as
+/// a bare package, so a bare filename would be reported as an unlisted npm
+/// dependency. Prepend `./` when the value is clearly a local path.
+///
+/// Paths that already start with `.`, `/`, contain a URL scheme (`://`), or
+/// use a scoped package prefix (`@scope/...`) are left untouched.
+pub fn normalize_angular_asset_url(url: &str) -> String {
+    if url.starts_with('.') || url.starts_with('/') || url.contains("://") {
+        return url.to_string();
+    }
+    if url.starts_with('@') && url.contains('/') {
+        return url.to_string();
+    }
+    format!("./{url}")
+}
+
 /// Angular signal-based API function names that implicitly mark class properties
 /// as framework-managed (Angular 17+). Properties initialized with these calls
 /// should be treated like decorated members.
@@ -592,6 +613,78 @@ pub(super) fn is_builtin_constructor(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── normalize_angular_asset_url ──────────────────────────
+
+    #[test]
+    fn normalize_angular_asset_bare_filename_gets_dot_slash() {
+        assert_eq!(
+            normalize_angular_asset_url("app.component.html"),
+            "./app.component.html"
+        );
+        assert_eq!(
+            normalize_angular_asset_url("app.component.scss"),
+            "./app.component.scss"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_bare_subdir_gets_dot_slash() {
+        assert_eq!(
+            normalize_angular_asset_url("templates/app.html"),
+            "./templates/app.html"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_dot_slash_unchanged() {
+        assert_eq!(
+            normalize_angular_asset_url("./app.component.html"),
+            "./app.component.html"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_parent_relative_unchanged() {
+        assert_eq!(
+            normalize_angular_asset_url("../shared/app.html"),
+            "../shared/app.html"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_absolute_path_unchanged() {
+        assert_eq!(
+            normalize_angular_asset_url("/src/app.html"),
+            "/src/app.html"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_url_scheme_unchanged() {
+        assert_eq!(
+            normalize_angular_asset_url("https://cdn.example.com/app.html"),
+            "https://cdn.example.com/app.html"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_scoped_package_unchanged() {
+        // Scoped package path aliases (webpack/esbuild) should stay bare so
+        // the resolver can handle them via node_modules / alias resolution.
+        assert_eq!(
+            normalize_angular_asset_url("@shared/header.html"),
+            "@shared/header.html"
+        );
+    }
+
+    #[test]
+    fn normalize_angular_asset_empty_string_edge_case() {
+        // Empty templateUrl is syntactically possible but semantically invalid
+        // in Angular. Document current behavior: the normalizer prepends `./`,
+        // producing `./` which the resolver will fail to match to a file.
+        assert_eq!(normalize_angular_asset_url(""), "./");
+    }
 
     // ── regex_pattern_to_suffix ──────────────────────────────
 

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -2514,6 +2514,85 @@ fn angular_component_style_urls_array_emits_multiple_imports() {
 }
 
 #[test]
+fn angular_component_template_url_without_dot_slash_normalized() {
+    // Angular resolves `'app.component.html'` the same as `'./app.component.html'`.
+    // Fallow must normalize the bare form so downstream resolution doesn't
+    // misclassify it as an unlisted npm package. Regression test for #99.
+    let info = parse(
+        r"
+        import { Component } from '@angular/core';
+
+        @Component({
+            selector: 'app-root',
+            templateUrl: 'app.component.html',
+        })
+        export class AppComponent {}
+        ",
+    );
+    let template_import = info
+        .imports
+        .iter()
+        .find(|i| matches!(i.imported_name, ImportedName::SideEffect))
+        .unwrap();
+    assert_eq!(template_import.source, "./app.component.html");
+}
+
+#[test]
+fn angular_component_style_url_without_dot_slash_normalized() {
+    // Regression test for #99: bare `styleUrl` values must be normalized.
+    let info = parse(
+        r"
+        import { Component } from '@angular/core';
+
+        @Component({
+            selector: 'app-root',
+            templateUrl: 'app.component.html',
+            styleUrl: 'app.component.scss',
+        })
+        export class AppComponent {}
+        ",
+    );
+    let sources: Vec<&str> = info
+        .imports
+        .iter()
+        .filter(|i| matches!(i.imported_name, ImportedName::SideEffect))
+        .map(|i| i.source.as_str())
+        .collect();
+    assert!(sources.contains(&"./app.component.html"));
+    assert!(sources.contains(&"./app.component.scss"));
+}
+
+#[test]
+fn angular_component_style_urls_array_without_dot_slash_normalized() {
+    // Regression test for #99: bare entries in a `styleUrls` array must be
+    // normalized individually, and a mixed array must preserve relative entries.
+    let info = parse(
+        r"
+        import { Component } from '@angular/core';
+
+        @Component({
+            selector: 'app-root',
+            templateUrl: 'app.component.html',
+            styleUrls: ['app.component.scss', './theme.scss'],
+        })
+        export class AppComponent {}
+        ",
+    );
+    let sources: Vec<&str> = info
+        .imports
+        .iter()
+        .filter(|i| matches!(i.imported_name, ImportedName::SideEffect))
+        .map(|i| i.source.as_str())
+        .collect();
+    assert!(sources.contains(&"./app.component.html"));
+    assert!(sources.contains(&"./app.component.scss"));
+    assert!(sources.contains(&"./theme.scss"));
+    // The already-relative entry must not be double-prefixed.
+    assert!(!sources.contains(&".//theme.scss"));
+    assert!(!sources.contains(&"././theme.scss"));
+}
+
+#[test]
 fn angular_component_without_template_url_no_side_effect() {
     let info = parse(
         r"

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -15,7 +15,7 @@ use crate::{
 use super::helpers::{
     extract_angular_component_metadata, extract_class_members, extract_concat_parts,
     extract_super_class_name, has_angular_class_decorator, is_meta_url_arg,
-    regex_pattern_to_suffix,
+    normalize_angular_asset_url, regex_pattern_to_suffix,
 };
 use super::{ModuleInfoExtractor, try_extract_dynamic_import, try_extract_require};
 
@@ -672,10 +672,13 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         // templateUrl/styleUrl imports, inline template refs, host binding refs,
         // and inputs/outputs member names.
         if let Some(meta) = extract_angular_component_metadata(class) {
-            // Emit SideEffect imports for templateUrl and styleUrl/styleUrls
+            // Emit SideEffect imports for templateUrl and styleUrl/styleUrls.
+            // Angular resolves both `'app.html'` and `'./app.html'` relative to
+            // the component file; normalize bare filenames so downstream
+            // resolution doesn't misclassify them as npm packages.
             if let Some(ref template_url) = meta.template_url {
                 self.imports.push(ImportInfo {
-                    source: template_url.clone(),
+                    source: normalize_angular_asset_url(template_url),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,
@@ -685,7 +688,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             }
             for style_url in &meta.style_urls {
                 self.imports.push(ImportInfo {
-                    source: style_url.clone(),
+                    source: normalize_angular_asset_url(style_url),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,


### PR DESCRIPTION
## Summary

- Angular `@Component` decorators using `templateUrl: 'app.component.html'` (no `./` prefix) were reported as unlisted npm dependencies, because the visitor emitted the raw specifier and downstream resolution classified bare filenames as npm packages.
- Angular resolves both `'foo.html'` and `'./foo.html'` identically (relative to the component file), so the fix normalizes bare filenames to `./foo.html` at extraction time.
- Mirrors the existing CSS import normalization pattern in `crates/extract/src/css.rs:86`. Leaves already-relative (`./`, `../`), absolute (`/`), URL (`://`), and scoped (`@scope/...`) paths untouched.
- Bumps `CACHE_VERSION` 30 → 31 so warm caches don't keep the stale bare specifier.

Fixes #99

## Test plan

- [x] 8 direct unit tests for `normalize_angular_asset_url` covering happy path, subdir, `./`, `../`, `/`, `https://`, `@scope/...`, empty string
- [x] 3 parse-level regression tests: bare `templateUrl`, bare `styleUrl`, mixed `styleUrls` array
- [x] `cargo test --workspace --all-targets` — all suites green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `typos .` clean
- [x] End-to-end repro of the exact fixture from #99 returns `total_issues: 0`, no unlisted deps, no unresolved imports — matches the `./`-prefixed control case byte-for-byte
- [x] Benchmarks (zod, preact, vite) — no crashes, deterministic output, counts match prior runs