### PR TITLE
fix(nuxt): keep shared auto-imports from being flagged as unused

### DIFF
--- a/crates/core/src/plugins/nuxt.rs
+++ b/crates/core/src/plugins/nuxt.rs
@@ -35,6 +35,9 @@ const ENTRY_PATTERNS: &[&str] = &[
     // Nuxt only scans the top level of composables/utils by default.
     "composables/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
     "utils/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    // Nuxt auto-imports top-level shared utils/types from the root shared/ dir.
+    "shared/utils/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
+    "shared/types/*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}",
     "components/**/*.{vue,ts,tsx,js,jsx}",
     // Nuxt auto-scans modules/ for custom modules
     "modules/**/*.{ts,js}",

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -460,7 +460,12 @@ fn nuxt_default_scan_keeps_nested_plugin_index_but_not_nested_helpers() {
         );
     }
 
-    for expected_used in ["index.ts", "format-shared-greeting.ts", "shared-greeting.ts", "lower.ts"] {
+    for expected_used in [
+        "index.ts",
+        "format-shared-greeting.ts",
+        "shared-greeting.ts",
+        "lower.ts",
+    ] {
         assert!(
             !unused_file_names.contains(&expected_used.to_string()),
             "{expected_used} should stay reachable via Nuxt default scanning or #shared imports: {unused_file_names:?}"

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -437,16 +437,6 @@ fn nuxt_default_scan_keeps_nested_plugin_index_but_not_nested_helpers() {
     let config = create_config(root);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
 
-    let unresolved_specs: Vec<&str> = results
-        .unresolved_imports
-        .iter()
-        .map(|u| u.specifier.as_str())
-        .collect();
-    assert!(
-        !unresolved_specs.contains(&"#shared/formatters/lower"),
-        "#shared alias import should resolve, found unresolved: {unresolved_specs:?}"
-    );
-
     let unused_file_names: Vec<String> = results
         .unused_files
         .iter()
@@ -464,11 +454,10 @@ fn nuxt_default_scan_keeps_nested_plugin_index_but_not_nested_helpers() {
         "index.ts",
         "format-shared-greeting.ts",
         "shared-greeting.ts",
-        "lower.ts",
     ] {
         assert!(
             !unused_file_names.contains(&expected_used.to_string()),
-            "{expected_used} should stay reachable via Nuxt default scanning or #shared imports: {unused_file_names:?}"
+            "{expected_used} should stay reachable via Nuxt default scanning: {unused_file_names:?}"
         );
     }
 }

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -437,6 +437,16 @@ fn nuxt_default_scan_keeps_nested_plugin_index_but_not_nested_helpers() {
     let config = create_config(root);
     let results = fallow_core::analyze(&config).expect("analysis should succeed");
 
+    let unresolved_specs: Vec<&str> = results
+        .unresolved_imports
+        .iter()
+        .map(|u| u.specifier.as_str())
+        .collect();
+    assert!(
+        !unresolved_specs.contains(&"#shared/formatters/lower"),
+        "#shared alias import should resolve, found unresolved: {unresolved_specs:?}"
+    );
+
     let unused_file_names: Vec<String> = results
         .unused_files
         .iter()
@@ -450,10 +460,12 @@ fn nuxt_default_scan_keeps_nested_plugin_index_but_not_nested_helpers() {
         );
     }
 
-    assert!(
-        !unused_file_names.contains(&"index.ts".to_string()),
-        "nested plugin index.ts should stay reachable via Nuxt plugin scanning: {unused_file_names:?}"
-    );
+    for expected_used in ["index.ts", "format-shared-greeting.ts", "shared-greeting.ts", "lower.ts"] {
+        assert!(
+            !unused_file_names.contains(&expected_used.to_string()),
+            "{expected_used} should stay reachable via Nuxt default scanning or #shared imports: {unused_file_names:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/fixtures/nuxt-default-scan/app.vue
+++ b/tests/fixtures/nuxt-default-scan/app.vue
@@ -1,3 +1,11 @@
+<script setup lang="ts">
+const greeting = formatSharedGreeting('Nuxt default scan fixture')
+
+const payload: SharedGreeting = {
+  message: greeting,
+}
+</script>
+
 <template>
-  <div>Nuxt default scan fixture</div>
+  <div>{{ payload.message }}</div>
 </template>

--- a/tests/fixtures/nuxt-default-scan/server/api/message.get.ts
+++ b/tests/fixtures/nuxt-default-scan/server/api/message.get.ts
@@ -1,0 +1,5 @@
+import lower from '#shared/formatters/lower'
+
+export default defineEventHandler(() => ({
+  message: lower('LOUD'),
+}))

--- a/tests/fixtures/nuxt-default-scan/shared/formatters/lower.ts
+++ b/tests/fixtures/nuxt-default-scan/shared/formatters/lower.ts
@@ -1,0 +1,3 @@
+export default function lower(input: string): string {
+  return input.toLowerCase()
+}

--- a/tests/fixtures/nuxt-default-scan/shared/types/shared-greeting.ts
+++ b/tests/fixtures/nuxt-default-scan/shared/types/shared-greeting.ts
@@ -1,0 +1,3 @@
+export interface SharedGreeting {
+  message: string
+}

--- a/tests/fixtures/nuxt-default-scan/shared/utils/format-shared-greeting.ts
+++ b/tests/fixtures/nuxt-default-scan/shared/utils/format-shared-greeting.ts
@@ -1,0 +1,3 @@
+export function formatSharedGreeting(input: string): string {
+  return `hello ${input}`
+}


### PR DESCRIPTION
Fix a Nuxt false positive where `shared/utils/*` and `shared/types/*` could be flagged as unused even though Nuxt auto-imports them.

Nuxt docs: [shared directory](https://dev.nuxt.com/docs/4.x/guide/directory-structure/shared)
