### PR TITLE
feat: add MCP trace tools

### DIFF
--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -7,7 +7,7 @@ paths:
 
 MCP server exposing fallow analysis as tools for AI agents. Stdio transport, wraps `fallow` CLI via subprocess.
 
-## Tools (11 total)
+## Tools (15 total)
 - `analyze` - full dead code analysis (`fallow dead-code --format json`), supports `boundary_violations` convenience param
 - `check_changed` - incremental analysis (`fallow dead-code --changed-since`)
 - `find_dupes` - code duplication (`fallow dupes --format json`), supports `changed_since`
@@ -19,6 +19,10 @@ MCP server exposing fallow analysis as tools for AI agents. Stdio transport, wra
 - `project_info` - project metadata (`fallow list --format json`), supports section params (`entry_points`, `files`, `plugins`, `boundaries`)
 - `list_boundaries` - architecture boundary zones and rules (`fallow list --boundaries --format json`)
 - `feature_flags` - detect feature flag patterns (`fallow flags --format json`), supports `flag_type`, `confidence`, `dead_code_only` params
+- `trace_export` - trace why an export is used/unused (`fallow dead-code --trace FILE:EXPORT_NAME --format json`). Required `file` and `export_name` params. Returns file reachability, entry-point status, direct references, re-export chains, and a reason summary. Use before deleting a supposedly-unused export.
+- `trace_file` - trace all graph edges for a file (`fallow dead-code --trace-file PATH --format json`). Required `file` param. Returns reachability, entry-point status, exports, imports-from, imported-by, and re-exports. Use to decide whether a file is isolated, barrel-only, or imported by live entry points.
+- `trace_dependency` - trace where a dependency is imported (`fallow dead-code --trace-dependency PACKAGE --format json`). Required `package_name` param. Returns importing files, type-only importers, and total import count. Use before removing a dependency or moving between `dependencies` and `devDependencies`.
+- `trace_clone` - trace duplicate-code groups at a location (`fallow dupes --trace FILE:LINE --format json`). Required `file` and `line` params. Returns the matched clone instance plus every clone group containing it. Supports `mode`, `min_tokens`, `min_lines`, `threshold`, `skip_local`, `cross_language`, `ignore_imports`. Use to consolidate duplication when you need exact sibling locations.
 
 ## Global flags (available on all tools)
 - `no_cache` (bool) — disable incremental parse cache
@@ -42,7 +46,7 @@ All JSON output includes structured `actions` arrays on every finding:
 - Dupes groups: `extract-shared` + suppress
 - Audit: inherits actions from all three sub-analyses
 
-All params structs derive `Default` for ergonomic test construction except `CheckChangedParams` and `CheckProductionCoverageParams`, which each have one required non-default field (`since` and `coverage` respectively). Their test helpers (`check_changed("main")`, `check_production_coverage("./coverage")`) substitute for `Default::default()`.
+All params structs derive `Default` for ergonomic test construction except those with required non-default fields: `CheckChangedParams` (`since`), `CheckProductionCoverageParams` (`coverage`), `TraceExportParams` (`file`, `export_name`), `TraceFileParams` (`file`), `TraceDependencyParams` (`package_name`), and `TraceCloneParams` (`file`, `line`). Trace param tests build struct literals directly; the first two use the helpers `check_changed("main")` and `check_production_coverage("./coverage")`.
 
 Built with `rmcp` (official Rust MCP SDK). Thin subprocess wrapper — all analysis logic stays in the CLI.
 - `FALLOW_BIN` — binary path (defaults to sibling binary or `fallow` in PATH)

--- a/crates/mcp/src/params.rs
+++ b/crates/mcp/src/params.rs
@@ -263,6 +263,137 @@ pub struct ProjectInfoParams {
     pub threads: Option<usize>,
 }
 
+#[derive(Deserialize, JsonSchema)]
+pub struct TraceExportParams {
+    /// File containing the export to trace, relative to the project root.
+    #[schemars(length(min = 1))]
+    pub file: String,
+
+    /// Export name to trace (use "default" for default exports).
+    #[schemars(length(min = 1))]
+    pub export_name: String,
+
+    /// Root directory of the project. Defaults to current working directory.
+    pub root: Option<String>,
+
+    /// Path to fallow config file.
+    pub config: Option<String>,
+
+    /// Only analyze production code (excludes tests, stories, dev files).
+    pub production: Option<bool>,
+
+    /// Scope analysis to one or more workspaces. Accepts a single package name
+    /// for the common case, or a comma-separated list with globs and `!` negation.
+    pub workspace: Option<String>,
+
+    /// Disable the incremental parse cache. Forces a full re-parse of all files.
+    pub no_cache: Option<bool>,
+
+    /// Number of parser threads. Defaults to available CPU cores.
+    pub threads: Option<usize>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct TraceFileParams {
+    /// File to trace, relative to the project root.
+    #[schemars(length(min = 1))]
+    pub file: String,
+
+    /// Root directory of the project. Defaults to current working directory.
+    pub root: Option<String>,
+
+    /// Path to fallow config file.
+    pub config: Option<String>,
+
+    /// Only analyze production code (excludes tests, stories, dev files).
+    pub production: Option<bool>,
+
+    /// Scope analysis to one or more workspaces. Accepts a single package name
+    /// for the common case, or a comma-separated list with globs and `!` negation.
+    pub workspace: Option<String>,
+
+    /// Disable the incremental parse cache. Forces a full re-parse of all files.
+    pub no_cache: Option<bool>,
+
+    /// Number of parser threads. Defaults to available CPU cores.
+    pub threads: Option<usize>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct TraceDependencyParams {
+    /// Package name to trace (for example "react" or "@scope/pkg").
+    #[schemars(length(min = 1))]
+    pub package_name: String,
+
+    /// Root directory of the project. Defaults to current working directory.
+    pub root: Option<String>,
+
+    /// Path to fallow config file.
+    pub config: Option<String>,
+
+    /// Only analyze production code (excludes tests, stories, dev files).
+    pub production: Option<bool>,
+
+    /// Scope analysis to one or more workspaces. Accepts a single package name
+    /// for the common case, or a comma-separated list with globs and `!` negation.
+    pub workspace: Option<String>,
+
+    /// Disable the incremental parse cache. Forces a full re-parse of all files.
+    pub no_cache: Option<bool>,
+
+    /// Number of parser threads. Defaults to available CPU cores.
+    pub threads: Option<usize>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct TraceCloneParams {
+    /// File containing the clone candidate, relative to the project root.
+    #[schemars(length(min = 1))]
+    pub file: String,
+
+    /// 1-based line number inside the clone candidate.
+    #[schemars(range(min = 1))]
+    pub line: usize,
+
+    /// Root directory of the project. Defaults to current working directory.
+    pub root: Option<String>,
+
+    /// Path to fallow config file (.fallowrc.json or fallow.toml).
+    pub config: Option<String>,
+
+    /// Scope analysis to one or more workspaces. Accepts a single package name
+    /// for the common case, or a comma-separated list with globs and `!` negation.
+    pub workspace: Option<String>,
+
+    /// Detection mode: "strict" (exact tokens), "mild" (normalized identifiers),
+    /// "weak" (structural only), or "semantic" (type-aware). Defaults to "mild".
+    pub mode: Option<String>,
+
+    /// Minimum token count for a clone to be reported. Default: 50.
+    pub min_tokens: Option<u32>,
+
+    /// Minimum line count for a clone to be reported. Default: 5.
+    pub min_lines: Option<u32>,
+
+    /// Fail if duplication percentage exceeds this value. 0 = no limit.
+    pub threshold: Option<f64>,
+
+    /// Skip file-local duplicates, only report cross-file clones.
+    pub skip_local: Option<bool>,
+
+    /// Enable cross-language detection (strip TS type annotations for TS<->JS matching).
+    pub cross_language: Option<bool>,
+
+    /// Exclude import declarations from clone detection (reduces noise from sorted import blocks).
+    pub ignore_imports: Option<bool>,
+
+    /// Disable the incremental parse cache. Forces a full re-parse of all files.
+    pub no_cache: Option<bool>,
+
+    /// Number of parser threads. Defaults to available CPU cores.
+    pub threads: Option<usize>,
+}
+
 #[derive(Default, Deserialize, JsonSchema)]
 pub struct HealthParams {
     /// Root directory of the project to analyze. Defaults to current working directory.

--- a/crates/mcp/src/server/mod.rs
+++ b/crates/mcp/src/server/mod.rs
@@ -6,13 +6,14 @@ use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_router};
 use crate::params::{
     AnalyzeParams, AuditParams, CheckChangedParams, CheckProductionCoverageParams,
     FeatureFlagsParams, FindDupesParams, FixParams, HealthParams, ListBoundariesParams,
-    ProjectInfoParams,
+    ProjectInfoParams, TraceCloneParams, TraceDependencyParams, TraceExportParams, TraceFileParams,
 };
 use crate::tools::{
     build_analyze_args, build_audit_args, build_check_changed_args,
     build_check_production_coverage_args, build_feature_flags_args, build_find_dupes_args,
     build_fix_apply_args, build_fix_preview_args, build_health_args, build_list_boundaries_args,
-    build_project_info_args, run_fallow,
+    build_project_info_args, build_trace_clone_args, build_trace_dependency_args,
+    build_trace_export_args, build_trace_file_args, run_fallow,
 };
 
 #[cfg(test)]
@@ -137,7 +138,63 @@ impl FallowMcp {
     }
 
     #[tool(
-        description = "Check code health metrics (cyclomatic and cognitive complexity) for functions in the project. Returns structured JSON with complexity scores per function, sorted by severity. Set score=true for a single 0-100 health score with letter grade (A/B/C/D/F); forces full pipeline for accuracy. Set min_score=N to fail if score drops below a threshold (CI quality gate). Set file_scores=true for per-file maintainability index (fan-in, fan-out, dead code ratio, complexity density). Set coverage_gaps=true to explicitly include static test coverage gaps: runtime files and exports with no test dependency path (not line-level coverage). A provided config file may also enable coverage gaps via rules.coverage-gaps when no health sections are explicitly selected. Set hotspots=true to identify files that are both complex and frequently changing (combines git churn with complexity). Set ownership=true (implies hotspots) to attach per-file ownership signals: bus factor, contributor count, declared CODEOWNERS owner, drift, and unowned-hotspot flag. Use ownership_email_mode=raw|handle|hash for author email privacy (default handle). Set targets=true for ranked refactoring recommendations sorted by efficiency (quick wins first), with confidence scores and adaptive percentile-based thresholds. Set trend=true to compare current metrics against the most recent saved snapshot and show per-metric deltas with directional indicators (improving/declining/stable). Implies --score. Requires prior snapshots saved with save_snapshot. Set effort to control analysis depth: 'low' (fast, surface-level), 'medium' (balanced, default), or 'high' (thorough, all heuristics). Set summary=true to include a natural-language summary of findings alongside the structured JSON. Set coverage to a path to Istanbul-format coverage data (coverage-final.json from Jest, Vitest, c8, nyc) for accurate per-function CRAP scores instead of the default static binary model. Set production_coverage to a path (V8 coverage directory, V8 JSON file, or Istanbul JSON file) for merged runtime production-coverage findings (paid feature; requires an active license via `fallow license activate`). Set min_invocations_hot=N to tune the hot-path threshold used by production-coverage output (default 100), min_observation_volume=N to raise the high-confidence verdict floor (default 5000), and low_traffic_threshold=F to adjust the active/low_traffic split (default 0.001). All three take effect only when production_coverage is also set. Set group_by to \"owner\" (CODEOWNERS), \"directory\", \"package\" (workspace), or \"section\" (GitLab CODEOWNERS `[Section]` headers, with `owners` metadata per group) to partition results. Supports config, baseline comparisons, and performance tuning (no_cache, threads). Useful for identifying hard-to-maintain code and prioritizing refactoring.",
+        description = "Trace why an export is considered used or unused. Returns file reachability, entry-point status, direct references, re-export chains, and a concise reason string. Use this when an agent needs evidence before deleting or rewriting a supposedly unused export.",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn trace_export(
+        &self,
+        params: Parameters<TraceExportParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match build_trace_export_args(&params.0) {
+            Ok(args) => run_fallow(&self.binary, &args).await,
+            Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+        }
+    }
+
+    #[tool(
+        description = "Trace a file's graph context. Returns whether the file is reachable or an entry point, what it exports, what it imports, what imports it, and which re-exports it declares. Use this to understand whether a file is isolated, barrel-only, or imported by live entry points.",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn trace_file(
+        &self,
+        params: Parameters<TraceFileParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match build_trace_file_args(&params.0) {
+            Ok(args) => run_fallow(&self.binary, &args).await,
+            Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+        }
+    }
+
+    #[tool(
+        description = "Trace where a dependency is used. Returns which files import the package, which imports are type-only, and whether the dependency is used at all. Useful before removing a dependency or moving it between dependencies and devDependencies.",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn trace_dependency(
+        &self,
+        params: Parameters<TraceDependencyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match build_trace_dependency_args(&params.0) {
+            Ok(args) => run_fallow(&self.binary, &args).await,
+            Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+        }
+    }
+
+    #[tool(
+        description = "Trace duplicate-code groups containing a given file and line. Returns the matched clone instance plus every clone group that contains it. Useful when an agent wants to consolidate duplication but needs the exact sibling locations first.",
+        annotations(read_only_hint = true, open_world_hint = true)
+    )]
+    async fn trace_clone(
+        &self,
+        params: Parameters<TraceCloneParams>,
+    ) -> Result<CallToolResult, McpError> {
+        match build_trace_clone_args(&params.0) {
+            Ok(args) => run_fallow(&self.binary, &args).await,
+            Err(msg) => Ok(CallToolResult::error(vec![Content::text(msg)])),
+        }
+    }
+
+    #[tool(
+        description = "Check code health metrics (cyclomatic and cognitive complexity) for functions in the project. Returns structured JSON with complexity scores per function, sorted by severity. Set score=true for a single 0-100 health score with letter grade (A/B/C/D/F); forces full pipeline for accuracy. Set min_score=N to fail if score drops below a threshold (CI quality gate). Set file_scores=true for per-file maintainability index (fan-in, fan-out, dead code ratio, complexity density). Set coverage_gaps=true to explicitly include static test coverage gaps: runtime files and exports with no test dependency path (not line-level coverage). A provided config file may also enable coverage gaps via rules.coverage-gaps when no health sections are explicitly selected. Set hotspots=true to identify files that are both complex and frequently changing (combines git churn with complexity). Set ownership=true (implies hotspots) to attach per-file ownership signals: bus factor, contributor count, declared CODEOWNERS owner, drift, and unowned-hotspot flag. Use ownership_email_mode=raw|handle|hash for author email privacy (default handle). Set targets=true for ranked refactoring recommendations sorted by efficiency (quick wins first), with confidence scores and adaptive percentile-based thresholds. Set trend=true to compare current metrics against the most recent saved snapshot and show per-metric deltas with directional indicators (improving/declining/stable). Implies --score. Requires prior snapshots saved with save_snapshot. Set effort to control analysis depth: 'low' (fast, surface-level), 'medium' (balanced, default), or 'high' (thorough, all heuristics). Set summary=true to include a natural-language summary of findings alongside the structured JSON. Set coverage to a path to Istanbul-format coverage data (coverage-final.json from Jest, Vitest, c8, nyc) for accurate per-function CRAP scores instead of the default static binary model. Set production_coverage to a path (V8 coverage directory, V8 JSON file, or Istanbul JSON file) for merged runtime production-coverage findings (paid feature; requires an active license via `fallow license activate`). Set min_invocations_hot=N to tune the hot-path threshold used by production-coverage output (default 100). Set group_by to \"owner\" (CODEOWNERS), \"directory\", \"package\" (workspace), or \"section\" (GitLab CODEOWNERS `[Section]` headers, with `owners` metadata per group) to partition results. Supports config, baseline comparisons, and performance tuning (no_cache, threads). Useful for identifying hard-to-maintain code and prioritizing refactoring.",
         annotations(read_only_hint = true, open_world_hint = true)
     )]
     async fn check_health(
@@ -209,6 +266,7 @@ impl ServerHandler for FallowMcp {
                  Tools: analyze (full analysis), check_changed (incremental/PR analysis), \
                  find_dupes (code duplication), fix_preview/fix_apply (auto-fix), \
                  project_info (plugins, files, entry points, boundary zones), \
+                 trace_export / trace_file / trace_dependency / trace_clone (graph and clone evidence), \
                  check_health (code complexity metrics), \
                  check_production_coverage (paid; merges a V8 or Istanbul production coverage dump into the health report), \
                  audit (combined dead-code + complexity + duplication for changed files, returns verdict), \

--- a/crates/mcp/src/server/tests/args.rs
+++ b/crates/mcp/src/server/tests/args.rs
@@ -3,7 +3,8 @@ use crate::tools::{
     ISSUE_TYPE_FLAGS, VALID_DUPES_MODES, build_analyze_args, build_audit_args,
     build_check_changed_args, build_check_production_coverage_args, build_feature_flags_args,
     build_find_dupes_args, build_fix_apply_args, build_fix_preview_args, build_health_args,
-    build_list_boundaries_args, build_project_info_args,
+    build_list_boundaries_args, build_project_info_args, build_trace_clone_args,
+    build_trace_dependency_args, build_trace_export_args, build_trace_file_args,
 };
 
 fn check_production_coverage(coverage: &str) -> CheckProductionCoverageParams {
@@ -536,6 +537,243 @@ fn project_info_args_with_all_options() {
     );
 }
 
+// ── Argument building: trace tools ───────────────────────────────
+
+#[test]
+fn trace_export_args_minimal() {
+    let args = build_trace_export_args(&TraceExportParams {
+        file: "src/utils.ts".to_string(),
+        export_name: "usedFunction".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    assert_eq!(
+        args,
+        [
+            "dead-code",
+            "--format",
+            "json",
+            "--quiet",
+            "--trace",
+            "src/utils.ts:usedFunction",
+        ]
+    );
+}
+
+#[test]
+fn trace_file_args_with_scope() {
+    let args = build_trace_file_args(&TraceFileParams {
+        file: "src/utils.ts".to_string(),
+        root: Some("/repo".to_string()),
+        config: Some("fallow.toml".to_string()),
+        production: Some(true),
+        workspace: Some("packages/web".to_string()),
+        no_cache: Some(true),
+        threads: Some(3),
+    })
+    .unwrap();
+    assert_eq!(
+        args,
+        [
+            "dead-code",
+            "--format",
+            "json",
+            "--quiet",
+            "--root",
+            "/repo",
+            "--config",
+            "fallow.toml",
+            "--no-cache",
+            "--threads",
+            "3",
+            "--production",
+            "--workspace",
+            "packages/web",
+            "--trace-file",
+            "src/utils.ts",
+        ]
+    );
+}
+
+#[test]
+fn trace_dependency_args_minimal() {
+    let args = build_trace_dependency_args(&TraceDependencyParams {
+        package_name: "react".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    assert_eq!(
+        args,
+        [
+            "dead-code",
+            "--format",
+            "json",
+            "--quiet",
+            "--trace-dependency",
+            "react",
+        ]
+    );
+}
+
+#[test]
+fn trace_clone_args_with_all_options() {
+    let args = build_trace_clone_args(&TraceCloneParams {
+        file: "src/original.ts".to_string(),
+        line: 12,
+        root: Some("/repo".to_string()),
+        config: Some("fallow.toml".to_string()),
+        workspace: Some("packages/ui".to_string()),
+        mode: Some("semantic".to_string()),
+        min_tokens: Some(80),
+        min_lines: Some(7),
+        threshold: Some(3.5),
+        skip_local: Some(true),
+        cross_language: Some(true),
+        ignore_imports: Some(true),
+        no_cache: Some(true),
+        threads: Some(6),
+    })
+    .unwrap();
+    assert_eq!(
+        args,
+        [
+            "dupes",
+            "--format",
+            "json",
+            "--quiet",
+            "--root",
+            "/repo",
+            "--config",
+            "fallow.toml",
+            "--no-cache",
+            "--threads",
+            "6",
+            "--workspace",
+            "packages/ui",
+            "--mode",
+            "semantic",
+            "--min-tokens",
+            "80",
+            "--min-lines",
+            "7",
+            "--threshold",
+            "3.5",
+            "--skip-local",
+            "--cross-language",
+            "--ignore-imports",
+            "--trace",
+            "src/original.ts:12",
+        ]
+    );
+}
+
+#[test]
+fn trace_clone_args_invalid_mode_returns_error() {
+    let err = build_trace_clone_args(&TraceCloneParams {
+        file: "src/original.ts".to_string(),
+        line: 2,
+        root: None,
+        config: None,
+        workspace: None,
+        mode: Some("bogus".to_string()),
+        min_tokens: None,
+        min_lines: None,
+        threshold: None,
+        skip_local: None,
+        cross_language: None,
+        ignore_imports: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert!(err.contains("Invalid mode 'bogus'"));
+}
+
+#[test]
+fn trace_args_reject_blank_required_values() {
+    let export_err = build_trace_export_args(&TraceExportParams {
+        file: " ".to_string(),
+        export_name: "usedFunction".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert_eq!(export_err, "file must not be empty");
+
+    let export_name_err = build_trace_export_args(&TraceExportParams {
+        file: "src/utils.ts".to_string(),
+        export_name: String::new(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert_eq!(export_name_err, "export_name must not be empty");
+
+    let file_err = build_trace_file_args(&TraceFileParams {
+        file: "\t".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert_eq!(file_err, "file must not be empty");
+
+    let dependency_err = build_trace_dependency_args(&TraceDependencyParams {
+        package_name: String::new(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert_eq!(dependency_err, "package_name must not be empty");
+}
+
+#[test]
+fn trace_clone_args_reject_zero_line() {
+    let err = build_trace_clone_args(&TraceCloneParams {
+        file: "src/original.ts".to_string(),
+        line: 0,
+        root: None,
+        config: None,
+        workspace: None,
+        mode: None,
+        min_tokens: None,
+        min_lines: None,
+        threshold: None,
+        skip_local: None,
+        cross_language: None,
+        ignore_imports: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap_err();
+    assert_eq!(err, "line must be greater than 0");
+}
+
 // ── Argument building: health ─────────────────────────────────────
 
 #[test]
@@ -722,6 +960,54 @@ fn all_arg_builders_include_format_json_and_quiet() {
     let fix_preview = build_fix_preview_args(&FixParams::default());
     let fix_apply = build_fix_apply_args(&FixParams::default());
     let project_info = build_project_info_args(&ProjectInfoParams::default());
+    let trace_export = build_trace_export_args(&TraceExportParams {
+        file: "src/utils.ts".to_string(),
+        export_name: "usedFunction".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let trace_file = build_trace_file_args(&TraceFileParams {
+        file: "src/utils.ts".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let trace_dependency = build_trace_dependency_args(&TraceDependencyParams {
+        package_name: "react".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let trace_clone = build_trace_clone_args(&TraceCloneParams {
+        file: "src/original.ts".to_string(),
+        line: 2,
+        root: None,
+        config: None,
+        workspace: None,
+        mode: None,
+        min_tokens: None,
+        min_lines: None,
+        threshold: None,
+        skip_local: None,
+        cross_language: None,
+        ignore_imports: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
     let health = build_health_args(&HealthParams::default());
     let audit = build_audit_args(&AuditParams::default());
     let list_boundaries = build_list_boundaries_args(&ListBoundariesParams::default());
@@ -736,6 +1022,10 @@ fn all_arg_builders_include_format_json_and_quiet() {
         ("fix_preview", &fix_preview),
         ("fix_apply", &fix_apply),
         ("project_info", &project_info),
+        ("trace_export", &trace_export),
+        ("trace_file", &trace_file),
+        ("trace_dependency", &trace_dependency),
+        ("trace_clone", &trace_clone),
         ("health", &health),
         ("audit", &audit),
         ("list_boundaries", &list_boundaries),
@@ -781,6 +1071,66 @@ fn each_tool_uses_correct_subcommand() {
     assert_eq!(
         build_feature_flags_args(&FeatureFlagsParams::default())[0],
         "flags"
+    );
+    assert_eq!(
+        build_trace_export_args(&TraceExportParams {
+            file: "src/utils.ts".to_string(),
+            export_name: "usedFunction".to_string(),
+            root: None,
+            config: None,
+            production: None,
+            workspace: None,
+            no_cache: None,
+            threads: None,
+        })
+        .unwrap()[0],
+        "dead-code"
+    );
+    assert_eq!(
+        build_trace_file_args(&TraceFileParams {
+            file: "src/utils.ts".to_string(),
+            root: None,
+            config: None,
+            production: None,
+            workspace: None,
+            no_cache: None,
+            threads: None,
+        })
+        .unwrap()[0],
+        "dead-code"
+    );
+    assert_eq!(
+        build_trace_dependency_args(&TraceDependencyParams {
+            package_name: "react".to_string(),
+            root: None,
+            config: None,
+            production: None,
+            workspace: None,
+            no_cache: None,
+            threads: None,
+        })
+        .unwrap()[0],
+        "dead-code"
+    );
+    assert_eq!(
+        build_trace_clone_args(&TraceCloneParams {
+            file: "src/original.ts".to_string(),
+            line: 2,
+            root: None,
+            config: None,
+            workspace: None,
+            mode: None,
+            min_tokens: None,
+            min_lines: None,
+            threshold: None,
+            skip_local: None,
+            cross_language: None,
+            ignore_imports: None,
+            no_cache: None,
+            threads: None,
+        })
+        .unwrap()[0],
+        "dupes"
     );
     assert_eq!(
         build_check_production_coverage_args(&check_production_coverage("./coverage"))[0],
@@ -916,6 +1266,70 @@ fn project_info_does_not_include_explain() {
         !args.contains(&"--explain".to_string()),
         "project_info should not include --explain"
     );
+}
+
+#[test]
+fn trace_tools_do_not_include_explain() {
+    let export = build_trace_export_args(&TraceExportParams {
+        file: "src/utils.ts".to_string(),
+        export_name: "usedFunction".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let file = build_trace_file_args(&TraceFileParams {
+        file: "src/utils.ts".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let dep = build_trace_dependency_args(&TraceDependencyParams {
+        package_name: "react".to_string(),
+        root: None,
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let clone = build_trace_clone_args(&TraceCloneParams {
+        file: "src/original.ts".to_string(),
+        line: 2,
+        root: None,
+        config: None,
+        workspace: None,
+        mode: None,
+        min_tokens: None,
+        min_lines: None,
+        threshold: None,
+        skip_local: None,
+        cross_language: None,
+        ignore_imports: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+
+    for (name, args) in [
+        ("trace_export", export),
+        ("trace_file", file),
+        ("trace_dependency", dep),
+        ("trace_clone", clone),
+    ] {
+        assert!(
+            !args.contains(&"--explain".to_string()),
+            "{name} should not include --explain"
+        );
+    }
 }
 
 // ── Global flags: no_cache boolean false is omitted ───────────────

--- a/crates/mcp/src/server/tests/e2e.rs
+++ b/crates/mcp/src/server/tests/e2e.rs
@@ -8,7 +8,10 @@ use std::path::PathBuf;
 
 use rmcp::model::RawContent;
 
-use crate::tools::{build_analyze_args, build_health_args, build_project_info_args, run_fallow};
+use crate::tools::{
+    build_analyze_args, build_health_args, build_project_info_args, build_trace_clone_args,
+    build_trace_dependency_args, build_trace_export_args, build_trace_file_args, run_fallow,
+};
 
 /// Resolve the fallow binary from `FALLOW_BIN`, or the workspace target dir.
 fn fallow_binary() -> String {
@@ -129,6 +132,129 @@ async fn e2e_analyze_with_issue_type_filter() {
         exports.is_none() || exports.unwrap().is_empty(),
         "filtered output should not have unused_exports"
     );
+}
+
+// ── End-to-end: trace_export ─────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_trace_export_returns_json() {
+    let bin = fallow_binary();
+    let root = fixture_path("basic-project");
+    let args = build_trace_export_args(&crate::params::TraceExportParams {
+        file: "src/utils.ts".to_string(),
+        export_name: "usedFunction".to_string(),
+        root: Some(root.to_string_lossy().to_string()),
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let result = run_fallow(&bin, &args).await.unwrap();
+
+    assert_eq!(result.is_error, Some(false));
+
+    let text = extract_text(&result);
+    let json: serde_json::Value = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\ntext: {text}"));
+    assert_eq!(json["file"].as_str(), Some("src/utils.ts"));
+    assert_eq!(json["export_name"].as_str(), Some("usedFunction"));
+    assert_eq!(json["is_used"].as_bool(), Some(true));
+}
+
+// ── End-to-end: trace_file ───────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_trace_file_returns_json() {
+    let bin = fallow_binary();
+    let root = fixture_path("basic-project");
+    let args = build_trace_file_args(&crate::params::TraceFileParams {
+        file: "src/utils.ts".to_string(),
+        root: Some(root.to_string_lossy().to_string()),
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let result = run_fallow(&bin, &args).await.unwrap();
+
+    assert_eq!(result.is_error, Some(false));
+
+    let text = extract_text(&result);
+    let json: serde_json::Value = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\ntext: {text}"));
+    assert_eq!(json["file"].as_str(), Some("src/utils.ts"));
+    assert_eq!(json["is_reachable"].as_bool(), Some(true));
+    assert!(
+        json["exports"].is_array(),
+        "trace_file should include exports"
+    );
+}
+
+// ── End-to-end: trace_dependency ─────────────────────────────────
+
+#[tokio::test]
+async fn e2e_trace_dependency_returns_json() {
+    let bin = fallow_binary();
+    let root = fixture_path("basic-project");
+    let args = build_trace_dependency_args(&crate::params::TraceDependencyParams {
+        package_name: "react".to_string(),
+        root: Some(root.to_string_lossy().to_string()),
+        config: None,
+        production: None,
+        workspace: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let result = run_fallow(&bin, &args).await.unwrap();
+
+    assert_eq!(result.is_error, Some(false));
+
+    let text = extract_text(&result);
+    let json: serde_json::Value = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\ntext: {text}"));
+    assert_eq!(json["package_name"].as_str(), Some("react"));
+    assert!(json["imported_by"].is_array());
+}
+
+// ── End-to-end: trace_clone ──────────────────────────────────────
+
+#[tokio::test]
+async fn e2e_trace_clone_returns_json() {
+    let bin = fallow_binary();
+    let root = fixture_path("duplicate-code");
+    let args = build_trace_clone_args(&crate::params::TraceCloneParams {
+        file: "src/original.ts".to_string(),
+        line: 2,
+        root: Some(root.to_string_lossy().to_string()),
+        config: None,
+        workspace: None,
+        mode: None,
+        min_tokens: None,
+        min_lines: None,
+        threshold: None,
+        skip_local: None,
+        cross_language: None,
+        ignore_imports: None,
+        no_cache: None,
+        threads: None,
+    })
+    .unwrap();
+    let result = run_fallow(&bin, &args).await.unwrap();
+
+    assert_eq!(result.is_error, Some(false));
+
+    let text = extract_text(&result);
+    let json: serde_json::Value = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\ntext: {text}"));
+    assert_eq!(json["file"].as_str(), Some("src/original.ts"));
+    assert_eq!(json["line"].as_u64(), Some(2));
+    assert!(json["matched_instance"].is_object());
+    assert!(json["clone_groups"].is_array());
 }
 
 // ── End-to-end: health ───────────────────────────────────────────

--- a/crates/mcp/src/server/tests/params.rs
+++ b/crates/mcp/src/server/tests/params.rs
@@ -198,6 +198,65 @@ fn project_info_params_with_global_flags() {
 }
 
 #[test]
+fn trace_export_params_require_file_and_export_name() {
+    let json = "{}";
+    let result: Result<TraceExportParams, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+
+    let json = r#"{"file":"src/utils.ts","export_name":"usedFunction"}"#;
+    let params: TraceExportParams = serde_json::from_str(json).unwrap();
+    assert_eq!(params.file, "src/utils.ts");
+    assert_eq!(params.export_name, "usedFunction");
+    assert!(params.root.is_none());
+}
+
+#[test]
+fn trace_file_params_require_file() {
+    let json = "{}";
+    let result: Result<TraceFileParams, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+
+    let json = r#"{"file":"src/utils.ts","production":true,"workspace":"apps/web"}"#;
+    let params: TraceFileParams = serde_json::from_str(json).unwrap();
+    assert_eq!(params.file, "src/utils.ts");
+    assert_eq!(params.production, Some(true));
+    assert_eq!(params.workspace.as_deref(), Some("apps/web"));
+}
+
+#[test]
+fn trace_dependency_params_require_package_name() {
+    let json = "{}";
+    let result: Result<TraceDependencyParams, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+
+    let json = r#"{"package_name":"react","root":"/repo"}"#;
+    let params: TraceDependencyParams = serde_json::from_str(json).unwrap();
+    assert_eq!(params.package_name, "react");
+    assert_eq!(params.root.as_deref(), Some("/repo"));
+}
+
+#[test]
+fn trace_clone_params_require_file_and_line() {
+    let json = "{}";
+    let result: Result<TraceCloneParams, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+
+    let json = r#"{
+        "file": "src/original.ts",
+        "line": 2,
+        "mode": "semantic",
+        "min_tokens": 80,
+        "skip_local": true
+    }"#;
+    let params: TraceCloneParams = serde_json::from_str(json).unwrap();
+    assert_eq!(params.file, "src/original.ts");
+    assert_eq!(params.line, 2);
+    assert_eq!(params.mode.as_deref(), Some("semantic"));
+    assert_eq!(params.min_tokens, Some(80));
+    assert_eq!(params.skip_local, Some(true));
+}
+
+#[test]
 fn find_dupes_params_all_fields_deserialize() {
     let json = r#"{
         "root": "/project",

--- a/crates/mcp/src/server/tests/server_info.rs
+++ b/crates/mcp/src/server/tests/server_info.rs
@@ -23,12 +23,16 @@ fn all_tools_registered() {
     assert!(names.contains(&"fix_preview".to_string()));
     assert!(names.contains(&"fix_apply".to_string()));
     assert!(names.contains(&"project_info".to_string()));
+    assert!(names.contains(&"trace_export".to_string()));
+    assert!(names.contains(&"trace_file".to_string()));
+    assert!(names.contains(&"trace_dependency".to_string()));
+    assert!(names.contains(&"trace_clone".to_string()));
     assert!(names.contains(&"check_health".to_string()));
     assert!(names.contains(&"audit".to_string()));
     assert!(names.contains(&"list_boundaries".to_string()));
     assert!(names.contains(&"feature_flags".to_string()));
     assert!(names.contains(&"check_production_coverage".to_string()));
-    assert_eq!(tools.len(), 11);
+    assert_eq!(tools.len(), 15);
 }
 
 #[test]
@@ -41,6 +45,10 @@ fn read_only_tools_have_annotations() {
         "find_dupes",
         "fix_preview",
         "project_info",
+        "trace_export",
+        "trace_file",
+        "trace_dependency",
+        "trace_clone",
         "check_health",
         "audit",
         "list_boundaries",
@@ -103,6 +111,10 @@ fn open_world_hint_on_analysis_tools() {
         "find_dupes",
         "fix_preview",
         "project_info",
+        "trace_export",
+        "trace_file",
+        "trace_dependency",
+        "trace_clone",
         "check_health",
         "audit",
         "list_boundaries",
@@ -157,6 +169,10 @@ fn server_instructions_mention_all_tools() {
     assert!(instructions.contains("fix_preview"));
     assert!(instructions.contains("fix_apply"));
     assert!(instructions.contains("project_info"));
+    assert!(instructions.contains("trace_export"));
+    assert!(instructions.contains("trace_file"));
+    assert!(instructions.contains("trace_dependency"));
+    assert!(instructions.contains("trace_clone"));
     assert!(instructions.contains("check_health"));
     assert!(instructions.contains("audit"));
     assert!(instructions.contains("list_boundaries"));
@@ -342,6 +358,159 @@ fn project_info_schema_contains_expected_properties() {
         assert!(
             schema.contains(prop),
             "project_info schema should contain property '{prop}'"
+        );
+    }
+}
+
+#[test]
+fn trace_export_schema_contains_expected_properties() {
+    let server = FallowMcp::new();
+    let tools = server.tool_router.list_all();
+    let tool = tools.iter().find(|t| t.name == "trace_export").unwrap();
+    let schema = serde_json::to_string(&tool.input_schema).unwrap();
+    for prop in [
+        "file",
+        "export_name",
+        "root",
+        "config",
+        "production",
+        "workspace",
+        "no_cache",
+        "threads",
+    ] {
+        assert!(
+            schema.contains(prop),
+            "trace_export schema should contain property '{prop}'"
+        );
+    }
+    let schema: serde_json::Value = serde_json::to_value(&tool.input_schema).unwrap();
+    assert_required_fields(&schema, &["file", "export_name"]);
+    assert_eq!(
+        schema
+            .pointer("/properties/file/minLength")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+    assert_eq!(
+        schema
+            .pointer("/properties/export_name/minLength")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+}
+
+#[test]
+fn trace_file_schema_contains_expected_properties() {
+    let server = FallowMcp::new();
+    let tools = server.tool_router.list_all();
+    let tool = tools.iter().find(|t| t.name == "trace_file").unwrap();
+    let schema = serde_json::to_string(&tool.input_schema).unwrap();
+    for prop in [
+        "file",
+        "root",
+        "config",
+        "production",
+        "workspace",
+        "no_cache",
+        "threads",
+    ] {
+        assert!(
+            schema.contains(prop),
+            "trace_file schema should contain property '{prop}'"
+        );
+    }
+    let schema: serde_json::Value = serde_json::to_value(&tool.input_schema).unwrap();
+    assert_required_fields(&schema, &["file"]);
+    assert_eq!(
+        schema
+            .pointer("/properties/file/minLength")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+}
+
+#[test]
+fn trace_dependency_schema_contains_expected_properties() {
+    let server = FallowMcp::new();
+    let tools = server.tool_router.list_all();
+    let tool = tools.iter().find(|t| t.name == "trace_dependency").unwrap();
+    let schema = serde_json::to_string(&tool.input_schema).unwrap();
+    for prop in [
+        "package_name",
+        "root",
+        "config",
+        "production",
+        "workspace",
+        "no_cache",
+        "threads",
+    ] {
+        assert!(
+            schema.contains(prop),
+            "trace_dependency schema should contain property '{prop}'"
+        );
+    }
+    let schema: serde_json::Value = serde_json::to_value(&tool.input_schema).unwrap();
+    assert_required_fields(&schema, &["package_name"]);
+    assert_eq!(
+        schema
+            .pointer("/properties/package_name/minLength")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+}
+
+#[test]
+fn trace_clone_schema_contains_expected_properties() {
+    let server = FallowMcp::new();
+    let tools = server.tool_router.list_all();
+    let tool = tools.iter().find(|t| t.name == "trace_clone").unwrap();
+    let schema = serde_json::to_string(&tool.input_schema).unwrap();
+    for prop in [
+        "file",
+        "line",
+        "root",
+        "config",
+        "workspace",
+        "mode",
+        "min_tokens",
+        "min_lines",
+        "threshold",
+        "skip_local",
+        "cross_language",
+        "ignore_imports",
+        "no_cache",
+        "threads",
+    ] {
+        assert!(
+            schema.contains(prop),
+            "trace_clone schema should contain property '{prop}'"
+        );
+    }
+    let schema: serde_json::Value = serde_json::to_value(&tool.input_schema).unwrap();
+    assert_required_fields(&schema, &["file", "line"]);
+    assert_eq!(
+        schema
+            .pointer("/properties/file/minLength")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+    assert_eq!(
+        schema
+            .pointer("/properties/line/minimum")
+            .and_then(|v| v.as_u64()),
+        Some(1)
+    );
+}
+
+fn assert_required_fields(schema: &serde_json::Value, expected: &[&str]) {
+    let required = schema
+        .get("required")
+        .and_then(|v| v.as_array())
+        .expect("schema should have required fields");
+    for field in expected {
+        assert!(
+            required.iter().any(|v| v.as_str() == Some(field)),
+            "schema should require {field}, got {required:?}"
         );
     }
 }

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -8,6 +8,7 @@ mod flags;
 mod health;
 mod list_boundaries;
 mod project_info;
+mod trace;
 
 pub use analyze::build_analyze_args;
 pub use audit::build_audit_args;
@@ -19,6 +20,10 @@ pub use flags::build_feature_flags_args;
 pub use health::build_health_args;
 pub use list_boundaries::build_list_boundaries_args;
 pub use project_info::build_project_info_args;
+pub use trace::{
+    build_trace_clone_args, build_trace_dependency_args, build_trace_export_args,
+    build_trace_file_args,
+};
 
 use std::process::Stdio;
 use std::time::Duration;

--- a/crates/mcp/src/tools/trace.rs
+++ b/crates/mcp/src/tools/trace.rs
@@ -1,0 +1,144 @@
+use crate::params::{TraceCloneParams, TraceDependencyParams, TraceExportParams, TraceFileParams};
+
+use super::{VALID_DUPES_MODES, push_global, push_scope};
+
+/// Build CLI arguments for the `trace_export` tool.
+pub fn build_trace_export_args(params: &TraceExportParams) -> Result<Vec<String>, String> {
+    require_non_empty("file", &params.file)?;
+    require_non_empty("export_name", &params.export_name)?;
+
+    let mut args = vec![
+        "dead-code".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+
+    push_global(
+        &mut args,
+        params.root.as_deref(),
+        params.config.as_deref(),
+        params.no_cache,
+        params.threads,
+    );
+    push_scope(&mut args, params.production, params.workspace.as_deref());
+    args.extend([
+        "--trace".to_string(),
+        format!("{}:{}", params.file, params.export_name),
+    ]);
+    Ok(args)
+}
+
+/// Build CLI arguments for the `trace_file` tool.
+pub fn build_trace_file_args(params: &TraceFileParams) -> Result<Vec<String>, String> {
+    require_non_empty("file", &params.file)?;
+
+    let mut args = vec![
+        "dead-code".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+
+    push_global(
+        &mut args,
+        params.root.as_deref(),
+        params.config.as_deref(),
+        params.no_cache,
+        params.threads,
+    );
+    push_scope(&mut args, params.production, params.workspace.as_deref());
+    args.extend(["--trace-file".to_string(), params.file.clone()]);
+    Ok(args)
+}
+
+/// Build CLI arguments for the `trace_dependency` tool.
+pub fn build_trace_dependency_args(params: &TraceDependencyParams) -> Result<Vec<String>, String> {
+    require_non_empty("package_name", &params.package_name)?;
+
+    let mut args = vec![
+        "dead-code".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+
+    push_global(
+        &mut args,
+        params.root.as_deref(),
+        params.config.as_deref(),
+        params.no_cache,
+        params.threads,
+    );
+    push_scope(&mut args, params.production, params.workspace.as_deref());
+    args.extend([
+        "--trace-dependency".to_string(),
+        params.package_name.clone(),
+    ]);
+    Ok(args)
+}
+
+/// Build CLI arguments for the `trace_clone` tool.
+pub fn build_trace_clone_args(params: &TraceCloneParams) -> Result<Vec<String>, String> {
+    require_non_empty("file", &params.file)?;
+    if params.line == 0 {
+        return Err("line must be greater than 0".to_string());
+    }
+
+    let mut args = vec![
+        "dupes".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--quiet".to_string(),
+    ];
+
+    push_global(
+        &mut args,
+        params.root.as_deref(),
+        params.config.as_deref(),
+        params.no_cache,
+        params.threads,
+    );
+    if let Some(ref workspace) = params.workspace {
+        args.extend(["--workspace".to_string(), workspace.clone()]);
+    }
+    if let Some(ref mode) = params.mode {
+        if !VALID_DUPES_MODES.contains(&mode.as_str()) {
+            return Err(format!(
+                "Invalid mode '{mode}'. Valid values: strict, mild, weak, semantic"
+            ));
+        }
+        args.extend(["--mode".to_string(), mode.clone()]);
+    }
+    if let Some(min_tokens) = params.min_tokens {
+        args.extend(["--min-tokens".to_string(), min_tokens.to_string()]);
+    }
+    if let Some(min_lines) = params.min_lines {
+        args.extend(["--min-lines".to_string(), min_lines.to_string()]);
+    }
+    if let Some(threshold) = params.threshold {
+        args.extend(["--threshold".to_string(), threshold.to_string()]);
+    }
+    if params.skip_local == Some(true) {
+        args.push("--skip-local".to_string());
+    }
+    if params.cross_language == Some(true) {
+        args.push("--cross-language".to_string());
+    }
+    if params.ignore_imports == Some(true) {
+        args.push("--ignore-imports".to_string());
+    }
+    args.extend([
+        "--trace".to_string(),
+        format!("{}:{}", params.file, params.line),
+    ]);
+
+    Ok(args)
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(())
+}


### PR DESCRIPTION
What
- add MCP tools for tracing exports, files, dependencies, and duplicate-code groups
- reuse the existing CLI trace paths instead of adding a second analysis path
- validate required trace inputs at the MCP contract layer
- cover the new tools with arg-builder, schema, params, and e2e tests

Why
- agents can now ask for evidence before deleting exports, files, deps, or duplicated blocks
- this makes MCP output more useful for code review and cleanup workflows without bloating the analyzer core

Validation
- `cargo build -p fallow-cli -p fallow-mcp`
- `cargo test -p fallow-mcp`
- `cargo clippy -p fallow-mcp --tests -- -D warnings`
- `cargo fmt --all -- --check`
