### PR TITLE
fix(build): unbreak main after oxc 0.125 and rand 0.9 bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "oxc_parser 0.125.0",
  "oxc_semantic 0.125.0",
  "oxc_span 0.125.0",
+ "oxc_str 0.125.0",
  "proptest",
  "rayon",
  "regex",
@@ -925,7 +926,7 @@ version = "2.44.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
 ]
@@ -2626,8 +2627,8 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2664,12 +2665,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ oxc_parser = "0.125"
 oxc_resolver = "11"
 oxc_semantic = "0.125"
 oxc_span = "0.125"
+oxc_str = "0.125"
 oxc_syntax = "0.125"
 oxc_coverage_instrument = "0.3"
 

--- a/crates/cli/src/health/coverage.rs
+++ b/crates/cli/src/health/coverage.rs
@@ -1187,6 +1187,7 @@ fn write_istanbul_coverage_file(
                 s: BTreeMap::new(),
                 f,
                 b: BTreeMap::new(),
+                b_t: None,
                 input_source_map: None,
             },
         );

--- a/crates/extract/Cargo.toml
+++ b/crates/extract/Cargo.toml
@@ -24,6 +24,7 @@ oxc_ast_visit = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
 
 # Parallelism
 rayon = { workspace = true }

--- a/crates/extract/src/parse.rs
+++ b/crates/extract/src/parse.rs
@@ -474,7 +474,7 @@ pub fn compute_unused_import_bindings(
             continue;
         }
         // Look up the import binding in the module scope
-        let name = oxc_span::Ident::from(import.local_name.as_str());
+        let name = oxc_str::Ident::from(import.local_name.as_str());
         if let Some(symbol_id) = scoping.get_binding(root_scope, name)
             && scoping.get_resolved_references(symbol_id).count() == 0
         {

--- a/crates/license/Cargo.toml
+++ b/crates/license/Cargo.toml
@@ -19,7 +19,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["std", "p
 
 [dev-dependencies]
 ed25519-dalek = { version = "2", features = ["rand_core"] }
-rand = "0.9"
+rand = "0.8"
 
 [lints]
 workspace = true

--- a/crates/mcp/src/server/mod.rs
+++ b/crates/mcp/src/server/mod.rs
@@ -22,6 +22,13 @@ mod tests;
 #[derive(Clone)]
 pub struct FallowMcp {
     binary: String,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "read by the rmcp tool_router macro expansion and unit tests"
+        )
+    )]
     tool_router: ToolRouter<Self>,
 }
 


### PR DESCRIPTION
## Summary

Three pre-existing breakages from today's dependabot batch had to be resolved together to restore \`cargo build --workspace\` and \`cargo clippy -- -D warnings\`:

- **#151** bumped \`oxc_coverage_instrument\` 0.2 → 0.3, which added a non-optional \`b_t\` field to \`FileCoverage\`. Populate it as \`None\` in the CRAP coverage converter (\`crates/cli/src/health/coverage.rs:1182\`).
- **#151** also moved \`Ident\` under \`oxc_str::Ident\`; \`oxc_span::Ident\` is now private. Route \`fallow-extract\` through the canonical path and add \`oxc_str\` as a workspace dep.
- **#152** bumped \`rmcp\` 1.3 → 1.4. The \`tool_router\` field is no longer read by the \`#[tool_router]\` macro expansion outside the test binary, so \`dead_code\` fires under \`-D warnings\`. Scope a \`#[cfg_attr(not(test), expect(dead_code, reason = ...))]\` to keep clippy green while preserving test usage.
- **#153** bumped \`rand\` 0.8 → 0.9, which pulls \`rand_core\` 0.9 alongside the 0.6 version that \`ed25519-dalek\` 2.2 still expects. \`OsRng\` no longer satisfies \`CryptoRngCore\`. Pin \`rand\` to 0.8 in \`fallow-license\` dev-deps until \`ed25519-dalek\` 3 ships stably.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace --all-targets\` (all tests pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`