### PR TITLE
fix(nuxt): keep module-owned configs from being flagged unused

### DIFF
--- a/crates/core/src/analyze/mod.rs
+++ b/crates/core/src/analyze/mod.rs
@@ -241,7 +241,7 @@ pub fn find_dead_code_full(
         && let Some(ref pkg) = pkg
     {
         results.test_only_dependencies =
-            find_test_only_dependencies(graph, pkg, config, workspaces);
+            find_test_only_dependencies(graph, pkg, config, plugin_result, workspaces);
     }
 
     // Detect architecture boundary violations

--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use fallow_config::{PackageJson, ResolvedConfig};
+use fallow_config::{EntryPointRole, PackageJson, ResolvedConfig};
 
 use crate::discover::FileId;
 use crate::graph::ModuleGraph;
@@ -373,6 +373,7 @@ pub fn find_test_only_dependencies(
     graph: &ModuleGraph,
     pkg: &PackageJson,
     config: &ResolvedConfig,
+    plugin_result: Option<&crate::plugins::AggregatedPluginResult>,
     workspaces: &[fallow_config::WorkspaceInfo],
 ) -> Vec<TestOnlyDependency> {
     // Build a GlobSet from the production exclude patterns (test/dev/story files)
@@ -400,6 +401,7 @@ pub fn find_test_only_dependencies(
         .iter()
         .map(String::as_str)
         .collect();
+    let runtime_always_used = runtime_plugin_always_used_globset(plugin_result);
 
     let mut test_only_deps = Vec::new();
 
@@ -436,7 +438,10 @@ pub fn find_test_only_dependencies(
                     .path
                     .strip_prefix(&config.root)
                     .unwrap_or(&module.path);
-                test_globs.is_match(relative) || is_config_file(&module.path)
+                let runtime_used = runtime_always_used
+                    .as_ref()
+                    .is_some_and(|set| set.is_match(relative));
+                !runtime_used && (test_globs.is_match(relative) || is_config_file(&module.path))
             })
         });
 
@@ -453,6 +458,41 @@ pub fn find_test_only_dependencies(
     }
 
     test_only_deps
+}
+
+fn runtime_plugin_always_used_globset(
+    plugin_result: Option<&crate::plugins::AggregatedPluginResult>,
+) -> Option<globset::GlobSet> {
+    let plugin_result = plugin_result?;
+    let runtime_plugins: FxHashSet<&str> = plugin_result
+        .entry_point_roles
+        .iter()
+        .filter_map(|(plugin, role)| (*role == EntryPointRole::Runtime).then_some(plugin.as_str()))
+        .collect();
+    if runtime_plugins.is_empty() {
+        return None;
+    }
+
+    let mut builder = globset::GlobSetBuilder::new();
+    let mut added = false;
+    for (pattern, plugin_name) in plugin_result
+        .always_used
+        .iter()
+        .chain(plugin_result.discovered_always_used.iter())
+    {
+        if !runtime_plugins.contains(plugin_name.as_str()) {
+            continue;
+        }
+        if let Ok(glob) = globset::GlobBuilder::new(pattern)
+            .literal_separator(true)
+            .build()
+        {
+            builder.add(glob);
+            added = true;
+        }
+    }
+
+    added.then(|| builder.build().ok()).flatten()
 }
 
 /// Check whether a package is listed in root deps or in the workspace that owns `file_path`.

--- a/crates/core/src/analyze/unused_deps_tests/test_only_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/test_only_deps.rs
@@ -44,7 +44,7 @@ fn test_only_dep_from_root_test_file() {
     let pkg = make_pkg(&["vitest"], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
 
-    let test_only = find_test_only_dependencies(&graph, &pkg, &config, &[]);
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, None, &[]);
 
     assert!(
         test_only.iter().any(|d| d.package_name == "vitest"),
@@ -94,7 +94,7 @@ fn test_only_dep_from_root_config_file() {
     let pkg = make_pkg(&["vitest"], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
 
-    let test_only = find_test_only_dependencies(&graph, &pkg, &config, &[]);
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, None, &[]);
 
     assert!(
         test_only.iter().any(|d| d.package_name == "vitest"),
@@ -146,7 +146,7 @@ fn test_only_dep_from_workspace_config_file() {
     let pkg = make_pkg(&["vitest"], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
 
-    let test_only = find_test_only_dependencies(&graph, &pkg, &config, &[]);
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, None, &[]);
 
     assert!(
         test_only.iter().any(|d| d.package_name == "vitest"),
@@ -197,7 +197,7 @@ fn not_test_only_when_imported_from_app_config() {
     let pkg = make_pkg(&["@angular/router"], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
 
-    let test_only = find_test_only_dependencies(&graph, &pkg, &config, &[]);
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, None, &[]);
 
     assert!(
         test_only.is_empty(),
@@ -285,7 +285,7 @@ fn not_test_only_when_also_imported_from_source() {
     let pkg = make_pkg(&["some-lib"], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
 
-    let test_only = find_test_only_dependencies(&graph, &pkg, &config, &[]);
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, None, &[]);
 
     assert!(
         test_only.is_empty(),
@@ -335,10 +335,122 @@ fn test_only_dep_from_workspace_jest_config() {
     let pkg = make_pkg(&["ts-jest"], &[], &[]);
     let config = test_config(PathBuf::from("/project"));
 
-    let test_only = find_test_only_dependencies(&graph, &pkg, &config, &[]);
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, None, &[]);
 
     assert!(
         test_only.iter().any(|d| d.package_name == "ts-jest"),
         "dep imported only from workspace-level jest.config.ts should be flagged"
+    );
+}
+
+#[test]
+fn runtime_plugin_owned_config_is_not_test_only() {
+    let files = vec![DiscoveredFile {
+        id: FileId(0),
+        path: PathBuf::from("/project/content.config.ts"),
+        size_bytes: 100,
+    }];
+
+    let entry_points = vec![EntryPoint {
+        path: PathBuf::from("/project/content.config.ts"),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/content.config.ts"),
+        exports: vec![],
+        re_exports: vec![],
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "@nuxt/content".to_string(),
+                imported_name: ImportedName::Named("defineContentConfig".to_string()),
+                local_name: "defineContentConfig".to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::new(0, 20),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::NpmPackage("@nuxt/content".to_string()),
+        }],
+        resolved_dynamic_imports: vec![],
+        resolved_dynamic_patterns: vec![],
+        member_accesses: vec![],
+        whole_object_uses: vec![],
+        has_cjs_exports: false,
+        unused_import_bindings: FxHashSet::default(),
+    }];
+
+    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    let pkg = make_pkg(&["@nuxt/content"], &[], &[]);
+    let config = test_config(PathBuf::from("/project"));
+    let mut plugin_result = AggregatedPluginResult::default();
+    plugin_result
+        .entry_point_roles
+        .insert("nuxt".to_string(), fallow_config::EntryPointRole::Runtime);
+    plugin_result
+        .always_used
+        .push(("content.config.ts".to_string(), "nuxt".to_string()));
+
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, Some(&plugin_result), &[]);
+
+    assert!(
+        test_only.is_empty(),
+        "runtime plugin-owned config files should not make deps test-only"
+    );
+}
+
+#[test]
+fn test_plugin_config_stays_test_only_even_when_always_used() {
+    let files = vec![DiscoveredFile {
+        id: FileId(0),
+        path: PathBuf::from("/project/vitest.config.ts"),
+        size_bytes: 100,
+    }];
+
+    let entry_points = vec![EntryPoint {
+        path: PathBuf::from("/project/vitest.config.ts"),
+        source: EntryPointSource::PackageJsonMain,
+    }];
+
+    let resolved_modules = vec![ResolvedModule {
+        file_id: FileId(0),
+        path: PathBuf::from("/project/vitest.config.ts"),
+        exports: vec![],
+        re_exports: vec![],
+        resolved_imports: vec![ResolvedImport {
+            info: ImportInfo {
+                source: "vitest".to_string(),
+                imported_name: ImportedName::Named("defineConfig".to_string()),
+                local_name: "defineConfig".to_string(),
+                is_type_only: false,
+                span: oxc_span::Span::new(0, 20),
+                source_span: oxc_span::Span::default(),
+            },
+            target: ResolveResult::NpmPackage("vitest".to_string()),
+        }],
+        resolved_dynamic_imports: vec![],
+        resolved_dynamic_patterns: vec![],
+        member_accesses: vec![],
+        whole_object_uses: vec![],
+        has_cjs_exports: false,
+        unused_import_bindings: FxHashSet::default(),
+    }];
+
+    let graph = ModuleGraph::build(&resolved_modules, &entry_points, &files);
+    let pkg = make_pkg(&["vitest"], &[], &[]);
+    let config = test_config(PathBuf::from("/project"));
+    let mut plugin_result = AggregatedPluginResult::default();
+    plugin_result
+        .entry_point_roles
+        .insert("vitest".to_string(), fallow_config::EntryPointRole::Test);
+    plugin_result
+        .always_used
+        .push(("vitest.config.ts".to_string(), "vitest".to_string()));
+
+    let test_only = find_test_only_dependencies(&graph, &pkg, &config, Some(&plugin_result), &[]);
+
+    assert!(
+        test_only.iter().any(|d| d.package_name == "vitest"),
+        "test plugin config files should still make deps test-only"
     );
 }

--- a/crates/core/src/plugins/nuxt.rs
+++ b/crates/core/src/plugins/nuxt.rs
@@ -119,6 +119,13 @@ const TOOLING_DEPENDENCIES: &[&str] = &[
 const USED_EXPORTS_SERVER_API: &[&str] = &["default", "defineEventHandler"];
 const USED_EXPORTS_MIDDLEWARE: &[&str] = &["default"];
 const USED_EXPORTS_DEFAULT: &[&str] = &["default"];
+const MODULE_OWNED_DEFAULT_EXPORTS: &[&str] = &["default"];
+
+const NUXT_CONTENT_CONFIG_PATTERNS: &[&str] = &["content.config.{ts,js,mts,mjs,cts,cjs}"];
+const NUXT_BETTER_AUTH_CONFIG_PATTERNS: &[&str] = &[
+    "app/auth.config.{ts,js,mts,mjs,cts,cjs}",
+    "server/auth.config.{ts,js,mts,mjs,cts,cjs}",
+];
 
 const DEFAULT_EXPORT_ENTRY_PATTERNS: &[&str] = &[
     "pages/**/*.{vue,ts,tsx,js,jsx}",
@@ -287,6 +294,7 @@ impl Plugin for NuxtPlugin {
             let dep = crate::resolve::extract_package_name(module);
             result.referenced_dependencies.push(dep);
         }
+        add_nuxt_module_conventions(&mut result, &modules);
 
         // css: [...] → always-used files or referenced dependencies
         // Local paths (`~/`, `~~/`, `@/`, `@@/`, `./`, `/`) route through
@@ -507,6 +515,36 @@ fn add_src_dir_support(result: &mut PluginResult, src_dir: &str) {
 
 fn add_default_used_export(result: &mut PluginResult, pattern: impl Into<String>) {
     result.push_used_export_rule(pattern, ["default"]);
+}
+
+fn add_nuxt_module_conventions(result: &mut PluginResult, modules: &[String]) {
+    let mut has_nuxt_content = false;
+    let mut has_nuxt_better_auth = false;
+
+    for module in modules {
+        match crate::resolve::extract_package_name(module).as_str() {
+            "@nuxt/content" => has_nuxt_content = true,
+            "@onmax/nuxt-better-auth" => has_nuxt_better_auth = true,
+            _ => {}
+        }
+    }
+
+    if has_nuxt_content {
+        add_module_owned_config_patterns(result, NUXT_CONTENT_CONFIG_PATTERNS);
+    }
+
+    if has_nuxt_better_auth {
+        add_module_owned_config_patterns(result, NUXT_BETTER_AUTH_CONFIG_PATTERNS);
+    }
+}
+
+fn add_module_owned_config_patterns(result: &mut PluginResult, patterns: &[&str]) {
+    result
+        .always_used_files
+        .extend(patterns.iter().map(|pattern| (*pattern).to_string()));
+    for pattern in patterns {
+        result.push_used_export_rule(*pattern, MODULE_OWNED_DEFAULT_EXPORTS.iter().copied());
+    }
 }
 
 fn add_prefixed_default_used_exports(result: &mut PluginResult, prefix: &str, patterns: &[&str]) {

--- a/crates/core/src/plugins/nuxt.rs
+++ b/crates/core/src/plugins/nuxt.rs
@@ -121,10 +121,52 @@ const USED_EXPORTS_MIDDLEWARE: &[&str] = &["default"];
 const USED_EXPORTS_DEFAULT: &[&str] = &["default"];
 const MODULE_OWNED_DEFAULT_EXPORTS: &[&str] = &["default"];
 
-const NUXT_CONTENT_CONFIG_PATTERNS: &[&str] = &["content.config.{ts,js,mts,mjs,cts,cjs}"];
-const NUXT_BETTER_AUTH_CONFIG_PATTERNS: &[&str] = &[
-    "app/auth.config.{ts,js,mts,mjs,cts,cjs}",
-    "server/auth.config.{ts,js,mts,mjs,cts,cjs}",
+struct NuxtStaticConfigConvention {
+    pattern: &'static str,
+    used_exports: &'static [&'static str],
+}
+
+struct NuxtConfigPathConvention {
+    option_path: &'static [&'static str],
+    default_path: &'static str,
+    used_exports: &'static [&'static str],
+}
+
+struct NuxtModuleConvention {
+    package_name: &'static str,
+    static_configs: &'static [NuxtStaticConfigConvention],
+    configurable_paths: &'static [NuxtConfigPathConvention],
+}
+
+const NUXT_CONTENT_STATIC_CONFIGS: &[NuxtStaticConfigConvention] = &[NuxtStaticConfigConvention {
+    pattern: "content.config.{ts,js,mts,mjs,cts,cjs}",
+    used_exports: MODULE_OWNED_DEFAULT_EXPORTS,
+}];
+
+const NUXT_BETTER_AUTH_CONFIG_PATHS: &[NuxtConfigPathConvention] = &[
+    NuxtConfigPathConvention {
+        option_path: &["auth", "clientConfig"],
+        default_path: "app/auth.config",
+        used_exports: MODULE_OWNED_DEFAULT_EXPORTS,
+    },
+    NuxtConfigPathConvention {
+        option_path: &["auth", "serverConfig"],
+        default_path: "server/auth.config",
+        used_exports: MODULE_OWNED_DEFAULT_EXPORTS,
+    },
+];
+
+const NUXT_MODULE_CONVENTIONS: &[NuxtModuleConvention] = &[
+    NuxtModuleConvention {
+        package_name: "@nuxt/content",
+        static_configs: NUXT_CONTENT_STATIC_CONFIGS,
+        configurable_paths: &[],
+    },
+    NuxtModuleConvention {
+        package_name: "@onmax/nuxt-better-auth",
+        static_configs: &[],
+        configurable_paths: NUXT_BETTER_AUTH_CONFIG_PATHS,
+    },
 ];
 
 const DEFAULT_EXPORT_ENTRY_PATTERNS: &[&str] = &[
@@ -294,7 +336,7 @@ impl Plugin for NuxtPlugin {
             let dep = crate::resolve::extract_package_name(module);
             result.referenced_dependencies.push(dep);
         }
-        add_nuxt_module_conventions(&mut result, &modules);
+        add_nuxt_module_conventions(&mut result, &modules, source, config_path, root, &src_dir);
 
         // css: [...] → always-used files or referenced dependencies
         // Local paths (`~/`, `~~/`, `@/`, `@@/`, `./`, `/`) route through
@@ -517,34 +559,64 @@ fn add_default_used_export(result: &mut PluginResult, pattern: impl Into<String>
     result.push_used_export_rule(pattern, ["default"]);
 }
 
-fn add_nuxt_module_conventions(result: &mut PluginResult, modules: &[String]) {
-    let mut has_nuxt_content = false;
-    let mut has_nuxt_better_auth = false;
+fn add_nuxt_module_conventions(
+    result: &mut PluginResult,
+    modules: &[String],
+    source: &str,
+    config_path: &Path,
+    root: &Path,
+    src_dir: &str,
+) {
+    let mut applied = Vec::new();
 
     for module in modules {
-        match crate::resolve::extract_package_name(module).as_str() {
-            "@nuxt/content" => has_nuxt_content = true,
-            "@onmax/nuxt-better-auth" => has_nuxt_better_auth = true,
-            _ => {}
+        let package_name = crate::resolve::extract_package_name(module);
+        let Some(convention) = NUXT_MODULE_CONVENTIONS
+            .iter()
+            .find(|candidate| candidate.package_name == package_name)
+        else {
+            continue;
+        };
+        if applied.contains(&convention.package_name) {
+            continue;
         }
-    }
-
-    if has_nuxt_content {
-        add_module_owned_config_patterns(result, NUXT_CONTENT_CONFIG_PATTERNS);
-    }
-
-    if has_nuxt_better_auth {
-        add_module_owned_config_patterns(result, NUXT_BETTER_AUTH_CONFIG_PATTERNS);
+        applied.push(convention.package_name);
+        apply_nuxt_module_convention(result, convention, source, config_path, root, src_dir);
     }
 }
 
-fn add_module_owned_config_patterns(result: &mut PluginResult, patterns: &[&str]) {
-    result
-        .always_used_files
-        .extend(patterns.iter().map(|pattern| (*pattern).to_string()));
-    for pattern in patterns {
-        result.push_used_export_rule(*pattern, MODULE_OWNED_DEFAULT_EXPORTS.iter().copied());
+fn apply_nuxt_module_convention(
+    result: &mut PluginResult,
+    convention: &NuxtModuleConvention,
+    source: &str,
+    config_path: &Path,
+    root: &Path,
+    src_dir: &str,
+) {
+    for config in convention.static_configs {
+        add_module_owned_config_pattern(result, config.pattern.to_string(), config.used_exports);
     }
+
+    for config in convention.configurable_paths {
+        let raw = config_parser::extract_config_string(source, config_path, config.option_path)
+            .unwrap_or_else(|| config.default_path.to_string());
+        if let Some(normalized) = normalize_nuxt_path(&raw, config_path, root, src_dir) {
+            add_module_owned_config_pattern(
+                result,
+                script_entry_pattern(&normalized),
+                config.used_exports,
+            );
+        }
+    }
+}
+
+fn add_module_owned_config_pattern(
+    result: &mut PluginResult,
+    pattern: String,
+    used_exports: &[&str],
+) {
+    result.always_used_files.push(pattern.clone());
+    result.push_used_export_rule(pattern, used_exports.iter().copied());
 }
 
 fn add_prefixed_default_used_exports(result: &mut PluginResult, prefix: &str, patterns: &[&str]) {
@@ -781,8 +853,11 @@ mod tests {
             });
         "#;
         let plugin = NuxtPlugin;
-        let result =
-            plugin.resolve_config(Path::new("nuxt.config.ts"), source, Path::new("/project"));
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
         assert!(
             result
                 .referenced_dependencies
@@ -793,6 +868,84 @@ mod tests {
                 .referenced_dependencies
                 .contains(&"@pinia/nuxt".to_string())
         );
+    }
+
+    #[test]
+    fn resolve_config_applies_module_owned_config_conventions() {
+        let source = r#"
+            export default defineNuxtConfig({
+                modules: ["@nuxt/content", "@onmax/nuxt-better-auth"]
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
+
+        for expected in [
+            "content.config.{ts,js,mts,mjs,cts,cjs}",
+            "app/auth.config.{ts,js,mts,cts,mjs,cjs}",
+            "server/auth.config.{ts,js,mts,cts,mjs,cjs}",
+        ] {
+            assert!(
+                result.always_used_files.contains(&expected.to_string()),
+                "{expected} should be treated as always used: {:?}",
+                result.always_used_files
+            );
+            assert!(
+                has_used_export_rule(&result, expected, &["default"]),
+                "{expected} should keep its default export alive"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_config_honors_module_owned_config_overrides() {
+        let source = r#"
+            export default defineNuxtConfig({
+                modules: ["@onmax/nuxt-better-auth"],
+                auth: {
+                    clientConfig: "app/custom/client-auth",
+                    serverConfig: "server/custom/server-auth"
+                }
+            });
+        "#;
+        let plugin = NuxtPlugin;
+        let result = plugin.resolve_config(
+            Path::new("/project/nuxt.config.ts"),
+            source,
+            Path::new("/project"),
+        );
+
+        for expected in [
+            "app/custom/client-auth.{ts,js,mts,cts,mjs,cjs}",
+            "server/custom/server-auth.{ts,js,mts,cts,mjs,cjs}",
+        ] {
+            assert!(
+                result.always_used_files.contains(&expected.to_string()),
+                "{expected} should be treated as always used: {:?}",
+                result.always_used_files
+            );
+            assert!(
+                has_used_export_rule(&result, expected, &["default"]),
+                "{expected} should keep its default export alive"
+            );
+        }
+
+        for default_pattern in [
+            "app/auth.config.{ts,js,mts,cts,mjs,cjs}",
+            "server/auth.config.{ts,js,mts,cts,mjs,cjs}",
+        ] {
+            assert!(
+                !result
+                    .always_used_files
+                    .contains(&default_pattern.to_string()),
+                "{default_pattern} should not stay active when overridden: {:?}",
+                result.always_used_files
+            );
+        }
     }
 
     #[test]

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -622,3 +622,75 @@ fn nuxt_convention_exports_preserve_defaults_but_report_dead_helpers() {
         );
     }
 }
+
+#[test]
+fn nuxt_module_owned_config_files_are_not_flagged_unused() {
+    let root = fixture_path("nuxt-module-owned-configs");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+
+    for expected_used in [
+        "content.config.ts",
+        "app/auth.config.ts",
+        "server/auth.config.ts",
+        "app.config.ts",
+    ] {
+        assert!(
+            !unused_file_names
+                .iter()
+                .any(|path| path.ends_with(expected_used)),
+            "{expected_used} should be kept alive by Nuxt module conventions: {unused_file_names:?}"
+        );
+    }
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.path.to_string_lossy().replace('\\', "/"),
+                e.export_name.clone(),
+            )
+        })
+        .collect();
+
+    for expected_used in [
+        "content.config.ts",
+        "app/auth.config.ts",
+        "server/auth.config.ts",
+        "app.config.ts",
+    ] {
+        assert!(
+            !unused_exports
+                .iter()
+                .any(|(path, export)| path.ends_with(expected_used) && export == "default"),
+            "{expected_used}:default should be framework-used in Nuxt, found: {unused_exports:?}"
+        );
+    }
+
+    let unused_dependencies: Vec<&str> = results
+        .unused_dependencies
+        .iter()
+        .map(|dep| dep.package_name.as_str())
+        .collect();
+    let test_only_dependencies: Vec<&str> = results
+        .test_only_dependencies
+        .iter()
+        .map(|dep| dep.package_name.as_str())
+        .collect();
+
+    assert!(
+        !unused_dependencies.contains(&"@nuxt/content"),
+        "@nuxt/content should not be reported as unused: {unused_dependencies:?}"
+    );
+    assert!(
+        !test_only_dependencies.contains(&"@nuxt/content"),
+        "@nuxt/content should not be reported as test-only: {test_only_dependencies:?}"
+    );
+}

--- a/crates/core/tests/integration_test/frameworks.rs
+++ b/crates/core/tests/integration_test/frameworks.rs
@@ -694,3 +694,105 @@ fn nuxt_module_owned_config_files_are_not_flagged_unused() {
         "@nuxt/content should not be reported as test-only: {test_only_dependencies:?}"
     );
 }
+
+fn copy_dir_recursive(source: &std::path::Path, target: &std::path::Path) {
+    std::fs::create_dir_all(target).expect("create target dir");
+    for entry in std::fs::read_dir(source).expect("read source dir") {
+        let entry = entry.expect("read dir entry");
+        let file_type = entry.file_type().expect("read file type");
+        let destination = target.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&entry.path(), &destination);
+        } else {
+            std::fs::copy(entry.path(), destination).expect("copy fixture file");
+        }
+    }
+}
+
+#[test]
+fn nuxt_module_owned_config_overrides_are_not_flagged_unused() {
+    let source_root = fixture_path("nuxt-module-owned-configs");
+    let temp = tempfile::tempdir().expect("create temp dir");
+    copy_dir_recursive(&source_root, temp.path());
+
+    std::fs::write(
+        temp.path().join("nuxt.config.ts"),
+        r#"export default defineNuxtConfig({
+  modules: ['@nuxt/content', '@nuxt/ui', '@onmax/nuxt-better-auth'],
+  auth: {
+    clientConfig: 'app/custom/client-auth',
+    serverConfig: 'server/custom/server-auth'
+  }
+})"#,
+    )
+    .expect("write overridden nuxt config");
+    std::fs::create_dir_all(temp.path().join("app/custom")).expect("create custom app dir");
+    std::fs::create_dir_all(temp.path().join("server/custom")).expect("create custom server dir");
+    std::fs::write(
+        temp.path().join("app/custom/client-auth.ts"),
+        "import { defineClientAuth } from '@onmax/nuxt-better-auth/config'\n\nexport default defineClientAuth({})\n",
+    )
+    .expect("write custom client auth config");
+    std::fs::write(
+        temp.path().join("server/custom/server-auth.ts"),
+        "import { defineServerAuth } from '@onmax/nuxt-better-auth/config'\n\nexport default defineServerAuth({ emailAndPassword: { enabled: true } })\n",
+    )
+    .expect("write custom server auth config");
+
+    let config = create_config(temp.path().to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_file_names: Vec<String> = results
+        .unused_files
+        .iter()
+        .map(|f| f.path.to_string_lossy().replace('\\', "/"))
+        .collect();
+
+    for expected_used in [
+        "content.config.ts",
+        "app.config.ts",
+        "app/custom/client-auth.ts",
+        "server/custom/server-auth.ts",
+    ] {
+        assert!(
+            !unused_file_names
+                .iter()
+                .any(|path| path.ends_with(expected_used)),
+            "{expected_used} should be kept alive by Nuxt module conventions: {unused_file_names:?}"
+        );
+    }
+
+    for expected_unused in ["app/auth.config.ts", "server/auth.config.ts"] {
+        assert!(
+            unused_file_names
+                .iter()
+                .any(|path| path.ends_with(expected_unused)),
+            "{expected_unused} should no longer be kept alive once Better Auth paths are overridden: {unused_file_names:?}"
+        );
+    }
+
+    let unused_exports: Vec<(String, String)> = results
+        .unused_exports
+        .iter()
+        .map(|e| {
+            (
+                e.path.to_string_lossy().replace('\\', "/"),
+                e.export_name.clone(),
+            )
+        })
+        .collect();
+
+    for expected_used in [
+        "content.config.ts",
+        "app.config.ts",
+        "app/custom/client-auth.ts",
+        "server/custom/server-auth.ts",
+    ] {
+        assert!(
+            !unused_exports
+                .iter()
+                .any(|(path, export)| path.ends_with(expected_used) && export == "default"),
+            "{expected_used}:default should be framework-used in Nuxt, found: {unused_exports:?}"
+        );
+    }
+}

--- a/tests/fixtures/nuxt-module-owned-configs/app.config.ts
+++ b/tests/fixtures/nuxt-module-owned-configs/app.config.ts
@@ -1,0 +1,7 @@
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'blue',
+    },
+  },
+})

--- a/tests/fixtures/nuxt-module-owned-configs/app/app.vue
+++ b/tests/fixtures/nuxt-module-owned-configs/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Nuxt module-owned config fixture</div>
+</template>

--- a/tests/fixtures/nuxt-module-owned-configs/app/auth.config.ts
+++ b/tests/fixtures/nuxt-module-owned-configs/app/auth.config.ts
@@ -1,0 +1,3 @@
+import { defineClientAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineClientAuth({})

--- a/tests/fixtures/nuxt-module-owned-configs/content.config.ts
+++ b/tests/fixtures/nuxt-module-owned-configs/content.config.ts
@@ -1,0 +1,5 @@
+import { defineContentConfig } from '@nuxt/content'
+
+export default defineContentConfig({
+  collections: {},
+})

--- a/tests/fixtures/nuxt-module-owned-configs/nuxt.config.ts
+++ b/tests/fixtures/nuxt-module-owned-configs/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  modules: ['@nuxt/content', '@nuxt/ui', '@onmax/nuxt-better-auth'],
+})

--- a/tests/fixtures/nuxt-module-owned-configs/package.json
+++ b/tests/fixtures/nuxt-module-owned-configs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nuxt-module-owned-configs",
+  "private": true,
+  "dependencies": {
+    "nuxt": "4.0.0",
+    "@nuxt/content": "3.13.0",
+    "@nuxt/ui": "4.6.1",
+    "@onmax/nuxt-better-auth": "0.0.2-alpha.31"
+  }
+}

--- a/tests/fixtures/nuxt-module-owned-configs/server/auth.config.ts
+++ b/tests/fixtures/nuxt-module-owned-configs/server/auth.config.ts
@@ -1,0 +1,7 @@
+import { defineServerAuth } from '@onmax/nuxt-better-auth/config'
+
+export default defineServerAuth({
+  emailAndPassword: {
+    enabled: true,
+  },
+})


### PR DESCRIPTION
Fix false positives for Nuxt module-owned config files like `content.config.ts` and Better Auth auth configs.