### PR TITLE
fix(nuxt): route css paths through normalize_nuxt_path

### DIFF
--- a/crates/core/src/plugins/nuxt.rs
+++ b/crates/core/src/plugins/nuxt.rs
@@ -289,21 +289,15 @@ impl Plugin for NuxtPlugin {
         }
 
         // css: [...] → always-used files or referenced dependencies
-        // Nuxt aliases: `~/` = srcDir (app/ or root), `~~/` = rootDir
-        // npm package CSS (e.g., `@unocss/reset/tailwind.css`) → referenced dependency
+        // Local paths (`~/`, `~~/`, `@/`, `@@/`, `./`, `/`) route through
+        // `normalize_nuxt_path` for the same workspace-root-relative resolution
+        // used by plugins/components/alias. Bare specifiers are npm package CSS.
         let css = config_parser::extract_config_string_array(source, config_path, &["css"]);
         for entry in &css {
-            if let Some(stripped) = entry.strip_prefix("~/") {
-                // ~ = srcDir: resolve to the configured source root, if any.
-                result
-                    .always_used_files
-                    .push(prefix_with_src_dir(&src_dir, stripped));
-            } else if let Some(stripped) = entry.strip_prefix("~~/") {
-                // ~~ = rootDir: always relative to project root
-                result.always_used_files.push(stripped.to_string());
-            } else if entry.starts_with('.') || entry.starts_with('/') {
-                // Relative or absolute local path
-                result.always_used_files.push(entry.clone());
+            if is_local_css_path(entry) {
+                if let Some(normalized) = normalize_nuxt_path(entry, config_path, root, &src_dir) {
+                    result.always_used_files.push(normalized);
+                }
             } else {
                 // npm package CSS (e.g., `@unocss/reset/tailwind.css`, `floating-vue/dist/style.css`)
                 let dep = crate::resolve::extract_package_name(entry);
@@ -461,6 +455,15 @@ fn default_nuxt_src_dir(root: &Path) -> String {
     } else {
         String::new()
     }
+}
+
+fn is_local_css_path(entry: &str) -> bool {
+    entry.starts_with("~/")
+        || entry.starts_with("~~/")
+        || entry.starts_with("@/")
+        || entry.starts_with("@@/")
+        || entry.starts_with('.')
+        || entry.starts_with('/')
 }
 
 fn extract_nuxt_src_dir(source: &str, config_path: &Path, root: &Path) -> Option<String> {
@@ -892,13 +895,74 @@ mod tests {
             });
         "#;
         let plugin = NuxtPlugin;
-        let result =
-            plugin.resolve_config(Path::new("nuxt.config.ts"), source, Path::new("/project"));
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
         assert!(
             result
                 .always_used_files
-                .contains(&"./assets/global.css".to_string()),
-            "relative CSS path should be an always-used file"
+                .contains(&"assets/global.css".to_string()),
+            "relative CSS path should resolve to a workspace-root-relative always-used file: {:?}",
+            result.always_used_files
+        );
+    }
+
+    #[test]
+    fn resolve_config_css_relative_with_nested_config() {
+        // `./assets/global.css` in docs/nuxt.config.ts is config-relative, so it
+        // resolves to docs/assets/global.css at the workspace root.
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("docs")).expect("create docs");
+        let config_path = root.join("docs/nuxt.config.ts");
+
+        let source = r#"
+            export default defineNuxtConfig({
+                css: ["./assets/global.css"]
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(&config_path, source, root);
+
+        let expected = "docs/assets/global.css";
+        assert!(
+            result
+                .always_used_files
+                .iter()
+                .any(|p| p.replace('\\', "/") == expected),
+            "./assets/global.css should resolve relative to config dir: {:?}",
+            result.always_used_files
+        );
+    }
+
+    #[test]
+    fn resolve_config_css_tilde_with_srcdir_app() {
+        // Root-level config with explicit srcDir: 'app' plus `css: ['~/assets/main.css']`.
+        // Previously untested combination — covers the tests/904–1128 gap.
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("app")).expect("create app");
+        let config_path = root.join("nuxt.config.ts");
+
+        let source = r#"
+            export default defineNuxtConfig({
+                srcDir: "app/",
+                css: ["~/assets/main.css"]
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(&config_path, source, root);
+
+        let expected = "app/assets/main.css";
+        assert!(
+            result
+                .always_used_files
+                .iter()
+                .any(|p| p.replace('\\', "/") == expected),
+            "~/assets/main.css with srcDir:'app' should resolve to {expected}: {:?}",
+            result.always_used_files
         );
     }
 

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -548,6 +548,28 @@ fn nuxt_configured_runtime_paths_reduce_false_positives_and_keep_dead_exports_vi
 }
 
 #[test]
+fn nuxt_css_tilde_alias_keeps_app_assets_alive() {
+    // nuxt.config.ts with css:['~/assets/main.css'] must not flag
+    // app/assets/main.css as unused (default Nuxt 4 srcDir = app/).
+    let root = fixture_path("nuxt-css-alias");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_files: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+
+    assert!(
+        !unused_files
+            .iter()
+            .any(|p| p.ends_with("app/assets/main.css")),
+        "app/assets/main.css should be kept alive by nuxt.config.ts css entry: {unused_files:?}"
+    );
+}
+
+#[test]
 fn nuxt_convention_exports_preserve_defaults_but_report_dead_helpers() {
     let root = fixture_path("nuxt-convention-exports");
     let config = create_config(root);

--- a/tests/fixtures/nuxt-css-alias/app/app.vue
+++ b/tests/fixtures/nuxt-css-alias/app/app.vue
@@ -1,0 +1,1 @@
+<template><div>app</div></template>

--- a/tests/fixtures/nuxt-css-alias/app/assets/main.css
+++ b/tests/fixtures/nuxt-css-alias/app/assets/main.css
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/tests/fixtures/nuxt-css-alias/nuxt.config.ts
+++ b/tests/fixtures/nuxt-css-alias/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  css: ["~/assets/main.css"],
+});

--- a/tests/fixtures/nuxt-css-alias/package.json
+++ b/tests/fixtures/nuxt-css-alias/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nuxt-css-alias",
+  "dependencies": {
+    "nuxt": "^3.0.0",
+    "vue": "^3.0.0"
+  }
+}


### PR DESCRIPTION
**Before:** CSS loop in `nuxt.rs` pushed raw paths; `@/` / `@@/` unsupported, `./foo.css` kept the leading `./`.

**Expected:** same path resolution as plugins/components/alias — which already go through `normalize_nuxt_path`.

**Change:** route local CSS entries through `normalize_nuxt_path`. Bare specifiers still treated as npm package CSS. Added integration fixture `nuxt-css-alias` asserting `app/assets/main.css` isn't flagged unused.