### PR TITLE
fix: track class members used through interface types

### DIFF
--- a/crates/core/src/analyze/unused_members.rs
+++ b/crates/core/src/analyze/unused_members.rs
@@ -147,13 +147,47 @@ pub fn find_unused_members(
 
     let mut class_heritage_by_export: FxHashMap<ExportKey, (Option<String>, Vec<String>)> =
         FxHashMap::default();
+    let mut class_heritage_by_file = FxHashMap::default();
     for module in modules {
+        class_heritage_by_file.insert(module.file_id, module.class_heritage.as_slice());
         class_heritage_by_export.extend(module.class_heritage.iter().map(|heritage| {
             (
                 ExportKey::new(module.file_id, heritage.export_name.clone()),
                 (heritage.super_class.clone(), heritage.implements.clone()),
             )
         }));
+    }
+
+    let mut interface_to_implementers: FxHashMap<ExportKey, Vec<ExportKey>> = FxHashMap::default();
+    for resolved in resolved_modules {
+        let Some(class_heritage) = class_heritage_by_file.get(&resolved.file_id) else {
+            continue;
+        };
+        if class_heritage.is_empty() {
+            continue;
+        }
+
+        let local_to_export_keys = build_local_to_export_keys(resolved);
+        for heritage in *class_heritage {
+            if heritage.implements.is_empty() {
+                continue;
+            }
+
+            let implementer_key = ExportKey::new(resolved.file_id, heritage.export_name.clone());
+            for interface_name in &heritage.implements {
+                let Some(interface_keys) = local_to_export_keys.get(interface_name.as_str()) else {
+                    continue;
+                };
+                for interface_key in interface_keys {
+                    let implementers = interface_to_implementers
+                        .entry(interface_key.clone())
+                        .or_default();
+                    if !implementers.contains(&implementer_key) {
+                        implementers.push(implementer_key.clone());
+                    }
+                }
+            }
+        }
     }
 
     // Map exported symbol identity -> set of member names that are accessed across all modules.
@@ -197,6 +231,27 @@ pub fn find_unused_members(
             if let Some(export_keys) = local_to_export_keys.get(local_name.as_str()) {
                 whole_object_used_exports.extend(export_keys.iter().cloned());
             }
+        }
+    }
+
+    if !interface_to_implementers.is_empty() {
+        let mut propagations: Vec<(ExportKey, Vec<String>)> = Vec::new();
+
+        for (interface_key, implementer_keys) in &interface_to_implementers {
+            let Some(interface_accesses) = accessed_members.get(interface_key) else {
+                continue;
+            };
+            let accesses: Vec<String> = interface_accesses.iter().cloned().collect();
+            for implementer_key in implementer_keys {
+                propagations.push((implementer_key.clone(), accesses.clone()));
+            }
+        }
+
+        for (implementer_key, accesses) in propagations {
+            accessed_members
+                .entry(implementer_key)
+                .or_default()
+                .extend(accesses);
         }
     }
 
@@ -1421,7 +1476,7 @@ mod tests {
         // `this.service = new MyService()` then `this.service.doWork()`
         // should recognize doWork as a used member of MyService.
         // The visitor emits MemberAccess { object: "MyService", member: "doWork" }
-        // after resolving the `this.service` binding via instance_binding_names.
+        // after resolving the `this.service` binding via binding_target_names.
         let mut graph = build_graph(&[("/src/main.ts", true), ("/src/service.ts", false)]);
         graph.modules[1].set_reachable(true);
         graph.modules[1].exports = vec![make_export_with_members(
@@ -1468,6 +1523,233 @@ mod tests {
         // Only unusedMethod should be flagged; doWork is used via this.service.doWork()
         assert_eq!(class_members.len(), 1);
         assert_eq!(class_members[0].member_name, "unusedMethod");
+    }
+
+    #[test]
+    fn interface_member_usage_propagates_to_implementers() {
+        let mut graph = build_graph(&[
+            ("/src/main.ts", true),
+            ("/src/scroll-strategy.interface.ts", false),
+            ("/src/fixed-size-strategy.ts", false),
+            ("/src/scroll-viewport.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[2].set_reachable(true);
+        graph.modules[3].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members(
+            "VirtualScrollStrategy",
+            vec![],
+            Some(3),
+        )];
+        graph.modules[2].exports = vec![make_export_with_members(
+            "FixedSizeScrollStrategy",
+            vec![
+                make_member("attached", MemberKind::ClassProperty),
+                make_member("attach", MemberKind::ClassMethod),
+                make_member("detach", MemberKind::ClassMethod),
+                make_member("unusedHelper", MemberKind::ClassMethod),
+            ],
+            Some(0),
+        )];
+
+        let modules = vec![make_module_with_class_heritage(
+            2,
+            "FixedSizeScrollStrategy",
+            None,
+            &["VirtualScrollStrategy"],
+        )];
+
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(2),
+                path: PathBuf::from("/src/fixed-size-strategy.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./scroll-strategy.interface".to_string(),
+                        imported_name: ImportedName::Named("VirtualScrollStrategy".to_string()),
+                        local_name: "VirtualScrollStrategy".to_string(),
+                        is_type_only: false,
+                        span: Span::new(0, 30),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(3),
+                path: PathBuf::from("/src/scroll-viewport.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./scroll-strategy.interface".to_string(),
+                        imported_name: ImportedName::Named("VirtualScrollStrategy".to_string()),
+                        local_name: "VirtualScrollStrategy".to_string(),
+                        is_type_only: false,
+                        span: Span::new(0, 30),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                member_accesses: vec![
+                    MemberAccess {
+                        object: "VirtualScrollStrategy".to_string(),
+                        member: "attach".to_string(),
+                    },
+                    MemberAccess {
+                        object: "VirtualScrollStrategy".to_string(),
+                        member: "attached".to_string(),
+                    },
+                    MemberAccess {
+                        object: "VirtualScrollStrategy".to_string(),
+                        member: "detach".to_string(),
+                    },
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let (_, class_members) = find_unused_members(
+            &graph,
+            &resolved_modules,
+            &modules,
+            &SuppressionContext::empty(),
+            &FxHashMap::default(),
+            &[],
+        );
+
+        let unused_names: FxHashSet<String> = class_members
+            .iter()
+            .map(|member| format!("{}.{}", member.parent_name, member.member_name))
+            .collect();
+
+        assert!(
+            !unused_names.contains("FixedSizeScrollStrategy.attach"),
+            "attach should be credited through interface usage: {unused_names:?}"
+        );
+        assert!(
+            !unused_names.contains("FixedSizeScrollStrategy.attached"),
+            "attached should be credited through interface usage: {unused_names:?}"
+        );
+        assert!(
+            !unused_names.contains("FixedSizeScrollStrategy.detach"),
+            "detach should be credited through interface usage: {unused_names:?}"
+        );
+        assert!(
+            unused_names.contains("FixedSizeScrollStrategy.unusedHelper"),
+            "unrelated members should still be reported: {unused_names:?}"
+        );
+    }
+
+    #[test]
+    fn same_named_interfaces_do_not_share_member_usage() {
+        let mut graph = build_graph(&[
+            ("/src/main.ts", true),
+            ("/src/one-interface.ts", false),
+            ("/src/two-interface.ts", false),
+            ("/src/one-impl.ts", false),
+            ("/src/two-impl.ts", false),
+            ("/src/consumer.ts", false),
+        ]);
+        graph.modules[1].set_reachable(true);
+        graph.modules[2].set_reachable(true);
+        graph.modules[3].set_reachable(true);
+        graph.modules[4].set_reachable(true);
+        graph.modules[5].set_reachable(true);
+        graph.modules[1].exports = vec![make_export_with_members("Strategy", vec![], Some(5))];
+        graph.modules[2].exports = vec![make_export_with_members("Strategy", vec![], Some(0))];
+        graph.modules[3].exports = vec![make_export_with_members(
+            "OneStrategy",
+            vec![make_member("attach", MemberKind::ClassMethod)],
+            Some(0),
+        )];
+        graph.modules[4].exports = vec![make_export_with_members(
+            "TwoStrategy",
+            vec![make_member("attach", MemberKind::ClassMethod)],
+            Some(0),
+        )];
+
+        let modules = vec![
+            make_module_with_class_heritage(3, "OneStrategy", None, &["Strategy"]),
+            make_module_with_class_heritage(4, "TwoStrategy", None, &["Strategy"]),
+        ];
+
+        let resolved_modules = vec![
+            ResolvedModule {
+                file_id: FileId(3),
+                path: PathBuf::from("/src/one-impl.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./one-interface".to_string(),
+                        imported_name: ImportedName::Named("Strategy".to_string()),
+                        local_name: "Strategy".to_string(),
+                        is_type_only: true,
+                        span: Span::new(0, 30),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(4),
+                path: PathBuf::from("/src/two-impl.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./two-interface".to_string(),
+                        imported_name: ImportedName::Named("Strategy".to_string()),
+                        local_name: "Strategy".to_string(),
+                        is_type_only: true,
+                        span: Span::new(0, 30),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(2)),
+                }],
+                ..Default::default()
+            },
+            ResolvedModule {
+                file_id: FileId(5),
+                path: PathBuf::from("/src/consumer.ts"),
+                resolved_imports: vec![ResolvedImport {
+                    info: ImportInfo {
+                        source: "./one-interface".to_string(),
+                        imported_name: ImportedName::Named("Strategy".to_string()),
+                        local_name: "Strategy".to_string(),
+                        is_type_only: true,
+                        span: Span::new(0, 30),
+                        source_span: Span::default(),
+                    },
+                    target: ResolveResult::InternalModule(FileId(1)),
+                }],
+                member_accesses: vec![MemberAccess {
+                    object: "Strategy".to_string(),
+                    member: "attach".to_string(),
+                }],
+                ..Default::default()
+            },
+        ];
+
+        let (_, class_members) = find_unused_members(
+            &graph,
+            &resolved_modules,
+            &modules,
+            &SuppressionContext::empty(),
+            &FxHashMap::default(),
+            &[],
+        );
+
+        let unused_names: FxHashSet<String> = class_members
+            .iter()
+            .map(|member| format!("{}.{}", member.parent_name, member.member_name))
+            .collect();
+
+        assert!(
+            !unused_names.contains("OneStrategy.attach"),
+            "OneStrategy.attach should be credited through its own interface export: {unused_names:?}"
+        );
+        assert!(
+            unused_names.contains("TwoStrategy.attach"),
+            "TwoStrategy.attach should remain unused when only the other interface export is used: {unused_names:?}"
+        );
     }
 
     #[test]

--- a/crates/core/tests/integration_test/false_positive_fixes.rs
+++ b/crates/core/tests/integration_test/false_positive_fixes.rs
@@ -120,3 +120,35 @@ fn broken_tsconfig_extends_does_not_poison_sibling_resolution() {
             .collect::<Vec<_>>()
     );
 }
+
+// ── Interface-mediated class member usage (issue #132) ──────
+
+#[test]
+fn interface_member_usage_does_not_flag_implementer_members() {
+    let root = fixture_path("interface-member-usage");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_members: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|member| format!("{}.{}", member.parent_name, member.member_name))
+        .collect();
+
+    assert!(
+        !unused_members.contains(&"FixedSizeScrollStrategy.attached".to_string()),
+        "attached should be credited through interface-typed access: {unused_members:?}"
+    );
+    assert!(
+        !unused_members.contains(&"FixedSizeScrollStrategy.attach".to_string()),
+        "attach should be credited through interface-typed access: {unused_members:?}"
+    );
+    assert!(
+        !unused_members.contains(&"FixedSizeScrollStrategy.detach".to_string()),
+        "detach should be credited through interface-typed access: {unused_members:?}"
+    );
+    assert!(
+        unused_members.contains(&"FixedSizeScrollStrategy.unusedHelper".to_string()),
+        "unrelated members should still be reported: {unused_members:?}"
+    );
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -7,7 +7,7 @@ use bitcode::{Decode, Encode};
 use crate::MemberKind;
 
 /// Cache version — bump when the cache format or cached extraction semantics change.
-pub(super) const CACHE_VERSION: u32 = 43;
+pub(super) const CACHE_VERSION: u32 = 44;
 
 /// Maximum cache file size to deserialize (256 MB).
 pub(super) const MAX_CACHE_SIZE: usize = 256 * 1024 * 1024;

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -4,7 +4,7 @@
 
 use oxc_ast::ast::{
     Argument, ArrayExpressionElement, BinaryExpression, Class, ClassElement, Expression,
-    ObjectPropertyKind, Statement, TSTypeName,
+    ObjectPropertyKind, Statement, TSType, TSTypeAnnotation, TSTypeName,
 };
 
 use crate::{MemberInfo, MemberKind};
@@ -368,6 +368,22 @@ pub fn extract_implemented_interface_names(class: &Class<'_>) -> Vec<String> {
         .iter()
         .filter_map(|item| extract_type_name(&item.expression))
         .collect()
+}
+
+/// Extract a simple referenced type name from a type annotation.
+#[must_use]
+pub fn extract_type_annotation_name(type_annotation: &TSTypeAnnotation<'_>) -> Option<String> {
+    extract_type_reference_name(&type_annotation.type_annotation)
+}
+
+/// Extract a simple referenced type name from a TypeScript type node.
+#[must_use]
+pub fn extract_type_reference_name(ty: &TSType<'_>) -> Option<String> {
+    match ty {
+        TSType::TSTypeReference(type_ref) => extract_type_name(&type_ref.type_name),
+        TSType::TSParenthesizedType(paren) => extract_type_reference_name(&paren.type_annotation),
+        _ => None,
+    }
 }
 
 fn extract_static_expression_name(expr: &Expression<'_>) -> Option<String> {

--- a/crates/extract/src/visitor/mod.rs
+++ b/crates/extract/src/visitor/mod.rs
@@ -45,10 +45,10 @@ pub(crate) struct ModuleInfoExtractor {
     /// (e.g., `import * as ns`, `const mod = require(...)`, `const mod = await import(...)`).
     /// Used to detect destructuring patterns like `const { a, b } = ns`.
     namespace_binding_names: Vec<String>,
-    /// Local names bound to `new ClassName()` expressions.
-    /// Maps local_name -> class_name so that `x.method()` member accesses
-    /// on an instance `const x = new Foo()` count against `Foo`'s members.
-    instance_binding_names: FxHashMap<String, String>,
+    /// Local bindings and `this.<field>` aliases resolved to a target symbol name.
+    /// Used so `x.method()` or `this.service.method()` can be mapped back to the
+    /// imported/exported class or interface that owns the member.
+    binding_target_names: FxHashMap<String, String>,
     /// Nesting depth inside `TSModuleDeclaration` (namespace) bodies.
     /// When > 0, inner `export` declarations are collected as namespace members
     /// instead of being extracted as top-level module exports.
@@ -132,23 +132,23 @@ impl ModuleInfoExtractor {
         }
     }
 
-    /// Map instance member accesses to class member accesses.
+    /// Map bound member accesses to their target symbol member accesses.
     ///
-    /// When `const x = new Foo()` and later `x.bar()`, emit an additional
-    /// `MemberAccess { object: "Foo", member: "bar" }` so the analysis layer
-    /// can track it as usage of Foo's class member. Same for whole-object uses.
-    fn resolve_instance_member_accesses(&mut self) {
-        if self.instance_binding_names.is_empty() {
+    /// When `const x = new Foo()` and later `x.bar()`, or `const x: Service`
+    /// and later `x.bar()`, emit an additional `MemberAccess` against the
+    /// resolved symbol name so the analysis layer can track the member usage.
+    fn resolve_bound_member_accesses(&mut self) {
+        if self.binding_target_names.is_empty() {
             return;
         }
         let additional_accesses: Vec<MemberAccess> = self
             .member_accesses
             .iter()
             .filter_map(|access| {
-                self.instance_binding_names
+                self.binding_target_names
                     .get(&access.object)
-                    .map(|class_name| MemberAccess {
-                        object: class_name.clone(),
+                    .map(|target_name| MemberAccess {
+                        object: target_name.clone(),
                         member: access.member.clone(),
                     })
             })
@@ -156,7 +156,7 @@ impl ModuleInfoExtractor {
         let additional_whole: Vec<String> = self
             .whole_object_uses
             .iter()
-            .filter_map(|name| self.instance_binding_names.get(name).cloned())
+            .filter_map(|name| self.binding_target_names.get(name).cloned())
             .collect();
         self.member_accesses.extend(additional_accesses);
         self.whole_object_uses.extend(additional_whole);
@@ -183,7 +183,7 @@ impl ModuleInfoExtractor {
         suppressions: Vec<Suppression>,
     ) -> ModuleInfo {
         self.enrich_local_class_exports();
-        self.resolve_instance_member_accesses();
+        self.resolve_bound_member_accesses();
         ModuleInfo {
             file_id,
             exports: self.exports,
@@ -208,7 +208,7 @@ impl ModuleInfoExtractor {
     /// Merge this extractor's fields into an existing `ModuleInfo`.
     pub(crate) fn merge_into(mut self, info: &mut ModuleInfo) {
         self.enrich_local_class_exports();
-        self.resolve_instance_member_accesses();
+        self.resolve_bound_member_accesses();
         info.imports.extend(self.imports);
         info.exports.extend(self.exports);
         info.re_exports.extend(self.re_exports);

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -695,6 +695,92 @@ fn this_field_chained_access_without_new_not_mapped() {
 }
 
 #[test]
+fn typed_variable_binding_maps_member_access() {
+    let info = parse(
+        r"
+            import { VirtualScrollStrategy } from './strategy';
+            const strategy: VirtualScrollStrategy = createStrategy();
+            strategy.attach();
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "VirtualScrollStrategy" && a.member == "attach"),
+        "typed variable binding should map strategy.attach() to VirtualScrollStrategy.attach, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_only_alias_binding_maps_member_access() {
+    let info = parse(
+        r"
+            import type { VirtualScrollStrategy as Strategy } from './strategy';
+            const strategy: Strategy = createStrategy();
+            strategy.attach();
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Strategy" && a.member == "attach"),
+        "type-only aliased binding should map strategy.attach() to Strategy.attach, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn this_field_assignment_from_typed_parameter_maps_member_access() {
+    let info = parse(
+        r"
+            import { VirtualScrollStrategy } from './strategy';
+            class ScrollViewport {
+                private strategy: VirtualScrollStrategy;
+
+                constructor(strategy: VirtualScrollStrategy) {
+                    this.strategy = strategy;
+                }
+
+                initialize() {
+                    this.strategy.attach();
+                }
+            }
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "VirtualScrollStrategy" && a.member == "attach"),
+        "typed field assignment should map this.strategy.attach() to VirtualScrollStrategy.attach, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn parameter_property_maps_this_field_member_access() {
+    let info = parse(
+        r"
+            import { VirtualScrollStrategy } from './strategy';
+            class ScrollViewport {
+                constructor(private strategy: VirtualScrollStrategy) {}
+
+                initialize() {
+                    this.strategy.attach();
+                }
+            }
+        ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "VirtualScrollStrategy" && a.member == "attach"),
+        "parameter property should map this.strategy.attach() to VirtualScrollStrategy.attach, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
 fn this_field_builtin_constructor_not_tracked() {
     let info = parse(
         r"

--- a/crates/extract/src/visitor/visit_impl.rs
+++ b/crates/extract/src/visitor/visit_impl.rs
@@ -19,8 +19,8 @@ use crate::html::is_remote_url;
 
 use super::helpers::{
     extract_angular_component_metadata, extract_class_members, extract_concat_parts,
-    extract_implemented_interface_names, extract_super_class_name, has_angular_class_decorator,
-    is_meta_url_arg, regex_pattern_to_suffix,
+    extract_implemented_interface_names, extract_super_class_name, extract_type_annotation_name,
+    has_angular_class_decorator, is_meta_url_arg, regex_pattern_to_suffix,
 };
 use super::{
     ModuleInfoExtractor, try_extract_arrow_wrapped_import, try_extract_dynamic_import,
@@ -28,6 +28,43 @@ use super::{
 };
 
 impl<'a> Visit<'a> for ModuleInfoExtractor {
+    fn visit_formal_parameter(&mut self, param: &FormalParameter<'a>) {
+        if let BindingPattern::BindingIdentifier(id) = &param.pattern
+            && let Some(type_annotation) = param.type_annotation.as_deref()
+            && let Some(type_name) = extract_type_annotation_name(type_annotation)
+        {
+            self.binding_target_names
+                .insert(id.name.to_string(), type_name.clone());
+            if param.accessibility.is_some() {
+                self.binding_target_names
+                    .insert(format!("this.{}", id.name), type_name);
+            }
+        }
+
+        walk::walk_formal_parameter(self, param);
+    }
+
+    fn visit_property_definition(&mut self, prop: &PropertyDefinition<'a>) {
+        if let Some(name) = prop.key.static_name() {
+            if let Some(type_annotation) = prop.type_annotation.as_deref()
+                && let Some(type_name) = extract_type_annotation_name(type_annotation)
+            {
+                self.binding_target_names
+                    .insert(format!("this.{name}"), type_name);
+            }
+
+            if let Some(Expression::NewExpression(new_expr)) = &prop.value
+                && let Expression::Identifier(callee) = &new_expr.callee
+                && !super::helpers::is_builtin_constructor(callee.name.as_str())
+            {
+                self.binding_target_names
+                    .insert(format!("this.{name}"), callee.name.to_string());
+            }
+        }
+
+        walk::walk_property_definition(self, prop);
+    }
+
     fn visit_block_statement(&mut self, stmt: &BlockStatement<'a>) {
         self.block_depth += 1;
         walk::walk_block_statement(self, stmt);
@@ -360,6 +397,14 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
 
     fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
         for declarator in &decl.declarations {
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(type_annotation) = declarator.type_annotation.as_deref()
+                && let Some(type_name) = extract_type_annotation_name(type_annotation)
+            {
+                self.binding_target_names
+                    .insert(id.name.to_string(), type_name);
+            }
+
             let Some(init) = &declarator.init else {
                 continue;
             };
@@ -378,7 +423,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 && let BindingPattern::BindingIdentifier(id) = &declarator.id
                 && !super::helpers::is_builtin_constructor(callee.name.as_str())
             {
-                self.instance_binding_names
+                self.binding_target_names
                     .insert(id.name.to_string(), callee.name.to_string());
                 // No `continue` — falls through to dynamic import detection (which
                 // won't match NewExpression) and then the loop continues.
@@ -394,7 +439,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                 && let Some(class_name) =
                     super::helpers::try_extract_factory_new_class(&call.arguments)
             {
-                self.instance_binding_names
+                self.binding_target_names
                     .insert(id.name.to_string(), class_name);
             }
 
@@ -633,18 +678,24 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
                     object: "this".to_string(),
                     member: member.property.name.to_string(),
                 });
-                // Track `this.field = new ClassName(...)` for chained member access
-                // resolution. Enables `this.field.method()` to count as usage of
-                // `ClassName.method`. Uses the `instance_binding_names` map with a
-                // synthetic `"this.field"` key (safe: dots are invalid in identifiers).
+                // Track `this.field = new ClassName(...)` and `this.field = local`
+                // for chained member access resolution. This lets
+                // `this.field.method()` count as usage of the resolved target
+                // symbol via the synthetic `"this.field"` binding key.
                 if let Expression::NewExpression(new_expr) = &expr.right
                     && let Expression::Identifier(callee) = &new_expr.callee
                     && !super::helpers::is_builtin_constructor(callee.name.as_str())
                 {
-                    self.instance_binding_names.insert(
+                    self.binding_target_names.insert(
                         format!("this.{}", member.property.name),
                         callee.name.to_string(),
                     );
+                } else if let Expression::Identifier(ident) = &expr.right
+                    && let Some(target_name) =
+                        self.binding_target_names.get(ident.name.as_str()).cloned()
+                {
+                    self.binding_target_names
+                        .insert(format!("this.{}", member.property.name), target_name);
                 }
             }
         }
@@ -668,7 +719,7 @@ impl<'a> Visit<'a> for ModuleInfoExtractor {
         }
         // Capture `this.field.member` patterns — chained access through a class field.
         // Recorded as `MemberAccess { object: "this.field", member }` which is later
-        // resolved via `instance_binding_names` when `this.field = new ClassName(...)`.
+        // resolved via `binding_target_names` when the field points at a known symbol.
         if let Expression::StaticMemberExpression(inner) = &expr.object
             && matches!(inner.object, Expression::ThisExpression(_))
         {

--- a/tests/fixtures/interface-member-usage/package.json
+++ b/tests/fixtures/interface-member-usage/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "interface-member-usage",
+  "main": "src/main.ts"
+}

--- a/tests/fixtures/interface-member-usage/src/fixed-size-strategy.ts
+++ b/tests/fixtures/interface-member-usage/src/fixed-size-strategy.ts
@@ -1,0 +1,13 @@
+import { VirtualScrollStrategy } from './scroll-strategy.interface';
+
+export class FixedSizeScrollStrategy implements VirtualScrollStrategy {
+  attached = true;
+
+  attach(_viewport: unknown): void {}
+
+  detach(): void {}
+
+  unusedHelper(): string {
+    return 'unused';
+  }
+}

--- a/tests/fixtures/interface-member-usage/src/main.ts
+++ b/tests/fixtures/interface-member-usage/src/main.ts
@@ -1,0 +1,8 @@
+import { FixedSizeScrollStrategy } from './fixed-size-strategy';
+import { ScrollViewport } from './scroll-viewport';
+
+const strategy = new FixedSizeScrollStrategy();
+const viewport = new ScrollViewport(strategy);
+
+viewport.initialize();
+viewport.destroy();

--- a/tests/fixtures/interface-member-usage/src/scroll-strategy.interface.ts
+++ b/tests/fixtures/interface-member-usage/src/scroll-strategy.interface.ts
@@ -1,0 +1,5 @@
+export interface VirtualScrollStrategy {
+  attached: boolean;
+  attach(viewport: unknown): void;
+  detach(): void;
+}

--- a/tests/fixtures/interface-member-usage/src/scroll-viewport.ts
+++ b/tests/fixtures/interface-member-usage/src/scroll-viewport.ts
@@ -1,0 +1,18 @@
+import { VirtualScrollStrategy } from './scroll-strategy.interface';
+
+export class ScrollViewport {
+  private strategy: VirtualScrollStrategy;
+
+  constructor(strategy: VirtualScrollStrategy) {
+    this.strategy = strategy;
+  }
+
+  initialize(): boolean {
+    this.strategy.attach(this);
+    return this.strategy.attached;
+  }
+
+  destroy(): void {
+    this.strategy.detach();
+  }
+}


### PR DESCRIPTION
What
- recover typed bindings in the extractor for locals, params, class fields, and parameter properties so member access can resolve beyond `new Foo()` shapes
- propagate member usage from interface exports to implementing classes using resolved export identity
- add regressions for #132, including `import type` aliases and same-named interface isolation

Why
- current main can flag implementer members as unused when calls go through interface-typed bindings
- that is a bad false positive for a dead-code tool because it makes live members look deletable

Validation
- `cargo +1.95 test -p fallow-extract -p fallow-core --lib --tests -- --nocapture`
- `cargo +1.95 clippy -p fallow-extract -p fallow-core --lib --tests -- -D warnings`
- `cargo +1.95 fmt --all -- --check`
- temp CLI repro for #132 now only reports `unusedHelper`
