### PR TITLE
feat: add scoped usedClassMembers rules

### DIFF
--- a/crates/cli/src/health/mod.rs
+++ b/crates/cli/src/health/mod.rs
@@ -1424,6 +1424,7 @@ mod tests {
             line_offsets: vec![0],
             complexity,
             flag_uses: vec![],
+            class_heritage: vec![],
         }
     }
 

--- a/crates/cli/src/health/scoring.rs
+++ b/crates/cli/src/health/scoring.rs
@@ -1152,6 +1152,7 @@ mod tests {
             line_offsets: vec![],
             complexity: vec![],
             flag_uses: vec![],
+            class_heritage: vec![],
         };
 
         let (cyc, cog, funcs, lines) = aggregate_complexity(&module);
@@ -1178,6 +1179,7 @@ mod tests {
             suppressions: vec![],
             unused_import_bindings: vec![],
             flag_uses: vec![],
+            class_heritage: vec![],
             line_offsets: vec![0, 10, 20, 30, 40], // 5 lines
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: "doStuff".into(),
@@ -1214,6 +1216,7 @@ mod tests {
             suppressions: vec![],
             unused_import_bindings: vec![],
             flag_uses: vec![],
+            class_heritage: vec![],
             line_offsets: vec![0, 10, 20], // 3 lines
             complexity: vec![
                 fallow_types::extract::FunctionComplexity {
@@ -1480,6 +1483,7 @@ mod tests {
             line_offsets: (0..line_count).map(|i| (i * 10) as u32).collect(),
             complexity: functions,
             flag_uses: vec![],
+            class_heritage: vec![],
         }
     }
 

--- a/crates/cli/src/vital_signs.rs
+++ b/crates/cli/src/vital_signs.rs
@@ -885,6 +885,7 @@ mod tests {
             unused_import_bindings: Vec::new(),
             line_offsets: Vec::new(),
             flag_uses: Vec::new(),
+            class_heritage: Vec::new(),
             complexity: vec![fallow_types::extract::FunctionComplexity {
                 name: format!("fn_{id}"),
                 line: id + 1,

--- a/crates/config/src/config/mod.rs
+++ b/crates/config/src/config/mod.rs
@@ -6,6 +6,7 @@ mod health;
 mod parsing;
 mod resolution;
 mod rules;
+mod used_class_members;
 
 pub use boundaries::{
     BoundaryConfig, BoundaryPreset, BoundaryRule, BoundaryZone, ResolvedBoundaryConfig,
@@ -19,6 +20,7 @@ pub use format::OutputFormat;
 pub use health::{EmailMode, HealthConfig, OwnershipConfig};
 pub use resolution::{ConfigOverride, IgnoreExportRule, ResolvedConfig, ResolvedOverride};
 pub use rules::{PartialRulesConfig, RulesConfig, Severity};
+pub use used_class_members::{ScopedUsedClassMemberRule, UsedClassMemberRule};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -104,14 +106,12 @@ pub struct FallowConfig {
     #[serde(default)]
     pub ignore_exports: Vec<IgnoreExportRule>,
 
-    /// Class member method/property names that should never be flagged as
-    /// unused. Extends the built-in lifecycle allowlist (Angular/React) with
-    /// framework-invoked names from libraries that call interface methods at
-    /// runtime (e.g. ag-Grid's `agInit`, `refresh`). Use this at the top level
-    /// for project-wide additions; use a plugin file's `usedClassMembers` when
-    /// the names should only apply when a specific package is installed.
+    /// Class member method/property rules that should never be flagged as
+    /// unused. Supports plain member names for global suppression and scoped
+    /// objects with `extends` / `implements` constraints for framework-invoked
+    /// methods that should only be suppressed on matching classes.
     #[serde(default)]
-    pub used_class_members: Vec<String>,
+    pub used_class_members: Vec<UsedClassMemberRule>,
 
     /// Duplication detection settings.
     #[serde(default)]
@@ -360,6 +360,34 @@ mod tests {
         assert!(config.dynamically_loaded.is_empty());
     }
 
+    #[test]
+    fn deserialize_json_used_class_members_supports_strings_and_scoped_rules() {
+        let json = r#"{
+            "usedClassMembers": [
+                "agInit",
+                { "implements": "ICellRendererAngularComp", "members": ["refresh"] },
+                { "extends": "BaseCommand", "implements": "CanActivate", "members": ["execute"] }
+            ]
+        }"#;
+        let config: FallowConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.used_class_members,
+            vec![
+                UsedClassMemberRule::from("agInit"),
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: None,
+                    implements: Some("ICellRendererAngularComp".to_string()),
+                    members: vec!["refresh".to_string()],
+                }),
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: Some("BaseCommand".to_string()),
+                    implements: Some("CanActivate".to_string()),
+                    members: vec!["execute".to_string()],
+                }),
+            ]
+        );
+    }
+
     // ── TOML deserialization ────────────────────────────────────────
 
     #[test]
@@ -414,6 +442,43 @@ exports = ["*"]
         assert_eq!(config.ignore_exports.len(), 1);
         assert_eq!(config.ignore_exports[0].file, "src/types/**/*.ts");
         assert_eq!(config.ignore_exports[0].exports, vec!["*"]);
+    }
+
+    #[test]
+    fn deserialize_toml_used_class_members_supports_scoped_rules() {
+        let toml_str = r#"
+usedClassMembers = [
+  { implements = "ICellRendererAngularComp", members = ["refresh"] },
+  { extends = "BaseCommand", members = ["execute"] },
+]
+"#;
+        let config: FallowConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.used_class_members,
+            vec![
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: None,
+                    implements: Some("ICellRendererAngularComp".to_string()),
+                    members: vec!["refresh".to_string()],
+                }),
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: Some("BaseCommand".to_string()),
+                    implements: None,
+                    members: vec!["execute".to_string()],
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn deserialize_json_used_class_members_rejects_unconstrained_scoped_rules() {
+        let result = serde_json::from_str::<FallowConfig>(
+            r#"{"usedClassMembers":[{"members":["refresh"]}]}"#,
+        );
+        assert!(
+            result.is_err(),
+            "unconstrained scoped rule should be rejected"
+        );
     }
 
     #[test]

--- a/crates/config/src/config/resolution.rs
+++ b/crates/config/src/config/resolution.rs
@@ -10,6 +10,7 @@ use super::flags::FlagsConfig;
 use super::format::OutputFormat;
 use super::health::HealthConfig;
 use super::rules::{PartialRulesConfig, RulesConfig, Severity};
+use super::used_class_members::UsedClassMemberRule;
 use crate::external_plugin::{ExternalPluginDef, discover_external_plugins};
 
 use super::FallowConfig;
@@ -56,7 +57,7 @@ pub struct ResolvedConfig {
     /// Class member names that should never be flagged as unused-class-members.
     /// Union of top-level config and active plugin contributions; merged during
     /// config resolution so analysis code reads a single list.
-    pub used_class_members: Vec<String>,
+    pub used_class_members: Vec<UsedClassMemberRule>,
     pub duplicates: DuplicatesConfig,
     pub health: HealthConfig,
     pub rules: RulesConfig,

--- a/crates/config/src/config/used_class_members.rs
+++ b/crates/config/src/config/used_class_members.rs
@@ -1,0 +1,153 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A `usedClassMembers` entry from config or an external plugin.
+///
+/// Supports either a plain member name (`"agInit"`) or a scoped rule that
+/// only applies when a class matches specific `extends` / `implements`
+/// heritage clauses.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum UsedClassMemberRule {
+    /// Globally suppress this class member name for all classes.
+    Name(String),
+    /// Suppress these class member names only for matching classes.
+    Scoped(ScopedUsedClassMemberRule),
+}
+
+impl From<&str> for UsedClassMemberRule {
+    fn from(value: &str) -> Self {
+        Self::Name(value.to_string())
+    }
+}
+
+impl From<String> for UsedClassMemberRule {
+    fn from(value: String) -> Self {
+        Self::Name(value)
+    }
+}
+
+/// A heritage-constrained `usedClassMembers` rule.
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ScopedUsedClassMemberRule {
+    /// Only apply when the class extends this parent class name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
+    /// Only apply when the class implements this interface name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implements: Option<String>,
+    /// Member names that should be treated as framework-used.
+    pub members: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ScopedUsedClassMemberRuleDef {
+    #[serde(default)]
+    extends: Option<String>,
+    #[serde(default)]
+    implements: Option<String>,
+    members: Vec<String>,
+}
+
+impl TryFrom<ScopedUsedClassMemberRuleDef> for ScopedUsedClassMemberRule {
+    type Error = &'static str;
+
+    fn try_from(value: ScopedUsedClassMemberRuleDef) -> Result<Self, Self::Error> {
+        if value.extends.is_none() && value.implements.is_none() {
+            return Err("scoped usedClassMembers rules require `extends` or `implements`");
+        }
+
+        Ok(Self {
+            extends: value.extends,
+            implements: value.implements,
+            members: value.members,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for ScopedUsedClassMemberRule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        ScopedUsedClassMemberRuleDef::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl ScopedUsedClassMemberRule {
+    #[must_use]
+    pub fn matches_heritage(
+        &self,
+        super_class: Option<&str>,
+        implemented_interfaces: &[String],
+    ) -> bool {
+        let extends_matches = self
+            .extends
+            .as_deref()
+            .is_none_or(|expected| super_class == Some(expected));
+        let implements_matches = self
+            .implements
+            .as_deref()
+            .is_none_or(|expected| implemented_interfaces.iter().any(|iface| iface == expected));
+
+        extends_matches && implements_matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_plain_member_name() {
+        let rule: UsedClassMemberRule = serde_json::from_str(r#""agInit""#).unwrap();
+        assert_eq!(rule, UsedClassMemberRule::Name("agInit".to_string()));
+    }
+
+    #[test]
+    fn deserialize_scoped_rule() {
+        let rule: UsedClassMemberRule = serde_json::from_str(
+            r#"{"implements":"ICellRendererAngularComp","members":["refresh"]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            rule,
+            UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                extends: None,
+                implements: Some("ICellRendererAngularComp".to_string()),
+                members: vec!["refresh".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn scoped_rule_matches_extends_and_implements() {
+        let rule = ScopedUsedClassMemberRule {
+            extends: Some("BaseCommand".to_string()),
+            implements: Some("Runnable".to_string()),
+            members: vec!["execute".to_string()],
+        };
+
+        assert!(rule.matches_heritage(
+            Some("BaseCommand"),
+            &["Runnable".to_string(), "Disposable".to_string()]
+        ));
+        assert!(!rule.matches_heritage(Some("OtherBase"), &["Runnable".to_string()]));
+        assert!(!rule.matches_heritage(Some("BaseCommand"), &["Other".to_string()]));
+    }
+
+    #[test]
+    fn deserialize_scoped_rule_requires_constraint() {
+        let error = serde_json::from_str::<ScopedUsedClassMemberRule>(r#"{"members":["refresh"]}"#)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("require `extends` or `implements`"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/config/src/external_plugin.rs
+++ b/crates/config/src/external_plugin.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::config::UsedClassMemberRule;
+
 /// Supported plugin file extensions.
 const PLUGIN_EXTENSIONS: &[&str] = &["toml", "json", "jsonc"];
 
@@ -113,14 +115,12 @@ pub struct ExternalPluginDef {
     #[serde(default)]
     pub used_exports: Vec<ExternalUsedExport>,
 
-    /// Class member method/property names the framework invokes at runtime.
-    /// Listed names extend the built-in lifecycle allowlist, so members with
-    /// these names are never flagged as unused-class-members. Use for libraries
-    /// that call interface methods reflectively (e.g. ag-Grid's `agInit`,
-    /// `refresh`; TypeORM's `MigrationInterface.up`/`down`; Web Components'
-    /// `connectedCallback`).
+    /// Class member method/property rules the framework invokes at runtime.
+    /// Supports plain member names for global suppression and scoped objects
+    /// with `extends` / `implements` constraints when the method name is too
+    /// common to suppress across the whole workspace.
     #[serde(default)]
-    pub used_class_members: Vec<String>,
+    pub used_class_members: Vec<UsedClassMemberRule>,
 }
 
 /// Exports considered used for files matching a pattern.
@@ -345,6 +345,7 @@ fn load_plugin_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ScopedUsedClassMemberRule;
 
     #[test]
     fn deserialize_minimal_plugin() {
@@ -374,7 +375,40 @@ enablers = ["my-pkg"]
         assert_eq!(plugin.name, "ag-grid");
         assert_eq!(
             plugin.used_class_members,
-            vec!["agInit".to_string(), "refresh".to_string()]
+            vec![
+                UsedClassMemberRule::from("agInit"),
+                UsedClassMemberRule::from("refresh"),
+            ]
+        );
+    }
+
+    #[test]
+    fn deserialize_plugin_with_scoped_used_class_members_json() {
+        let json_str = r#"{
+            "name": "ag-grid",
+            "enablers": ["ag-grid-angular"],
+            "usedClassMembers": [
+                "agInit",
+                { "implements": "ICellRendererAngularComp", "members": ["refresh"] },
+                { "extends": "BaseCommand", "members": ["execute"] }
+            ]
+        }"#;
+        let plugin: ExternalPluginDef = serde_json::from_str(json_str).unwrap();
+        assert_eq!(
+            plugin.used_class_members,
+            vec![
+                UsedClassMemberRule::from("agInit"),
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: None,
+                    implements: Some("ICellRendererAngularComp".to_string()),
+                    members: vec!["refresh".to_string()],
+                }),
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: Some("BaseCommand".to_string()),
+                    implements: None,
+                    members: vec!["execute".to_string()],
+                }),
+            ]
         );
     }
 
@@ -388,7 +422,53 @@ usedClassMembers = ["agInit", "refresh"]
         let plugin: ExternalPluginDef = toml::from_str(toml_str).unwrap();
         assert_eq!(
             plugin.used_class_members,
-            vec!["agInit".to_string(), "refresh".to_string()]
+            vec![
+                UsedClassMemberRule::from("agInit"),
+                UsedClassMemberRule::from("refresh"),
+            ]
+        );
+    }
+
+    #[test]
+    fn deserialize_plugin_with_scoped_used_class_members_toml() {
+        let toml_str = r#"
+name = "ag-grid"
+enablers = ["ag-grid-angular"]
+usedClassMembers = [
+  { implements = "ICellRendererAngularComp", members = ["refresh"] },
+  { extends = "BaseCommand", members = ["execute"] }
+]
+"#;
+        let plugin: ExternalPluginDef = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            plugin.used_class_members,
+            vec![
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: None,
+                    implements: Some("ICellRendererAngularComp".to_string()),
+                    members: vec!["refresh".to_string()],
+                }),
+                UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+                    extends: Some("BaseCommand".to_string()),
+                    implements: None,
+                    members: vec!["execute".to_string()],
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn deserialize_plugin_rejects_unconstrained_scoped_used_class_members() {
+        let result = serde_json::from_str::<ExternalPluginDef>(
+            r#"{
+                "name": "ag-grid",
+                "enablers": ["ag-grid-angular"],
+                "usedClassMembers": [{ "members": ["refresh"] }]
+            }"#,
+        );
+        assert!(
+            result.is_err(),
+            "unconstrained scoped rule should be rejected"
         );
     }
 

--- a/crates/core/benches/analysis.rs
+++ b/crates/core/benches/analysis.rs
@@ -594,6 +594,7 @@ fn bench_cache_round_trip(c: &mut Criterion) {
         line_offsets: vec![0],
         complexity: Vec::new(),
         flag_uses: vec![],
+        class_heritage: vec![],
     };
 
     c.bench_function("cache_round_trip", |b| {

--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -136,23 +136,19 @@ pub fn find_dead_code_full(
     if config.rules.unused_enum_members != Severity::Off
         || config.rules.unused_class_members != Severity::Off
     {
-        // Merge the top-level config allowlist with any plugin-contributed
-        // class member names. Plugins extend the built-in Angular/React
-        // lifecycle check with framework-invoked names (e.g. ag-Grid `agInit`)
-        // so consumers don't have to enumerate every library's interface
-        // methods in their config.
-        let mut user_class_members: rustc_hash::FxHashSet<&str> = config
-            .used_class_members
-            .iter()
-            .map(String::as_str)
-            .collect();
+        // Merge the top-level config rules with any plugin-contributed rules.
+        // Plain string entries behave like the old global allowlist; scoped
+        // object entries only apply to classes that match `extends` /
+        // `implements` constraints.
+        let mut user_class_members = config.used_class_members.clone();
         if let Some(plugin_result) = plugin_result {
-            user_class_members.extend(plugin_result.used_class_members.iter().map(String::as_str));
+            user_class_members.extend(plugin_result.used_class_members.iter().cloned());
         }
 
         let (enum_members, class_members) = find_unused_members(
             graph,
             resolved_modules,
+            modules,
             &suppressions,
             &line_offsets_by_file,
             &user_class_members,
@@ -729,6 +725,7 @@ mod tests {
                 line_offsets: vec![],
                 complexity: vec![],
                 flag_uses: vec![],
+                class_heritage: vec![],
             }];
 
             let rules = RulesConfig {

--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -1,7 +1,8 @@
+use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::discover::FileId;
-use crate::extract::{ANGULAR_TPL_SENTINEL, MemberKind};
+use crate::extract::{ANGULAR_TPL_SENTINEL, MemberKind, ModuleInfo};
 use crate::graph::ModuleGraph;
 use crate::resolve::{ResolveResult, ResolvedModule};
 use crate::results::UnusedMember;
@@ -18,10 +19,116 @@ use super::{LineOffsetsMap, byte_offset_to_line_col};
 /// `user_class_member_allowlist` extends the built-in Angular/React lifecycle
 /// allowlist with framework-invoked method names contributed by plugins and
 /// top-level config (see `FallowConfig::used_class_members` and
-/// `Plugin::used_class_members`). Members whose name is in this set are never
-/// flagged as unused-class-members — used for third-party interface patterns
-/// where a library calls consumer methods reflectively (ag-Grid's `agInit`,
-/// Web Components' `connectedCallback`, etc.).
+/// `Plugin::used_class_members`). Plain string entries suppress matching member
+/// names globally; scoped object entries only suppress classes whose heritage
+/// clause matches the configured `extends` / `implements` constraints.
+#[derive(Default)]
+struct ClassMemberAllowlist<'a> {
+    global: FxHashSet<&'a str>,
+    scoped: FxHashMap<&'a str, Vec<&'a ScopedUsedClassMemberRule>>,
+}
+
+impl<'a> ClassMemberAllowlist<'a> {
+    fn from_rules(rules: &'a [UsedClassMemberRule]) -> Self {
+        let mut allowlist = Self::default();
+        for rule in rules {
+            match rule {
+                UsedClassMemberRule::Name(name) => {
+                    allowlist.global.insert(name.as_str());
+                }
+                UsedClassMemberRule::Scoped(rule) => {
+                    for member in &rule.members {
+                        allowlist
+                            .scoped
+                            .entry(member.as_str())
+                            .or_default()
+                            .push(rule);
+                    }
+                }
+            }
+        }
+        allowlist
+    }
+
+    fn matches(
+        &self,
+        member_name: &str,
+        super_class: Option<&str>,
+        implemented_interfaces: &[String],
+    ) -> bool {
+        self.global.contains(member_name)
+            || self.scoped.get(member_name).is_some_and(|rules| {
+                rules
+                    .iter()
+                    .any(|rule| rule.matches_heritage(super_class, implemented_interfaces))
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ExportKey {
+    file_id: FileId,
+    export_name: String,
+}
+
+impl ExportKey {
+    fn new(file_id: FileId, export_name: impl Into<String>) -> Self {
+        Self {
+            file_id,
+            export_name: export_name.into(),
+        }
+    }
+}
+
+fn imported_export_name(imported_name: &crate::extract::ImportedName) -> Option<&str> {
+    match imported_name {
+        crate::extract::ImportedName::Named(name) => Some(name.as_str()),
+        crate::extract::ImportedName::Default => Some("default"),
+        crate::extract::ImportedName::Namespace | crate::extract::ImportedName::SideEffect => None,
+    }
+}
+
+fn push_local_export_key<'a>(
+    local_to_export_keys: &mut FxHashMap<&'a str, Vec<ExportKey>>,
+    local_name: &'a str,
+    export_key: ExportKey,
+) {
+    let entry = local_to_export_keys.entry(local_name).or_default();
+    if !entry.contains(&export_key) {
+        entry.push(export_key);
+    }
+}
+
+fn build_local_to_export_keys(resolved: &ResolvedModule) -> FxHashMap<&str, Vec<ExportKey>> {
+    let mut local_to_export_keys = FxHashMap::default();
+
+    for import in &resolved.resolved_imports {
+        let Some(imported_name) = imported_export_name(&import.info.imported_name) else {
+            continue;
+        };
+        let ResolveResult::InternalModule(target_file_id) = &import.target else {
+            continue;
+        };
+        push_local_export_key(
+            &mut local_to_export_keys,
+            import.info.local_name.as_str(),
+            ExportKey::new(*target_file_id, imported_name),
+        );
+    }
+
+    for export in &resolved.exports {
+        if let Some(local_name) = export.local_name.as_deref() {
+            push_local_export_key(
+                &mut local_to_export_keys,
+                local_name,
+                ExportKey::new(resolved.file_id, export.name.to_string()),
+            );
+        }
+    }
+
+    local_to_export_keys
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "member tracking requires many graph traversal steps; split candidate for sig-audit-loop"
@@ -29,16 +136,28 @@ use super::{LineOffsetsMap, byte_offset_to_line_col};
 pub fn find_unused_members(
     graph: &ModuleGraph,
     resolved_modules: &[ResolvedModule],
+    modules: &[ModuleInfo],
     suppressions: &SuppressionContext<'_>,
     line_offsets_by_file: &LineOffsetsMap<'_>,
-    user_class_member_allowlist: &FxHashSet<&str>,
+    user_class_member_allowlist: &[UsedClassMemberRule],
 ) -> (Vec<UnusedMember>, Vec<UnusedMember>) {
     let mut unused_enum_members = Vec::new();
     let mut unused_class_members = Vec::new();
+    let allowlist = ClassMemberAllowlist::from_rules(user_class_member_allowlist);
 
-    // Map export_name -> set of member_names that are accessed across all modules.
-    // We map local import names back to the original imported names.
-    let mut accessed_members: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
+    let mut class_heritage_by_export: FxHashMap<ExportKey, (Option<String>, Vec<String>)> =
+        FxHashMap::default();
+    for module in modules {
+        class_heritage_by_export.extend(module.class_heritage.iter().map(|heritage| {
+            (
+                ExportKey::new(module.file_id, heritage.export_name.clone()),
+                (heritage.super_class.clone(), heritage.implements.clone()),
+            )
+        }));
+    }
+
+    // Map exported symbol identity -> set of member names that are accessed across all modules.
+    let mut accessed_members: FxHashMap<ExportKey, FxHashSet<String>> = FxHashMap::default();
 
     // Also build a per-file set of `this.member` accesses. These indicate internal usage
     // within a class body — class members accessed via `this.foo` are used internally
@@ -46,25 +165,13 @@ pub fn find_unused_members(
     let mut self_accessed_members: FxHashMap<crate::discover::FileId, FxHashSet<String>> =
         FxHashMap::default();
 
-    // Build a set of export names that are used as whole objects (Object.values, for..in, etc.).
-    // All members of these exports should be considered used.
-    let mut whole_object_used_exports: FxHashSet<String> = FxHashSet::default();
+    // Build a set of exported symbols that are used as whole objects
+    // (Object.values, for..in, etc.). All members of these exports should be
+    // considered used.
+    let mut whole_object_used_exports: FxHashSet<ExportKey> = FxHashSet::default();
 
     for resolved in resolved_modules {
-        // Build a map from local name -> imported name for this module's imports
-        let local_to_imported: FxHashMap<&str, &str> = resolved
-            .resolved_imports
-            .iter()
-            .filter_map(|imp| match &imp.info.imported_name {
-                crate::extract::ImportedName::Named(name) => {
-                    Some((imp.info.local_name.as_str(), name.as_str()))
-                }
-                crate::extract::ImportedName::Default => {
-                    Some((imp.info.local_name.as_str(), "default"))
-                }
-                _ => None,
-            })
-            .collect();
+        let local_to_export_keys = build_local_to_export_keys(resolved);
 
         for access in &resolved.member_accesses {
             // Track `this.member` accesses per-file for internal class usage
@@ -75,24 +182,21 @@ pub fn find_unused_members(
                     .insert(access.member.clone());
                 continue;
             }
-            // If the object is a local name for an import, map it to the original export name
-            let export_name = local_to_imported
-                .get(access.object.as_str())
-                .copied()
-                .unwrap_or(access.object.as_str());
-            accessed_members
-                .entry(export_name.to_string())
-                .or_default()
-                .insert(access.member.clone());
+
+            if let Some(export_keys) = local_to_export_keys.get(access.object.as_str()) {
+                for export_key in export_keys {
+                    accessed_members
+                        .entry(export_key.clone())
+                        .or_default()
+                        .insert(access.member.clone());
+                }
+            }
         }
 
-        // Map whole-object uses from local names to imported names
         for local_name in &resolved.whole_object_uses {
-            let export_name = local_to_imported
-                .get(local_name.as_str())
-                .copied()
-                .unwrap_or(local_name.as_str());
-            whole_object_used_exports.insert(export_name.to_string());
+            if let Some(export_keys) = local_to_export_keys.get(local_name.as_str()) {
+                whole_object_used_exports.extend(export_keys.iter().cloned());
+            }
         }
     }
 
@@ -103,47 +207,24 @@ pub fn find_unused_members(
     // - A parent class method accesses `this.member` (credits child overrides)
     // - A child class override is flagged unused when the parent method is used
     //
-    // Maps are scoped by (parent_name, parent_file_id) to avoid collisions
-    // when two files each export a class with the same name.
-    //
-    // parent_to_children: ("BaseShape", FileId) → ["Circle", "Rectangle"]
-    let mut parent_to_children: FxHashMap<(String, FileId), Vec<String>> = FxHashMap::default();
+    // parent_to_children: BaseShape@file_a → [Circle@file_b, Rectangle@file_c]
+    let mut parent_to_children: FxHashMap<ExportKey, Vec<ExportKey>> = FxHashMap::default();
 
     for resolved in resolved_modules {
-        // Build local→imported map for resolving super_class names
-        let local_to_imported: FxHashMap<&str, (&str, FileId)> = resolved
-            .resolved_imports
-            .iter()
-            .filter_map(|imp| {
-                let imported_name = match &imp.info.imported_name {
-                    crate::extract::ImportedName::Named(name) => name.as_str(),
-                    crate::extract::ImportedName::Default => "default",
-                    _ => return None,
-                };
-                if let ResolveResult::InternalModule(file_id) = &imp.target {
-                    Some((imp.info.local_name.as_str(), (imported_name, *file_id)))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let local_to_export_keys = build_local_to_export_keys(resolved);
 
         for export in &resolved.exports {
             if let Some(super_local) = &export.super_class {
-                let child_name = export.name.to_string();
-                if let Some(&(parent_name, parent_file_id)) =
-                    local_to_imported.get(super_local.as_str())
-                {
-                    parent_to_children
-                        .entry((parent_name.to_string(), parent_file_id))
-                        .or_default()
-                        .push(child_name);
-                } else {
-                    // Parent class defined in the same file (no import needed)
-                    parent_to_children
-                        .entry((super_local.clone(), resolved.file_id))
-                        .or_default()
-                        .push(child_name);
+                let Some(parent_keys) = local_to_export_keys.get(super_local.as_str()) else {
+                    continue;
+                };
+                let child_key = ExportKey::new(resolved.file_id, export.name.to_string());
+
+                for parent_key in parent_keys {
+                    let children = parent_to_children.entry(parent_key.clone()).or_default();
+                    if !children.contains(&child_key) {
+                        children.push(child_key.clone());
+                    }
                 }
             }
         }
@@ -153,49 +234,35 @@ pub fn find_unused_members(
     // When BaseShape.describe() calls `this.getArea()`, that should credit
     // Circle.getArea() and Rectangle.getArea() as used.
     if !parent_to_children.is_empty() {
-        // Build export-name → file_id index for O(1) child lookup
-        let export_name_to_file: FxHashMap<String, FileId> = graph
-            .modules
-            .iter()
-            .flat_map(|m| {
-                m.exports
-                    .iter()
-                    .map(move |e| (e.name.to_string(), m.file_id))
-            })
-            .collect();
-
         // Collect propagations first to avoid borrow conflicts
         let mut propagations: Vec<(FileId, Vec<String>)> = Vec::new();
 
-        for ((parent_name, parent_fid), children) in &parent_to_children {
+        for (parent_key, children) in &parent_to_children {
             // Propagate parent's this.* accesses to child files
-            if let Some(parent_self_accesses) = self_accessed_members.get(parent_fid) {
+            if let Some(parent_self_accesses) = self_accessed_members.get(&parent_key.file_id) {
                 let accesses: Vec<String> = parent_self_accesses.iter().cloned().collect();
-                for child_name in children {
-                    if let Some(&child_fid) = export_name_to_file.get(child_name.as_str()) {
-                        propagations.push((child_fid, accesses.clone()));
-                    }
+                for child_key in children {
+                    propagations.push((child_key.file_id, accesses.clone()));
                 }
             }
 
             // Also propagate accessed_members bidirectionally:
             // If parent's member is externally accessed, credit all children
             // If child's member is externally accessed, credit the parent
-            let parent_accesses: Option<FxHashSet<String>> =
-                accessed_members.get(parent_name.as_str()).cloned();
+            let parent_accesses = accessed_members.get(parent_key).cloned();
             let mut child_accesses_to_propagate: FxHashSet<String> = FxHashSet::default();
 
-            for child_name in children {
-                if let Some(child_accesses) = accessed_members.get(child_name.as_str()) {
+            for child_key in children {
+                if let Some(child_accesses) = accessed_members.get(child_key) {
                     child_accesses_to_propagate.extend(child_accesses.iter().cloned());
                 }
             }
 
             // Parent → children
             if let Some(ref parent_acc) = parent_accesses {
-                for child_name in children {
+                for child_key in children {
                     accessed_members
-                        .entry(child_name.clone())
+                        .entry(child_key.clone())
                         .or_default()
                         .extend(parent_acc.iter().cloned());
                 }
@@ -204,7 +271,7 @@ pub fn find_unused_members(
             // Children → parent
             if !child_accesses_to_propagate.is_empty() {
                 accessed_members
-                    .entry(parent_name.clone())
+                    .entry(parent_key.clone())
                     .or_default()
                     .extend(child_accesses_to_propagate);
             }
@@ -283,10 +350,16 @@ pub fn find_unused_members(
             }
 
             let export_name = export.name.to_string();
+            let export_key = ExportKey::new(module.file_id, export_name.clone());
+            let (super_class, implemented_interfaces) = class_heritage_by_export
+                .get(&export_key)
+                .map_or((None, &[][..]), |(super_class, interfaces)| {
+                    (super_class.as_deref(), interfaces.as_slice())
+                });
 
             // If this export is used as a whole object (Object.values, for..in, etc.),
             // all members are considered used — skip individual member analysis.
-            if whole_object_used_exports.contains(&export_name) {
+            if whole_object_used_exports.contains(&export_key) {
                 continue;
             }
 
@@ -303,7 +376,7 @@ pub fn find_unused_members(
 
                 // Check if this member is accessed anywhere via external import
                 if accessed_members
-                    .get(&export_name)
+                    .get(&export_key)
                     .is_some_and(|s| s.contains(&member.name))
                 {
                     continue;
@@ -337,7 +410,7 @@ pub fn find_unused_members(
                     MemberKind::ClassMethod | MemberKind::ClassProperty
                 ) && (is_react_lifecycle_method(&member.name)
                     || is_angular_lifecycle_method(&member.name)
-                    || user_class_member_allowlist.contains(member.name.as_str()))
+                    || allowlist.matches(member.name.as_str(), super_class, implemented_interfaces))
                 {
                     continue;
                 }
@@ -388,10 +461,13 @@ mod tests {
     use super::*;
     use crate::discover::{DiscoveredFile, EntryPoint, EntryPointSource, FileId};
     use crate::extract::{
-        ExportName, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind, VisibilityTag,
+        ExportName, ImportInfo, ImportedName, MemberAccess, MemberInfo, MemberKind, ModuleInfo,
+        VisibilityTag,
     };
     use crate::graph::{ExportSymbol, ModuleGraph, SymbolReference};
     use crate::resolve::{ResolveResult, ResolvedImport, ResolvedModule};
+    use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
+    use fallow_types::extract::ClassHeritageInfo;
     use oxc_span::Span;
     use std::path::PathBuf;
 
@@ -464,6 +540,37 @@ mod tests {
         }
     }
 
+    fn make_module_with_class_heritage(
+        file_id: u32,
+        export_name: &str,
+        super_class: Option<&str>,
+        implements: &[&str],
+    ) -> ModuleInfo {
+        ModuleInfo {
+            file_id: FileId(file_id),
+            exports: vec![],
+            imports: vec![],
+            re_exports: vec![],
+            dynamic_imports: vec![],
+            dynamic_import_patterns: vec![],
+            require_calls: vec![],
+            member_accesses: vec![],
+            whole_object_uses: vec![],
+            has_cjs_exports: false,
+            content_hash: 0,
+            suppressions: vec![],
+            unused_import_bindings: vec![],
+            line_offsets: vec![],
+            complexity: vec![],
+            flag_uses: vec![],
+            class_heritage: vec![ClassHeritageInfo {
+                export_name: export_name.to_string(),
+                super_class: super_class.map(str::to_string),
+                implements: implements.iter().map(ToString::to_string).collect(),
+            }],
+        }
+    }
+
     #[test]
     fn unused_members_empty_graph() {
         let graph = build_graph(&[]);
@@ -471,9 +578,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(enum_members.is_empty());
         assert!(class_members.is_empty());
@@ -496,9 +604,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert_eq!(enum_members.len(), 2);
         assert!(class_members.is_empty());
@@ -548,9 +657,10 @@ mod tests {
         let (enum_members, _) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Only Inactive should be unused
         assert_eq!(enum_members.len(), 1);
@@ -592,9 +702,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(enum_members.is_empty());
         assert!(class_members.is_empty());
@@ -618,9 +729,10 @@ mod tests {
         let (_, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(class_members.is_empty());
     }
@@ -642,9 +754,10 @@ mod tests {
         let (_, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Only customMethod should be flagged
         assert_eq!(class_members.len(), 1);
@@ -668,9 +781,10 @@ mod tests {
         let (_, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert_eq!(class_members.len(), 1);
         assert_eq!(class_members[0].member_name, "myHelper");
@@ -694,12 +808,14 @@ mod tests {
             Some(0),
         )];
 
-        let mut allowlist: FxHashSet<&str> = FxHashSet::default();
-        allowlist.insert("agInit");
-        allowlist.insert("refresh");
+        let allowlist = vec![
+            UsedClassMemberRule::from("agInit"),
+            UsedClassMemberRule::from("refresh"),
+        ];
 
         let (_, class_members) = find_unused_members(
             &graph,
+            &[],
             &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
@@ -725,11 +841,11 @@ mod tests {
             Some(0),
         )];
 
-        let mut allowlist: FxHashSet<&str> = FxHashSet::default();
-        allowlist.insert("refresh");
+        let allowlist = vec![UsedClassMemberRule::from("refresh")];
 
         let (enum_members, _) = find_unused_members(
             &graph,
+            &[],
             &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
@@ -737,6 +853,82 @@ mod tests {
         );
         assert_eq!(enum_members.len(), 1);
         assert_eq!(enum_members[0].member_name, "refresh");
+    }
+
+    #[test]
+    fn scoped_allowlist_matches_implements_only() {
+        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/renderer.ts", false)]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "MyRendererComponent",
+            vec![
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let modules = vec![make_module_with_class_heritage(
+            1,
+            "MyRendererComponent",
+            None,
+            &["ICellRendererAngularComp"],
+        )];
+        let allowlist = vec![UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: None,
+            implements: Some("ICellRendererAngularComp".to_string()),
+            members: vec!["refresh".to_string()],
+        })];
+
+        let (_, class_members) = find_unused_members(
+            &graph,
+            &[],
+            &modules,
+            &SuppressionContext::empty(),
+            &FxHashMap::default(),
+            &allowlist,
+        );
+
+        assert_eq!(class_members.len(), 1);
+        assert_eq!(class_members[0].member_name, "customHelper");
+    }
+
+    #[test]
+    fn scoped_allowlist_matches_extends_only() {
+        let mut graph = build_graph(&[("/src/entry.ts", true), ("/src/command.ts", false)]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "GenerateReport",
+            vec![
+                make_member("execute", MemberKind::ClassMethod),
+                make_member("customHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let modules = vec![make_module_with_class_heritage(
+            1,
+            "GenerateReport",
+            Some("BaseCommand"),
+            &[],
+        )];
+        let allowlist = vec![UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: Some("BaseCommand".to_string()),
+            implements: None,
+            members: vec!["execute".to_string()],
+        })];
+
+        let (_, class_members) = find_unused_members(
+            &graph,
+            &[],
+            &modules,
+            &SuppressionContext::empty(),
+            &FxHashMap::default(),
+            &allowlist,
+        );
+
+        assert_eq!(class_members.len(), 1);
+        assert_eq!(class_members[0].member_name, "customHelper");
     }
 
     #[test]
@@ -766,9 +958,10 @@ mod tests {
         let (_, class_members) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Only unused_prop should be flagged (label is accessed via this)
         assert_eq!(class_members.len(), 1);
@@ -789,9 +982,10 @@ mod tests {
         let (enum_members, _) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Member analysis skipped because export itself is unreferenced
         assert!(enum_members.is_empty());
@@ -810,9 +1004,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(enum_members.is_empty());
         assert!(class_members.is_empty());
@@ -830,9 +1025,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(enum_members.is_empty());
         assert!(class_members.is_empty());
@@ -851,9 +1047,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert_eq!(enum_members.len(), 1);
         assert_eq!(enum_members[0].kind, MemberKind::EnumMember);
@@ -876,9 +1073,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(enum_members.is_empty());
         assert_eq!(class_members.len(), 2);
@@ -935,9 +1133,10 @@ mod tests {
         let (_, class_members) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Only unusedMethod should be flagged; greet is used via instance access
         assert_eq!(class_members.len(), 1);
@@ -973,9 +1172,10 @@ mod tests {
         let (enum_members, _) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Both enum members should be flagged — `this` access doesn't apply to enums
         assert_eq!(enum_members.len(), 2);
@@ -1001,9 +1201,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert_eq!(enum_members.len(), 1);
         assert_eq!(enum_members[0].parent_name, "Status");
@@ -1050,9 +1251,10 @@ mod tests {
         let (enum_members, _) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // S.Active maps back to Status.Active, so only Inactive is unused
         assert_eq!(enum_members.len(), 1);
@@ -1097,9 +1299,10 @@ mod tests {
         let (enum_members, _) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // MyEnum.X maps to default.X, so only Y is unused
         assert_eq!(enum_members.len(), 1);
@@ -1128,13 +1331,8 @@ mod tests {
         supp_map.insert(FileId(1), &supps);
         let suppressions = SuppressionContext::from_map(supp_map);
 
-        let (enum_members, _) = find_unused_members(
-            &graph,
-            &[],
-            &suppressions,
-            &FxHashMap::default(),
-            &FxHashSet::default(),
-        );
+        let (enum_members, _) =
+            find_unused_members(&graph, &[], &[], &suppressions, &FxHashMap::default(), &[]);
         assert!(
             enum_members.is_empty(),
             "suppressed enum member should not be flagged"
@@ -1162,13 +1360,8 @@ mod tests {
         supp_map.insert(FileId(1), &supps);
         let suppressions = SuppressionContext::from_map(supp_map);
 
-        let (_, class_members) = find_unused_members(
-            &graph,
-            &[],
-            &suppressions,
-            &FxHashMap::default(),
-            &FxHashSet::default(),
-        );
+        let (_, class_members) =
+            find_unused_members(&graph, &[], &[], &suppressions, &FxHashMap::default(), &[]);
         assert!(
             class_members.is_empty(),
             "suppressed class member should not be flagged"
@@ -1211,9 +1404,10 @@ mod tests {
         let (enum_members, _) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Object.values(S) maps S→Status, so all members of Status should be considered used
         assert!(
@@ -1266,13 +1460,113 @@ mod tests {
         let (_, class_members) = find_unused_members(
             &graph,
             &resolved_modules,
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         // Only unusedMethod should be flagged; doWork is used via this.service.doWork()
         assert_eq!(class_members.len(), 1);
         assert_eq!(class_members[0].member_name, "unusedMethod");
+    }
+
+    #[test]
+    fn same_named_exports_do_not_share_member_usage() {
+        let mut graph = build_graph(&[
+            ("/src/entry.ts", true),
+            ("/src/one.ts", false),
+            ("/src/two.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[2].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "Widget",
+            vec![
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("unusedOne", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+        graph.modules[2].exports = vec![make_export_with_members(
+            "Widget",
+            vec![
+                make_member("refresh", MemberKind::ClassMethod),
+                make_member("unusedTwo", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let resolved_modules = vec![ResolvedModule {
+            file_id: FileId(0),
+            path: PathBuf::from("/src/entry.ts"),
+            resolved_imports: vec![
+                ResolvedImport {
+                    info: ImportInfo {
+                        source: "./one".to_string(),
+                        imported_name: ImportedName::Named("Widget".to_string()),
+                        local_name: "FirstWidget".to_string(),
+                        is_type_only: false,
+                        span: Span::new(0, 30),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                },
+                ResolvedImport {
+                    info: ImportInfo {
+                        source: "./two".to_string(),
+                        imported_name: ImportedName::Named("Widget".to_string()),
+                        local_name: "SecondWidget".to_string(),
+                        is_type_only: false,
+                        span: Span::new(31, 62),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(2)),
+                },
+            ],
+            member_accesses: vec![MemberAccess {
+                object: "FirstWidget".to_string(),
+                member: "refresh".to_string(),
+            }],
+            ..Default::default()
+        }];
+
+        let (_, class_members) = find_unused_members(
+            &graph,
+            &resolved_modules,
+            &[],
+            &SuppressionContext::empty(),
+            &FxHashMap::default(),
+            &[],
+        );
+
+        let unused_members: FxHashSet<(String, String)> = class_members
+            .iter()
+            .map(|member| {
+                (
+                    member.path.display().to_string(),
+                    format!("{}.{}", member.parent_name, member.member_name),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            unused_members.len(),
+            3,
+            "unexpected members: {unused_members:?}"
+        );
+        assert!(
+            unused_members.contains(&("/src/one.ts".to_string(), "Widget.unusedOne".to_string()))
+        );
+        assert!(
+            unused_members.contains(&("/src/two.ts".to_string(), "Widget.refresh".to_string()))
+        );
+        assert!(
+            unused_members.contains(&("/src/two.ts".to_string(), "Widget.unusedTwo".to_string()))
+        );
+        assert!(
+            !unused_members.contains(&("/src/one.ts".to_string(), "Widget.refresh".to_string())),
+            "member usage from /src/one.ts should not leak into /src/two.ts: {unused_members:?}"
+        );
     }
 
     #[test]
@@ -1288,9 +1582,10 @@ mod tests {
         let (enum_members, class_members) = find_unused_members(
             &graph,
             &[],
+            &[],
             &SuppressionContext::empty(),
             &FxHashMap::default(),
-            &FxHashSet::default(),
+            &[],
         );
         assert!(enum_members.is_empty());
         assert!(class_members.is_empty());

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -11,7 +11,7 @@
 
 use std::path::{Path, PathBuf};
 
-use fallow_config::{EntryPointRole, PackageJson};
+use fallow_config::{EntryPointRole, PackageJson, UsedClassMemberRule};
 use regex::Regex;
 
 const TEST_ENTRY_POINT_PLUGINS: &[&str] = &[
@@ -87,11 +87,11 @@ pub struct PluginResult {
     pub replace_used_export_rules: bool,
     /// Additional export-usage rules discovered from config.
     pub used_exports: Vec<UsedExportRule>,
-    /// Class member names that should never be flagged as unused. Contributed
+    /// Class member rules that should never be flagged as unused. Contributed
     /// by plugins that know their framework invokes these methods at runtime
-    /// (e.g. ag-Grid's `agInit`, `refresh`). Merged with the built-in Angular/React
-    /// lifecycle allowlist during unused-class-member analysis.
-    pub used_class_members: Vec<String>,
+    /// and may scope suppression via `extends` / `implements` constraints when
+    /// the method name is too common to allowlist globally.
+    pub used_class_members: Vec<UsedClassMemberRule>,
     /// Dependencies referenced in config files (should not be flagged as unused).
     pub referenced_dependencies: Vec<String>,
     /// Additional files that are always considered used.

--- a/crates/core/src/plugins/registry/helpers.rs
+++ b/crates/core/src/plugins/registry/helpers.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::FxHashSet;
 
-use fallow_config::{ExternalPluginDef, PluginDetection};
+use fallow_config::{ExternalPluginDef, PluginDetection, UsedClassMemberRule};
 
 use super::super::{PathRule, Plugin, PluginResult, PluginUsedExportRule, UsedExportRule};
 use super::AggregatedPluginResult;
@@ -39,7 +39,9 @@ pub fn process_static_patterns(
             .push(PluginUsedExportRule::new(pname.clone(), rule));
     }
     for member in plugin.used_class_members() {
-        result.used_class_members.push((*member).to_string());
+        result
+            .used_class_members
+            .push(UsedClassMemberRule::from(*member));
     }
     for dep in plugin.tooling_dependencies() {
         result.tooling_dependencies.push((*dep).to_string());

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -7,7 +7,7 @@
 use rustc_hash::FxHashSet;
 use std::path::{Path, PathBuf};
 
-use fallow_config::{EntryPointRole, ExternalPluginDef, PackageJson};
+use fallow_config::{EntryPointRole, ExternalPluginDef, PackageJson, UsedClassMemberRule};
 
 use super::{PathRule, Plugin, PluginUsedExportRule};
 
@@ -38,10 +38,10 @@ pub struct AggregatedPluginResult {
     pub always_used: Vec<(String, String)>,
     /// All used export rules from active plugins.
     pub used_exports: Vec<PluginUsedExportRule>,
-    /// Class member names contributed by active plugins that should never be
+    /// Class member rules contributed by active plugins that should never be
     /// flagged as unused. Extends the built-in Angular/React lifecycle allowlist
-    /// with framework-invoked method names (e.g. ag-Grid `agInit`, `refresh`).
-    pub used_class_members: Vec<String>,
+    /// with framework-invoked method names, optionally scoped by class heritage.
+    pub used_class_members: Vec<UsedClassMemberRule>,
     /// Dependencies referenced in config files (should not be flagged unused).
     pub referenced_dependencies: Vec<String>,
     /// Additional always-used files discovered from config parsing: (pattern, plugin_name).

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -1,6 +1,9 @@
 use super::super::{PathRule, PluginResult, PluginUsedExportRule, UsedExportRule};
 use super::*;
-use fallow_config::{ExternalPluginDef, ExternalUsedExport, PluginDetection};
+use fallow_config::{
+    ExternalPluginDef, ExternalUsedExport, PluginDetection, ScopedUsedClassMemberRule,
+    UsedClassMemberRule,
+};
 use helpers::{check_plugin_detection, discover_json_config_files, process_config_result};
 
 /// Build a dependency object from names for JSON deserialization.
@@ -848,7 +851,7 @@ fn process_config_result_merges_all_fields() {
         replace_entry_patterns: false,
         replace_used_export_rules: false,
         used_exports: vec![used_export_rule("src/routes/**/*.ts", &["loader"])],
-        used_class_members: vec!["agInit".to_string()],
+        used_class_members: vec![fallow_config::UsedClassMemberRule::from("agInit")],
         referenced_dependencies: vec!["lodash".to_string(), "axios".to_string()],
         always_used_files: vec!["setup.ts".to_string()],
         path_aliases: vec![],
@@ -873,6 +876,11 @@ fn process_config_result_merges_all_fields() {
         vec!["loader".to_string()]
     );
 
+    assert_eq!(
+        aggregated.used_class_members,
+        vec![UsedClassMemberRule::from("agInit")]
+    );
+
     assert_eq!(aggregated.referenced_dependencies.len(), 2);
     assert!(
         aggregated
@@ -895,6 +903,30 @@ fn process_config_result_merges_all_fields() {
         PathBuf::from("/project/test/setup.ts")
     );
     assert_eq!(aggregated.setup_files[0].1, "test-plugin");
+}
+
+#[test]
+fn process_config_result_preserves_scoped_used_class_member_rules() {
+    let mut aggregated = AggregatedPluginResult::default();
+    let config_result = PluginResult {
+        used_class_members: vec![UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: Some("BaseCommand".to_string()),
+            implements: Some("CanActivate".to_string()),
+            members: vec!["execute".to_string()],
+        })],
+        ..PluginResult::default()
+    };
+
+    process_config_result("test-plugin", config_result, &mut aggregated);
+
+    assert_eq!(
+        aggregated.used_class_members,
+        vec![UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: Some("BaseCommand".to_string()),
+            implements: Some("CanActivate".to_string()),
+            members: vec!["execute".to_string()],
+        })]
+    );
 }
 
 #[test]

--- a/crates/core/tests/integration_test.rs
+++ b/crates/core/tests/integration_test.rs
@@ -79,6 +79,8 @@ mod workspace_cross_imports;
 
 #[path = "integration_test/inheritance_members.rs"]
 mod inheritance_members;
+#[path = "integration_test/scoped_used_class_members.rs"]
+mod scoped_used_class_members;
 #[path = "integration_test/scss_partials.rs"]
 mod scss_partials;
 

--- a/crates/core/tests/integration_test/caching.rs
+++ b/crates/core/tests/integration_test/caching.rs
@@ -35,6 +35,7 @@ fn cache_roundtrip() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
 
     store.insert(std::path::Path::new("test.ts"), cached);
@@ -180,6 +181,7 @@ fn incremental_cache_prune_stale_entries() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
 
     store.insert(std::path::Path::new("/project/existing.ts"), make_module());

--- a/crates/core/tests/integration_test/scoped_used_class_members.rs
+++ b/crates/core/tests/integration_test/scoped_used_class_members.rs
@@ -1,0 +1,84 @@
+use super::common::{create_config, fixture_path};
+use fallow_config::{ScopedUsedClassMemberRule, UsedClassMemberRule};
+
+#[test]
+fn scoped_used_class_members_respect_class_heritage() {
+    let root = fixture_path("scoped-used-class-members");
+    let mut config = create_config(root);
+    config.used_class_members = vec![
+        UsedClassMemberRule::from("agInit"),
+        UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: None,
+            implements: Some("ICellRendererAngularComp".to_string()),
+            members: vec!["refresh".to_string()],
+        }),
+        UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: Some("BaseCommand".to_string()),
+            implements: None,
+            members: vec!["execute".to_string()],
+        }),
+        UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: None,
+            implements: Some("Authorizable".to_string()),
+            members: vec!["authorize".to_string()],
+        }),
+        UsedClassMemberRule::Scoped(ScopedUsedClassMemberRule {
+            extends: Some("BaseCommand".to_string()),
+            implements: Some("Authorizable".to_string()),
+            members: vec!["hydrate".to_string()],
+        }),
+    ];
+
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.parent_name, m.member_name))
+        .collect();
+
+    assert!(
+        !unused_members.contains(&"PriceCellRenderer.agInit".to_string()),
+        "agInit should stay globally allowlisted: {unused_members:?}"
+    );
+    assert!(
+        !unused_members.contains(&"PriceCellRenderer.refresh".to_string()),
+        "refresh should be scoped to ICellRendererAngularComp: {unused_members:?}"
+    );
+    assert!(
+        !unused_members.contains(&"DeployCommand.execute".to_string()),
+        "execute should be scoped to BaseCommand subclasses: {unused_members:?}"
+    );
+    assert!(
+        !unused_members.contains(&"SecureCommand.authorize".to_string()),
+        "authorize should be scoped to Authorizable implementors: {unused_members:?}"
+    );
+    assert!(
+        !unused_members.contains(&"SecureCommand.hydrate".to_string()),
+        "hydrate should require both BaseCommand and CanActivate: {unused_members:?}"
+    );
+
+    assert!(
+        unused_members.contains(&"DashboardComponent.refresh".to_string()),
+        "refresh should still be flagged on unrelated classes: {unused_members:?}"
+    );
+    assert!(
+        unused_members.contains(&"DashboardComponent.execute".to_string()),
+        "execute should still be flagged on unrelated classes: {unused_members:?}"
+    );
+    assert!(
+        unused_members.contains(&"DashboardComponent.authorize".to_string()),
+        "authorize should still be flagged on unrelated classes: {unused_members:?}"
+    );
+    assert!(
+        unused_members.contains(&"PriceCellRenderer.unusedHelper".to_string()),
+        "scoped allowlists must not hide unrelated members: {unused_members:?}"
+    );
+    assert!(
+        unused_members.contains(&"DeployCommand.cleanup".to_string()),
+        "extends-scoped allowlist must not hide other members: {unused_members:?}"
+    );
+    assert!(
+        unused_members.contains(&"SecureCommand.cleanup".to_string()),
+        "combined scoped allowlist must not hide other members: {unused_members:?}"
+    );
+}

--- a/crates/extract/src/cache/conversion.rs
+++ b/crates/extract/src/cache/conversion.rs
@@ -157,6 +157,7 @@ pub fn cached_to_module(
         line_offsets: cached.line_offsets.clone(),
         complexity: cached.complexity.clone(),
         flag_uses: cached.flag_uses.clone(),
+        class_heritage: cached.class_heritage.clone(),
     }
 }
 
@@ -288,5 +289,6 @@ pub fn module_to_cached(
         line_offsets: module.line_offsets.clone(),
         complexity: module.complexity.clone(),
         flag_uses: module.flag_uses.clone(),
+        class_heritage: module.class_heritage.clone(),
     }
 }

--- a/crates/extract/src/cache/tests.rs
+++ b/crates/extract/src/cache/tests.rs
@@ -43,6 +43,7 @@ fn cache_store_insert_and_get() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
     assert_eq!(store.len(), 1);
@@ -71,6 +72,7 @@ fn cache_store_hash_mismatch_returns_none() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
     assert!(store.get(Path::new("test.ts"), 99).is_none());
@@ -103,6 +105,7 @@ fn cache_store_overwrite_entry() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     let m2 = CachedModule {
         content_hash: 2,
@@ -122,6 +125,7 @@ fn cache_store_overwrite_entry() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), m1);
     store.insert(Path::new("test.ts"), m2);
@@ -157,6 +161,7 @@ fn module_to_cached_roundtrip_named_export() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -200,6 +205,7 @@ fn module_to_cached_roundtrip_default_export() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -260,6 +266,7 @@ fn module_to_cached_roundtrip_imports() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -308,6 +315,7 @@ fn module_to_cached_roundtrip_re_exports() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -352,6 +360,7 @@ fn module_to_cached_roundtrip_dynamic_imports() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -417,6 +426,7 @@ fn module_to_cached_roundtrip_members() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -471,6 +481,7 @@ fn cache_save_and_load_roundtrip() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
     store.save(&dir).unwrap();
@@ -506,6 +517,7 @@ fn cache_version_mismatch_returns_none() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
     store.save(&dir).unwrap();
@@ -556,6 +568,7 @@ fn module_to_cached_roundtrip_type_only_import() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -587,6 +600,7 @@ fn get_by_path_only_returns_entry_regardless_of_hash() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -630,6 +644,7 @@ fn retain_paths_removes_stale_entries() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
 
     store.insert(Path::new("/project/a.ts"), m());
@@ -679,6 +694,7 @@ fn retain_paths_with_empty_files_clears_cache() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("a.ts"), m);
     assert_eq!(store.len(), 1);
@@ -708,6 +724,7 @@ fn get_by_metadata_returns_entry_on_match() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -737,6 +754,7 @@ fn get_by_metadata_returns_none_on_mtime_mismatch() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -768,6 +786,7 @@ fn get_by_metadata_returns_none_on_size_mismatch() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -799,6 +818,7 @@ fn get_by_metadata_returns_none_for_zero_mtime() {
         line_offsets: vec![],
         complexity: vec![],
         flag_uses: vec![],
+        class_heritage: vec![],
     };
     store.insert(Path::new("test.ts"), module);
 
@@ -839,6 +859,7 @@ fn module_to_cached_stores_mtime_and_size() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 12345, 6789);
@@ -866,6 +887,7 @@ fn module_to_cached_roundtrip_line_offsets() {
         line_offsets: vec![0, 15, 30, 45],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
     let cached = module_to_cached(&module, 0, 0);
     let restored = cached_to_module(&cached, FileId(0));
@@ -911,6 +933,7 @@ fn module_to_cached_roundtrip_suppressions_with_kinds() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -952,6 +975,7 @@ fn module_to_cached_roundtrip_visibility() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -987,6 +1011,7 @@ fn module_to_cached_roundtrip_visibility_internal() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1022,6 +1047,7 @@ fn module_to_cached_roundtrip_visibility_beta() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1057,6 +1083,7 @@ fn module_to_cached_roundtrip_visibility_alpha() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1095,6 +1122,7 @@ fn module_to_cached_roundtrip_dynamic_import_patterns() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1131,6 +1159,7 @@ fn module_to_cached_roundtrip_unused_import_bindings() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1190,6 +1219,7 @@ fn module_to_cached_roundtrip_complexity() {
             },
         ],
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1229,6 +1259,7 @@ fn module_to_cached_roundtrip_require_with_destructured() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1267,6 +1298,7 @@ fn module_to_cached_roundtrip_dynamic_import_with_local() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1304,6 +1336,7 @@ fn module_to_cached_roundtrip_source_span() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);
@@ -1345,6 +1378,7 @@ fn module_to_cached_roundtrip_member_decorators() {
         line_offsets: vec![],
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     };
 
     let cached = module_to_cached(&module, 0, 0);

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -7,7 +7,7 @@ use bitcode::{Decode, Encode};
 use crate::MemberKind;
 
 /// Cache version — bump when the cache format or cached extraction semantics change.
-pub(super) const CACHE_VERSION: u32 = 41;
+pub(super) const CACHE_VERSION: u32 = 42;
 
 /// Maximum cache file size to deserialize (256 MB).
 pub(super) const MAX_CACHE_SIZE: usize = 256 * 1024 * 1024;
@@ -57,6 +57,8 @@ pub struct CachedModule {
     pub complexity: Vec<fallow_types::extract::FunctionComplexity>,
     /// Feature flag use sites.
     pub flag_uses: Vec<fallow_types::extract::FlagUse>,
+    /// Heritage metadata for exported classes.
+    pub class_heritage: Vec<fallow_types::extract::ClassHeritageInfo>,
 }
 
 /// Cached suppression directive.

--- a/crates/extract/src/css.rs
+++ b/crates/extract/src/css.rs
@@ -250,6 +250,7 @@ pub(crate) fn parse_css_to_module(
         line_offsets: fallow_types::extract::compute_line_offsets(source),
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     }
 }
 

--- a/crates/extract/src/html.rs
+++ b/crates/extract/src/html.rs
@@ -155,6 +155,7 @@ pub(crate) fn parse_html_to_module(file_id: FileId, source: &str, content_hash: 
         line_offsets: fallow_types::extract::compute_line_offsets(source),
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     }
 }
 

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -30,9 +30,9 @@ use fallow_types::discover::{DiscoveredFile, FileId};
 
 // Re-export all extract types from fallow-types
 pub use fallow_types::extract::{
-    DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, ImportInfo, ImportedName,
-    MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult, ReExportInfo, RequireCallInfo,
-    VisibilityTag, compute_line_offsets,
+    ClassHeritageInfo, DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, ImportInfo,
+    ImportedName, MemberAccess, MemberInfo, MemberKind, ModuleInfo, ParseResult, ReExportInfo,
+    RequireCallInfo, VisibilityTag, compute_line_offsets,
 };
 
 // Re-export extraction functions for internal use and fuzzing

--- a/crates/extract/src/sfc.rs
+++ b/crates/extract/src/sfc.rs
@@ -178,6 +178,7 @@ fn empty_sfc_module(file_id: FileId, source: &str, content_hash: u64) -> ModuleI
         line_offsets: fallow_types::extract::compute_line_offsets(source),
         complexity: Vec::new(),
         flag_uses: Vec::new(),
+        class_heritage: vec![],
     }
 }
 

--- a/crates/extract/src/visitor/declarations.rs
+++ b/crates/extract/src/visitor/declarations.rs
@@ -12,9 +12,11 @@ use crate::{
     DynamicImportInfo, ExportInfo, ExportName, MemberInfo, MemberKind, RequireCallInfo,
     VisibilityTag,
 };
+use fallow_types::extract::ClassHeritageInfo;
 
 use super::helpers::{
-    extract_class_members, extract_super_class_name, has_angular_class_decorator,
+    extract_class_members, extract_implemented_interface_names, extract_super_class_name,
+    has_angular_class_decorator,
 };
 use super::{MemberAccess, ModuleInfoExtractor, extract_destructured_names};
 
@@ -55,6 +57,14 @@ impl ModuleInfoExtractor {
                 if let Some(id) = class.id.as_ref() {
                     let members = extract_class_members(class, has_angular_class_decorator(class));
                     let super_class = extract_super_class_name(class);
+                    let implemented_interfaces = extract_implemented_interface_names(class);
+                    if super_class.is_some() || !implemented_interfaces.is_empty() {
+                        self.class_heritage.push(ClassHeritageInfo {
+                            export_name: id.name.to_string(),
+                            super_class: super_class.clone(),
+                            implements: implemented_interfaces,
+                        });
+                    }
                     self.exports.push(ExportInfo {
                         name: ExportName::Named(id.name.to_string()),
                         local_name: Some(id.name.to_string()),

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -4,7 +4,7 @@
 
 use oxc_ast::ast::{
     Argument, ArrayExpressionElement, BinaryExpression, Class, ClassElement, Expression,
-    ObjectPropertyKind, Statement,
+    ObjectPropertyKind, Statement, TSTypeName,
 };
 
 use crate::{MemberInfo, MemberKind};
@@ -357,9 +357,40 @@ pub fn extract_class_members(class: &Class<'_>, is_angular_class: bool) -> Vec<M
 /// Only handles simple identifier references — complex expressions like
 /// `extends mixin(Base)` return `None`.
 pub fn extract_super_class_name(class: &Class<'_>) -> Option<String> {
-    match class.super_class.as_ref()? {
+    extract_static_expression_name(class.super_class.as_ref()?)
+}
+
+/// Extract implemented interface names from a class declaration.
+#[must_use]
+pub fn extract_implemented_interface_names(class: &Class<'_>) -> Vec<String> {
+    class
+        .implements
+        .iter()
+        .filter_map(|item| extract_type_name(&item.expression))
+        .collect()
+}
+
+fn extract_static_expression_name(expr: &Expression<'_>) -> Option<String> {
+    match expr {
         Expression::Identifier(ident) => Some(ident.name.to_string()),
+        Expression::StaticMemberExpression(member) => Some(format!(
+            "{}.{}",
+            extract_static_expression_name(&member.object)?,
+            member.property.name
+        )),
         _ => None,
+    }
+}
+
+fn extract_type_name(name: &TSTypeName<'_>) -> Option<String> {
+    match name {
+        TSTypeName::IdentifierReference(ident) => Some(ident.name.to_string()),
+        TSTypeName::QualifiedName(name) => Some(format!(
+            "{}.{}",
+            extract_type_name(&name.left)?,
+            name.right.name
+        )),
+        TSTypeName::ThisExpression(_) => None,
     }
 }
 

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -16,6 +16,14 @@ use crate::{
     DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, ImportInfo, MemberAccess,
     MemberInfo, ModuleInfo, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
+use fallow_types::extract::ClassHeritageInfo;
+
+#[derive(Debug, Clone)]
+struct LocalClassExportInfo {
+    members: Vec<MemberInfo>,
+    super_class: Option<String>,
+    implemented_interfaces: Vec<String>,
+}
 
 /// AST visitor that extracts all import/export information in a single pass.
 #[derive(Default)]
@@ -48,11 +56,74 @@ pub(crate) struct ModuleInfoExtractor {
     /// Members collected while walking a namespace body.
     /// Moved to the namespace's `ExportInfo.members` after the walk completes.
     pending_namespace_members: Vec<MemberInfo>,
+    /// Heritage metadata for exported classes.
+    pub(crate) class_heritage: Vec<ClassHeritageInfo>,
+    /// Module-scope local class declarations keyed by local binding name.
+    local_class_exports: FxHashMap<String, LocalClassExportInfo>,
+    /// Block nesting depth used to distinguish module-scope declarations.
+    block_depth: u32,
+    /// Function / arrow-function nesting depth used to distinguish module scope.
+    function_depth: u32,
 }
 
 impl ModuleInfoExtractor {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn record_local_class_export(
+        &mut self,
+        name: String,
+        members: Vec<MemberInfo>,
+        super_class: Option<String>,
+        implemented_interfaces: Vec<String>,
+    ) {
+        self.local_class_exports.insert(
+            name,
+            LocalClassExportInfo {
+                members,
+                super_class,
+                implemented_interfaces,
+            },
+        );
+    }
+
+    fn enrich_local_class_exports(&mut self) {
+        if self.local_class_exports.is_empty() {
+            return;
+        }
+
+        for export in &mut self.exports {
+            let Some(local_name) = export.local_name.as_deref() else {
+                continue;
+            };
+            let Some(local_class) = self.local_class_exports.get(local_name) else {
+                continue;
+            };
+
+            if export.members.is_empty() {
+                export.members = local_class.members.clone();
+            }
+            if export.super_class.is_none() {
+                export.super_class = local_class.super_class.clone();
+            }
+
+            let export_name = export.name.to_string();
+            let already_has_heritage = self
+                .class_heritage
+                .iter()
+                .any(|heritage| heritage.export_name == export_name);
+            if !already_has_heritage
+                && (local_class.super_class.is_some()
+                    || !local_class.implemented_interfaces.is_empty())
+            {
+                self.class_heritage.push(ClassHeritageInfo {
+                    export_name,
+                    super_class: local_class.super_class.clone(),
+                    implements: local_class.implemented_interfaces.clone(),
+                });
+            }
+        }
     }
 
     /// Map instance member accesses to class member accesses.
@@ -105,6 +176,7 @@ impl ModuleInfoExtractor {
         content_hash: u64,
         suppressions: Vec<Suppression>,
     ) -> ModuleInfo {
+        self.enrich_local_class_exports();
         self.resolve_instance_member_accesses();
         ModuleInfo {
             file_id,
@@ -123,11 +195,13 @@ impl ModuleInfoExtractor {
             line_offsets: Vec::new(),
             complexity: Vec::new(),
             flag_uses: Vec::new(),
+            class_heritage: self.class_heritage,
         }
     }
 
     /// Merge this extractor's fields into an existing `ModuleInfo`.
     pub(crate) fn merge_into(mut self, info: &mut ModuleInfo) {
+        self.enrich_local_class_exports();
         self.resolve_instance_member_accesses();
         info.imports.extend(self.imports);
         info.exports.extend(self.exports);
@@ -139,6 +213,7 @@ impl ModuleInfoExtractor {
         info.member_accesses.extend(self.member_accesses);
         info.whole_object_uses.extend(self.whole_object_uses);
         info.has_cjs_exports |= self.has_cjs_exports;
+        info.class_heritage.extend(self.class_heritage);
     }
 }
 

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -213,6 +213,55 @@ fn class_member_with_decorator_flagged() {
     );
 }
 
+#[test]
+fn local_class_export_specifier_keeps_members_and_heritage() {
+    let info = parse(
+        r"
+            interface Authorizable {
+                authorize(): boolean;
+            }
+
+            class SecureCommand implements Authorizable {
+                authorize(): boolean {
+                    return true;
+                }
+
+                cleanup(): void {}
+            }
+
+            export { SecureCommand };
+            ",
+    );
+
+    let class_export = info
+        .exports
+        .iter()
+        .find(|e| matches!(&e.name, ExportName::Named(n) if n == "SecureCommand"))
+        .expect("SecureCommand export should exist");
+    assert!(
+        class_export
+            .members
+            .iter()
+            .any(|m| m.name == "authorize" && m.kind == MemberKind::ClassMethod),
+        "export specifier should preserve class methods"
+    );
+    assert!(
+        class_export
+            .members
+            .iter()
+            .any(|m| m.name == "cleanup" && m.kind == MemberKind::ClassMethod),
+        "export specifier should preserve all public class methods"
+    );
+
+    assert!(
+        info.class_heritage.iter().any(|heritage| {
+            heritage.export_name == "SecureCommand"
+                && heritage.implements == vec!["Authorizable".to_string()]
+        }),
+        "export specifier should preserve implements metadata"
+    );
+}
+
 // ── Enum member extraction ───────────────────────────────────
 
 #[test]

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -6,19 +6,21 @@
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
+use oxc_semantic::ScopeFlags;
 
 use crate::{
     DynamicImportInfo, DynamicImportPattern, ExportInfo, ExportName, ImportInfo, ImportedName,
     MemberAccess, ReExportInfo, RequireCallInfo, VisibilityTag,
 };
+use fallow_types::extract::ClassHeritageInfo;
 
 use crate::asset_url::normalize_asset_url;
 use crate::html::is_remote_url;
 
 use super::helpers::{
     extract_angular_component_metadata, extract_class_members, extract_concat_parts,
-    extract_super_class_name, has_angular_class_decorator, is_meta_url_arg,
-    regex_pattern_to_suffix,
+    extract_implemented_interface_names, extract_super_class_name, has_angular_class_decorator,
+    is_meta_url_arg, regex_pattern_to_suffix,
 };
 use super::{
     ModuleInfoExtractor, try_extract_arrow_wrapped_import, try_extract_dynamic_import,
@@ -26,6 +28,42 @@ use super::{
 };
 
 impl<'a> Visit<'a> for ModuleInfoExtractor {
+    fn visit_block_statement(&mut self, stmt: &BlockStatement<'a>) {
+        self.block_depth += 1;
+        walk::walk_block_statement(self, stmt);
+        self.block_depth -= 1;
+    }
+
+    fn visit_declaration(&mut self, decl: &Declaration<'a>) {
+        if self.block_depth == 0
+            && self.function_depth == 0
+            && self.namespace_depth == 0
+            && let Declaration::ClassDeclaration(class) = decl
+            && let Some(id) = class.id.as_ref()
+        {
+            self.record_local_class_export(
+                id.name.to_string(),
+                extract_class_members(class, has_angular_class_decorator(class)),
+                extract_super_class_name(class),
+                extract_implemented_interface_names(class),
+            );
+        }
+
+        walk::walk_declaration(self, decl);
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        self.function_depth += 1;
+        walk::walk_function(self, func, flags);
+        self.function_depth -= 1;
+    }
+
+    fn visit_arrow_function_expression(&mut self, expr: &ArrowFunctionExpression<'a>) {
+        self.function_depth += 1;
+        walk::walk_arrow_function_expression(self, expr);
+        self.function_depth -= 1;
+    }
+
     fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
         let source = decl.source.value.to_string();
         let is_type_only = decl.import_kind.is_type();
@@ -188,19 +226,34 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
 
     fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
         // Extract members and super_class for default-exported classes
-        let (members, super_class) =
+        let (members, super_class, implemented_interfaces) =
             if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &decl.declaration {
                 (
                     extract_class_members(class, has_angular_class_decorator(class)),
                     extract_super_class_name(class),
+                    extract_implemented_interface_names(class),
                 )
             } else {
-                (vec![], None)
+                (vec![], None, vec![])
             };
+        let local_name =
+            if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &decl.declaration {
+                class.id.as_ref().map(|id| id.name.to_string())
+            } else {
+                None
+            };
+
+        if super_class.is_some() || !implemented_interfaces.is_empty() {
+            self.class_heritage.push(ClassHeritageInfo {
+                export_name: "default".to_string(),
+                super_class: super_class.clone(),
+                implements: implemented_interfaces,
+            });
+        }
 
         self.exports.push(ExportInfo {
             name: ExportName::Default,
-            local_name: None,
+            local_name,
             is_type_only: false,
             visibility: VisibilityTag::None,
             span: decl.span,

--- a/crates/types/src/extract.rs
+++ b/crates/types/src/extract.rs
@@ -48,6 +48,9 @@ pub struct ModuleInfo {
     /// Feature flag use sites detected during AST traversal.
     /// Used by the `fallow flags` subcommand to report feature flag patterns.
     pub flag_uses: Vec<FlagUse>,
+    /// Heritage metadata for exported classes that declare `implements`.
+    /// Used to scope `usedClassMembers` rules during analysis.
+    pub class_heritage: Vec<ClassHeritageInfo>,
 }
 
 /// Compute a table of line-start byte offsets from source text.
@@ -242,6 +245,26 @@ pub struct ExportInfo {
     pub super_class: Option<String>,
 }
 
+/// Additional heritage metadata for an exported class.
+#[derive(
+    Debug,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+    bitcode::Encode,
+    bitcode::Decode,
+    PartialEq,
+    Eq,
+)]
+pub struct ClassHeritageInfo {
+    /// Export name (`default` for default-exported classes).
+    pub export_name: String,
+    /// Parent class name from the `extends` clause, if any.
+    pub super_class: Option<String>,
+    /// Interface names from the class `implements` clause.
+    pub implements: Vec<String>,
+}
+
 /// A member of an enum, class, or namespace.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct MemberInfo {
@@ -421,7 +444,7 @@ const _: () = assert!(std::mem::size_of::<ImportedName>() == 24);
 const _: () = assert!(std::mem::size_of::<MemberAccess>() == 48);
 // `ModuleInfo` is the per-file extraction result — stored in a Vec during parallel parsing.
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(std::mem::size_of::<ModuleInfo>() == 328);
+const _: () = assert!(std::mem::size_of::<ModuleInfo>() == 352);
 
 /// A re-export declaration.
 #[derive(Debug, Clone)]

--- a/plugin-schema.json
+++ b/plugin-schema.json
@@ -74,10 +74,10 @@
       "default": []
     },
     "usedClassMembers": {
-      "description": "Class member method/property names the framework invokes at runtime.\nListed names extend the built-in lifecycle allowlist, so members with\nthese names are never flagged as unused-class-members. Use for libraries\nthat call interface methods reflectively (e.g. ag-Grid's `agInit`,\n`refresh`; TypeORM's `MigrationInterface.up`/`down`; Web Components'\n`connectedCallback`).",
+      "description": "Class member method/property rules the framework invokes at runtime.\nSupports plain member names for global suppression and scoped objects\nwith `extends` / `implements` constraints when the method name is too\ncommon to suppress across the whole workspace.",
       "type": "array",
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/UsedClassMemberRule"
       },
       "default": []
     }
@@ -204,6 +204,50 @@
       "required": [
         "pattern",
         "exports"
+      ]
+    },
+    "UsedClassMemberRule": {
+      "description": "A `usedClassMembers` entry from config or an external plugin.\n\nSupports either a plain member name (`\"agInit\"`) or a scoped rule that\nonly applies when a class matches specific `extends` / `implements`\nheritage clauses.",
+      "anyOf": [
+        {
+          "description": "Globally suppress this class member name for all classes.",
+          "type": "string"
+        },
+        {
+          "description": "Suppress these class member names only for matching classes.",
+          "$ref": "#/$defs/ScopedUsedClassMemberRule"
+        }
+      ]
+    },
+    "ScopedUsedClassMemberRule": {
+      "description": "A heritage-constrained `usedClassMembers` rule.",
+      "type": "object",
+      "properties": {
+        "extends": {
+          "description": "Only apply when the class extends this parent class name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "implements": {
+          "description": "Only apply when the class implements this interface name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "members": {
+          "description": "Member names that should be treated as framework-used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "members"
       ]
     }
   }

--- a/schema.json
+++ b/schema.json
@@ -73,10 +73,10 @@
       "default": []
     },
     "usedClassMembers": {
-      "description": "Class member method/property names that should never be flagged as\nunused. Extends the built-in lifecycle allowlist (Angular/React) with\nframework-invoked names from libraries that call interface methods at\nruntime (e.g. ag-Grid's `agInit`, `refresh`). Use this at the top level\nfor project-wide additions; use a plugin file's `usedClassMembers` when\nthe names should only apply when a specific package is installed.",
+      "description": "Class member method/property rules that should never be flagged as\nunused. Supports plain member names for global suppression and scoped\nobjects with `extends` / `implements` constraints for framework-invoked\nmethods that should only be suppressed on matching classes.",
       "type": "array",
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/UsedClassMemberRule"
       },
       "default": []
     },
@@ -292,10 +292,10 @@
           "default": []
         },
         "usedClassMembers": {
-          "description": "Class member method/property names the framework invokes at runtime.\nListed names extend the built-in lifecycle allowlist, so members with\nthese names are never flagged as unused-class-members. Use for libraries\nthat call interface methods reflectively (e.g. ag-Grid's `agInit`,\n`refresh`; TypeORM's `MigrationInterface.up`/`down`; Web Components'\n`connectedCallback`).",
+          "description": "Class member method/property rules the framework invokes at runtime.\nSupports plain member names for global suppression and scoped objects\nwith `extends` / `implements` constraints when the method name is too\ncommon to suppress across the whole workspace.",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/UsedClassMemberRule"
           },
           "default": []
         }
@@ -422,6 +422,50 @@
       "required": [
         "pattern",
         "exports"
+      ]
+    },
+    "UsedClassMemberRule": {
+      "description": "A `usedClassMembers` entry from config or an external plugin.\n\nSupports either a plain member name (`\"agInit\"`) or a scoped rule that\nonly applies when a class matches specific `extends` / `implements`\nheritage clauses.",
+      "anyOf": [
+        {
+          "description": "Globally suppress this class member name for all classes.",
+          "type": "string"
+        },
+        {
+          "description": "Suppress these class member names only for matching classes.",
+          "$ref": "#/$defs/ScopedUsedClassMemberRule"
+        }
+      ]
+    },
+    "ScopedUsedClassMemberRule": {
+      "description": "A heritage-constrained `usedClassMembers` rule.",
+      "type": "object",
+      "properties": {
+        "extends": {
+          "description": "Only apply when the class extends this parent class name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "implements": {
+          "description": "Only apply when the class implements this interface name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "members": {
+          "description": "Member names that should be treated as framework-used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "members"
       ]
     },
     "WorkspaceConfig": {

--- a/tests/fixtures/scoped-used-class-members/package.json
+++ b/tests/fixtures/scoped-used-class-members/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "scoped-used-class-members",
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/scoped-used-class-members/src/command.ts
+++ b/tests/fixtures/scoped-used-class-members/src/command.ts
@@ -1,0 +1,7 @@
+import { BaseCommand } from './contracts';
+
+export class DeployCommand extends BaseCommand {
+  async execute(): Promise<void> {}
+
+  cleanup(): void {}
+}

--- a/tests/fixtures/scoped-used-class-members/src/contracts.ts
+++ b/tests/fixtures/scoped-used-class-members/src/contracts.ts
@@ -1,0 +1,12 @@
+export interface ICellRendererAngularComp {
+  agInit(): void;
+  refresh(): boolean;
+}
+
+export interface Authorizable {
+  authorize(): boolean;
+}
+
+export abstract class BaseCommand {
+  abstract execute(): Promise<void>;
+}

--- a/tests/fixtures/scoped-used-class-members/src/grid-renderer.ts
+++ b/tests/fixtures/scoped-used-class-members/src/grid-renderer.ts
@@ -1,0 +1,13 @@
+import { ICellRendererAngularComp } from './contracts';
+
+export class PriceCellRenderer implements ICellRendererAngularComp {
+  agInit(): void {}
+
+  refresh(): boolean {
+    return true;
+  }
+
+  unusedHelper(): boolean {
+    return false;
+  }
+}

--- a/tests/fixtures/scoped-used-class-members/src/index.ts
+++ b/tests/fixtures/scoped-used-class-members/src/index.ts
@@ -1,0 +1,9 @@
+import { DeployCommand } from './command';
+import { PriceCellRenderer } from './grid-renderer';
+import { SecureCommand } from './secure-command';
+import { DashboardComponent } from './unrelated';
+
+void new PriceCellRenderer();
+void new DeployCommand();
+void new SecureCommand();
+void new DashboardComponent();

--- a/tests/fixtures/scoped-used-class-members/src/secure-command.ts
+++ b/tests/fixtures/scoped-used-class-members/src/secure-command.ts
@@ -1,0 +1,15 @@
+import { Authorizable, BaseCommand } from './contracts';
+
+class SecureCommand extends BaseCommand implements Authorizable {
+  async execute(): Promise<void> {}
+
+  authorize(): boolean {
+    return true;
+  }
+
+  hydrate(): void {}
+
+  cleanup(): void {}
+}
+
+export { SecureCommand };

--- a/tests/fixtures/scoped-used-class-members/src/unrelated.ts
+++ b/tests/fixtures/scoped-used-class-members/src/unrelated.ts
@@ -1,0 +1,11 @@
+export class DashboardComponent {
+  refresh(): boolean {
+    return true;
+  }
+
+  execute(): void {}
+
+  authorize(): boolean {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #117.

usedClassMembers was still effectively a flat name-based allowlist for common method names like refresh() and execute(), which could hide genuinely unused methods on unrelated classes. The export { Foo } path also dropped class members and heritage, so scoped rules never applied to that export style.

This change adds extends and implements scoped usedClassMembers entries, extracts class heritage for direct exports, default exports, and local export specifiers, preserves class member metadata for local export aliases, keys member usage by exported symbol identity instead of bare export name, and rejects unconstrained object-form rules instead of silently treating them as global allowlists.

That keeps framework-invoked methods suppressed only where the class contract actually matches while still reporting unrelated dead methods elsewhere in the workspace.

Validation
cargo fmt --all -- --check
cargo test --workspace
cargo clippy --workspace -- -D warnings
