### PR TITLE
fix(extract): normalize bare HTML/SFC asset specifiers without ./ prefix

### DIFF
--- a/crates/extract/src/asset_url.rs
+++ b/crates/extract/src/asset_url.rs
@@ -1,0 +1,124 @@
+//! Shared asset-reference URL normalization.
+//!
+//! Used by parsers that emit side-effect imports from user-authored asset
+//! references: Angular `@Component({ templateUrl, styleUrl })`, HTML
+//! `<script src>` / `<link href>`, and Vue/Svelte `<script src>`.
+//!
+//! Browsers, Vite, Parcel, Angular's compiler, and Vue/Svelte's SFC tooling
+//! all resolve these references relative to the document or component file
+//! whether or not they start with `./`. Fallow's downstream specifier
+//! classifier, however, treats any string not starting with `.`, `/`, or
+//! containing `://` as a bare npm package specifier, so bare filenames like
+//! `'app.component.html'` or `'app.js'` are misclassified as unlisted
+//! dependencies. Prepending `./` at extraction time aligns the emitted
+//! specifier with the real semantics of the reference.
+
+/// Normalize an asset-reference URL so bare filenames are treated as relative
+/// paths, not npm package specifiers.
+///
+/// Paths that already start with `.` (relative), `/` (absolute), contain a
+/// URL scheme (`://`), use a `data:` URI prefix, or use a scoped package
+/// prefix (`@scope/...`) are returned unchanged. Everything else gets `./`
+/// prepended.
+///
+/// The `data:` guard keeps this helper safe to call unconditionally even from
+/// call sites that don't pre-filter via `is_remote_url`.
+pub fn normalize_asset_url(url: &str) -> String {
+    if url.starts_with('.')
+        || url.starts_with('/')
+        || url.contains("://")
+        || url.starts_with("data:")
+    {
+        return url.to_string();
+    }
+    if url.starts_with('@') && url.contains('/') {
+        return url.to_string();
+    }
+    format!("./{url}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_filename_gets_dot_slash() {
+        assert_eq!(
+            normalize_asset_url("app.component.html"),
+            "./app.component.html"
+        );
+        assert_eq!(normalize_asset_url("app.js"), "./app.js");
+        assert_eq!(normalize_asset_url("styles.css"), "./styles.css");
+    }
+
+    #[test]
+    fn bare_subdir_gets_dot_slash() {
+        assert_eq!(
+            normalize_asset_url("templates/app.html"),
+            "./templates/app.html"
+        );
+        assert_eq!(normalize_asset_url("assets/logo.svg"), "./assets/logo.svg");
+    }
+
+    #[test]
+    fn dot_slash_unchanged() {
+        assert_eq!(
+            normalize_asset_url("./app.component.html"),
+            "./app.component.html"
+        );
+    }
+
+    #[test]
+    fn parent_relative_unchanged() {
+        assert_eq!(
+            normalize_asset_url("../shared/app.html"),
+            "../shared/app.html"
+        );
+    }
+
+    #[test]
+    fn absolute_path_unchanged() {
+        assert_eq!(normalize_asset_url("/src/app.html"), "/src/app.html");
+    }
+
+    #[test]
+    fn url_scheme_unchanged() {
+        assert_eq!(
+            normalize_asset_url("https://cdn.example.com/app.html"),
+            "https://cdn.example.com/app.html"
+        );
+        assert_eq!(
+            normalize_asset_url("http://example.com/script.js"),
+            "http://example.com/script.js"
+        );
+    }
+
+    #[test]
+    fn data_uri_unchanged() {
+        // `data:` URIs don't contain `://` but must not be prepended with `./`.
+        // Defensive check lets the helper be called unconditionally from SFC
+        // parsers that don't pre-filter remote/data URLs.
+        assert_eq!(
+            normalize_asset_url("data:text/javascript;base64,YWJj"),
+            "data:text/javascript;base64,YWJj"
+        );
+    }
+
+    #[test]
+    fn scoped_package_unchanged() {
+        // Scoped package path aliases (webpack/esbuild) should stay bare so
+        // the resolver can handle them via node_modules / alias resolution.
+        assert_eq!(
+            normalize_asset_url("@shared/header.html"),
+            "@shared/header.html"
+        );
+    }
+
+    #[test]
+    fn empty_string_edge_case() {
+        // Empty asset URL is syntactically possible but semantically invalid.
+        // Document current behavior: the normalizer prepends `./`, producing
+        // `./` which the resolver will fail to match to a file.
+        assert_eq!(normalize_asset_url(""), "./");
+    }
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -7,7 +7,7 @@ use bitcode::{Decode, Encode};
 use crate::MemberKind;
 
 /// Cache version — bump when the cache format or cached extraction semantics change.
-pub(super) const CACHE_VERSION: u32 = 33;
+pub(super) const CACHE_VERSION: u32 = 34;
 
 /// Maximum cache file size to deserialize (256 MB).
 pub(super) const MAX_CACHE_SIZE: usize = 256 * 1024 * 1024;

--- a/crates/extract/src/html.rs
+++ b/crates/extract/src/html.rs
@@ -13,6 +13,7 @@ use std::sync::LazyLock;
 
 use oxc_span::Span;
 
+use crate::asset_url::normalize_asset_url;
 use crate::sfc_template::angular::{self, ANGULAR_TPL_SENTINEL};
 use crate::{ImportInfo, ImportedName, MemberAccess, ModuleInfo};
 use fallow_types::discover::FileId;
@@ -72,13 +73,15 @@ pub(crate) fn parse_html_to_module(file_id: FileId, source: &str, content_hash: 
 
     let mut imports = Vec::new();
 
-    // Extract <script src="..."> references
+    // Extract <script src="..."> references.
+    // Bare filenames (e.g., `src="app.js"`) are normalized to `./app.js` so
+    // the resolver doesn't misclassify them as npm packages.
     for cap in SCRIPT_SRC_RE.captures_iter(&stripped) {
         if let Some(m) = cap.get(1) {
             let src = m.as_str().trim();
             if !src.is_empty() && !is_remote_url(src) {
                 imports.push(ImportInfo {
-                    source: src.to_string(),
+                    source: normalize_asset_url(src),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,
@@ -89,14 +92,15 @@ pub(crate) fn parse_html_to_module(file_id: FileId, source: &str, content_hash: 
         }
     }
 
-    // Extract <link rel="stylesheet" href="..."> and <link rel="modulepreload" href="...">
+    // Extract <link rel="stylesheet" href="..."> and <link rel="modulepreload" href="...">.
     // Handle both attribute orders: rel before href, and href before rel.
+    // Bare filenames are normalized identically to `<script src>`.
     for cap in LINK_HREF_RE.captures_iter(&stripped) {
         if let Some(m) = cap.get(2) {
             let href = m.as_str().trim();
             if !href.is_empty() && !is_remote_url(href) {
                 imports.push(ImportInfo {
-                    source: href.to_string(),
+                    source: normalize_asset_url(href),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,
@@ -111,7 +115,7 @@ pub(crate) fn parse_html_to_module(file_id: FileId, source: &str, content_hash: 
             let href = m.as_str().trim();
             if !href.is_empty() && !is_remote_url(href) {
                 imports.push(ImportInfo {
-                    source: href.to_string(),
+                    source: normalize_asset_url(href),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,
@@ -323,6 +327,90 @@ mod tests {
         );
         assert_eq!(info.imports.len(), 1);
         assert_eq!(info.imports[0].source, "./src/global.css");
+    }
+
+    // ── Bare asset references normalized to relative paths ──────
+    // Regression tests for the same class of bug as #99 (Angular templateUrl).
+    // Browsers resolve `src="app.js"` and `href="styles.css"` relative to the
+    // HTML file, so emitting these as bare specifiers would misclassify them
+    // as unlisted npm packages.
+
+    #[test]
+    fn bare_script_src_normalized_to_relative() {
+        let info = parse_html_to_module(FileId(0), r#"<script src="app.js"></script>"#, 0);
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "./app.js");
+    }
+
+    #[test]
+    fn bare_module_script_src_normalized_to_relative() {
+        let info = parse_html_to_module(
+            FileId(0),
+            r#"<script type="module" src="main.ts"></script>"#,
+            0,
+        );
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "./main.ts");
+    }
+
+    #[test]
+    fn bare_stylesheet_link_href_normalized_to_relative() {
+        let info = parse_html_to_module(
+            FileId(0),
+            r#"<link rel="stylesheet" href="styles.css" />"#,
+            0,
+        );
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "./styles.css");
+    }
+
+    #[test]
+    fn bare_link_href_reversed_attrs_normalized_to_relative() {
+        let info = parse_html_to_module(
+            FileId(0),
+            r#"<link href="styles.css" rel="stylesheet" />"#,
+            0,
+        );
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "./styles.css");
+    }
+
+    #[test]
+    fn bare_modulepreload_link_href_normalized_to_relative() {
+        let info = parse_html_to_module(
+            FileId(0),
+            r#"<link rel="modulepreload" href="vendor.js" />"#,
+            0,
+        );
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "./vendor.js");
+    }
+
+    #[test]
+    fn bare_asset_with_subdir_normalized_to_relative() {
+        let info = parse_html_to_module(FileId(0), r#"<script src="assets/app.js"></script>"#, 0);
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "./assets/app.js");
+    }
+
+    #[test]
+    fn root_absolute_script_src_unchanged() {
+        // `/src/main.ts` is a web convention (Vite root-relative) and must
+        // stay absolute so the resolver's HTML special case applies.
+        let info = parse_html_to_module(FileId(0), r#"<script src="/src/main.ts"></script>"#, 0);
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "/src/main.ts");
+    }
+
+    #[test]
+    fn parent_relative_script_src_unchanged() {
+        let info = parse_html_to_module(
+            FileId(0),
+            r#"<script src="../shared/vendor.js"></script>"#,
+            0,
+        );
+        assert_eq!(info.imports.len(), 1);
+        assert_eq!(info.imports[0].source, "../shared/vendor.js");
     }
 
     #[test]

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![warn(missing_docs)]
 
+mod asset_url;
 pub mod astro;
 pub mod cache;
 pub(crate) mod complexity;

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -12,6 +12,7 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use rustc_hash::FxHashSet;
 
+use crate::asset_url::normalize_asset_url;
 use crate::parse::compute_unused_import_bindings;
 use crate::sfc_template::{SfcKind, collect_template_usage};
 use crate::visitor::ModuleInfoExtractor;
@@ -216,8 +217,10 @@ fn merge_script_into_module(
 }
 
 fn add_script_src_import(module: &mut ModuleInfo, source: &str) {
+    // Normalize bare filenames (e.g., `<script src="logic.ts">`) so the
+    // resolver treats them as file-relative references, not npm packages.
     module.imports.push(ImportInfo {
-        source: source.to_string(),
+        source: normalize_asset_url(source),
         imported_name: ImportedName::SideEffect,
         local_name: String::new(),
         is_type_only: false,

--- a/crates/extract/src/tests/sfc.rs
+++ b/crates/extract/src/tests/sfc.rs
@@ -565,6 +565,29 @@ fn vue_script_src_attribute() {
 }
 
 #[test]
+fn vue_script_src_bare_filename_normalized() {
+    // Vue/Svelte <script src="..."> resolves relative to the SFC file, so a
+    // bare `logic.ts` must be normalized to `./logic.ts` and not reported as
+    // an unlisted npm package. Same bug shape as Angular templateUrl (#99).
+    let info = parse_sfc(
+        r#"<script src="logic.ts" lang="ts"></script><template><div/></template>"#,
+        "App.vue",
+    );
+    assert_eq!(info.imports.len(), 1);
+    assert_eq!(info.imports[0].source, "./logic.ts");
+}
+
+#[test]
+fn svelte_script_src_bare_filename_normalized() {
+    let info = parse_sfc(
+        r#"<script src="store.js"></script><div>hi</div>"#,
+        "App.svelte",
+    );
+    assert_eq!(info.imports.len(), 1);
+    assert_eq!(info.imports[0].source, "./store.js");
+}
+
+#[test]
 fn vue_script_inside_html_comment() {
     let info = parse_sfc(
         r#"

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -23,27 +23,6 @@ pub struct AngularComponentMetadata {
     pub input_output_members: Vec<String>,
 }
 
-/// Normalize an Angular `templateUrl`/`styleUrl` value so bare filenames are
-/// treated as relative paths, not npm package specifiers.
-///
-/// Angular resolves both `'app.component.html'` and `'./app.component.html'`
-/// relative to the component file — the `./` prefix is optional. Downstream
-/// import resolution classifies any specifier without `./`, `../`, or `/` as
-/// a bare package, so a bare filename would be reported as an unlisted npm
-/// dependency. Prepend `./` when the value is clearly a local path.
-///
-/// Paths that already start with `.`, `/`, contain a URL scheme (`://`), or
-/// use a scoped package prefix (`@scope/...`) are left untouched.
-pub fn normalize_angular_asset_url(url: &str) -> String {
-    if url.starts_with('.') || url.starts_with('/') || url.contains("://") {
-        return url.to_string();
-    }
-    if url.starts_with('@') && url.contains('/') {
-        return url.to_string();
-    }
-    format!("./{url}")
-}
-
 /// Angular signal-based API function names that implicitly mark class properties
 /// as framework-managed (Angular 17+). Properties initialized with these calls
 /// should be treated like decorated members.
@@ -613,78 +592,6 @@ pub(super) fn is_builtin_constructor(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── normalize_angular_asset_url ──────────────────────────
-
-    #[test]
-    fn normalize_angular_asset_bare_filename_gets_dot_slash() {
-        assert_eq!(
-            normalize_angular_asset_url("app.component.html"),
-            "./app.component.html"
-        );
-        assert_eq!(
-            normalize_angular_asset_url("app.component.scss"),
-            "./app.component.scss"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_bare_subdir_gets_dot_slash() {
-        assert_eq!(
-            normalize_angular_asset_url("templates/app.html"),
-            "./templates/app.html"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_dot_slash_unchanged() {
-        assert_eq!(
-            normalize_angular_asset_url("./app.component.html"),
-            "./app.component.html"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_parent_relative_unchanged() {
-        assert_eq!(
-            normalize_angular_asset_url("../shared/app.html"),
-            "../shared/app.html"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_absolute_path_unchanged() {
-        assert_eq!(
-            normalize_angular_asset_url("/src/app.html"),
-            "/src/app.html"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_url_scheme_unchanged() {
-        assert_eq!(
-            normalize_angular_asset_url("https://cdn.example.com/app.html"),
-            "https://cdn.example.com/app.html"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_scoped_package_unchanged() {
-        // Scoped package path aliases (webpack/esbuild) should stay bare so
-        // the resolver can handle them via node_modules / alias resolution.
-        assert_eq!(
-            normalize_angular_asset_url("@shared/header.html"),
-            "@shared/header.html"
-        );
-    }
-
-    #[test]
-    fn normalize_angular_asset_empty_string_edge_case() {
-        // Empty templateUrl is syntactically possible but semantically invalid
-        // in Angular. Document current behavior: the normalizer prepends `./`,
-        // producing `./` which the resolver will fail to match to a file.
-        assert_eq!(normalize_angular_asset_url(""), "./");
-    }
 
     // ── regex_pattern_to_suffix ──────────────────────────────
 

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -12,10 +12,12 @@ use crate::{
     MemberAccess, ReExportInfo, RequireCallInfo,
 };
 
+use crate::asset_url::normalize_asset_url;
+
 use super::helpers::{
     extract_angular_component_metadata, extract_class_members, extract_concat_parts,
     extract_super_class_name, has_angular_class_decorator, is_meta_url_arg,
-    normalize_angular_asset_url, regex_pattern_to_suffix,
+    regex_pattern_to_suffix,
 };
 use super::{ModuleInfoExtractor, try_extract_dynamic_import, try_extract_require};
 
@@ -678,7 +680,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             // resolution doesn't misclassify them as npm packages.
             if let Some(ref template_url) = meta.template_url {
                 self.imports.push(ImportInfo {
-                    source: normalize_angular_asset_url(template_url),
+                    source: normalize_asset_url(template_url),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,
@@ -688,7 +690,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
             }
             for style_url in &meta.style_urls {
                 self.imports.push(ImportInfo {
-                    source: normalize_angular_asset_url(style_url),
+                    source: normalize_asset_url(style_url),
                     imported_name: ImportedName::SideEffect,
                     local_name: String::new(),
                     is_type_only: false,


### PR DESCRIPTION
## Summary

Extends the #99 / #100 Angular `templateUrl` normalization fix to two additional parsers where the same bug shape was found during a post-ship audit:

- **HTML** — `<script src="app.js">`, `<link rel="stylesheet" href="styles.css">`, and `<link rel="modulepreload" href="vendor.js">` (forward and reverse attribute order). Bare filenames were emitted as-is and misclassified as unlisted npm packages.
- **Vue/Svelte SFC** — `<script src="logic.ts">` had the same bug via `add_script_src_import`.

Both browsers and Vue/Svelte tooling resolve these references relative to the containing document or component file whether the `./` prefix is present or not.

## Approach

- Generalize the previous `normalize_angular_asset_url` (which lived in `visitor/helpers.rs`) into a shared `crate::asset_url::normalize_asset_url` helper. Same logic; broader home since it's now used from three modules.
- Call the helper from all 5 emission sites: 3 in `html.rs` (script src + two link href orders) + 1 in `sfc.rs:add_script_src_import` + 2 Angular call sites in `visitor/visit_impl.rs` (migrated to the new location).
- Add a defensive `data:` URI guard in `normalize_asset_url` so it's safe to call from sites that don't pre-filter via `is_remote_url` (flagged by rust-reviewer).
- Bump `CACHE_VERSION` 33 → 34 since extraction output changed for HTML and SFC files.

## Test plan

- [x] 9 direct unit tests for `normalize_asset_url` (happy path, subdir, `./`, `../`, `/`, `http(s)://`, `data:`, `@scope/...`, empty string)
- [x] 8 new HTML regression tests (all 5 bare forms + subdir + `/` unchanged + `../` unchanged)
- [x] 2 new SFC regression tests (bare Vue `<script src="logic.ts">` and bare Svelte `<script src="store.js">`)
- [x] Existing Angular templateUrl/styleUrl tests still pass after the helper move
- [x] `cargo test --workspace --all-targets` — all suites green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] End-to-end repro of both new bugs AND the original #99 case against the release binary — all three now report `total_issues: 0`
- [x] rust-reviewer: CONCERN → resolved (module visibility narrowed, `data:` guard added, `../` HTML coverage added)