### PR TITLE
fix(mcp): follow-ups from PR #176 review

### DIFF
--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -36,6 +36,7 @@ MCP server exposing fallow analysis as tools for AI agents. Stdio transport, wra
 - Subprocess timeout: 120s default, configurable via `FALLOW_TIMEOUT_SECS` env var
 - Exit code 2+ errors: pass through CLI's structured JSON error from stdout when available; fall back to `{"error":true,"message":"...","exit_code":N}` from stderr
 - Exit code 1: treated as success (issues found, not an error)
+- Pre-spawn validation rejections (empty required field, out-of-range line, invalid mode, unknown issue type) return the same envelope with `exit_code: 0` via `validation_error_body` in `tools/mod.rs`. Clients should branch on `error: true`, not on `exit_code`, since `0` can mean either "never spawned" (validation) or "spawned and succeeded" (normal result).
 
 ## Actions injection
 All JSON output includes structured `actions` arrays on every finding:

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -425,12 +425,16 @@ pub fn trace_clone(
 
         if let Some(matched) = matching {
             if matched_instance.is_none() {
-                matched_instance = Some(matched.clone());
+                matched_instance = Some(relativize_instance(matched, root));
             }
             clone_groups.push(TracedCloneGroup {
                 token_count: group.token_count,
                 line_count: group.line_count,
-                instances: group.instances.clone(),
+                instances: group
+                    .instances
+                    .iter()
+                    .map(|inst| relativize_instance(inst, root))
+                    .collect(),
             });
         }
     }
@@ -440,6 +444,20 @@ pub fn trace_clone(
         line,
         matched_instance,
         clone_groups,
+    }
+}
+
+/// Return a copy of `inst` with `file` rewritten relative to `root` (forward-slash normalized
+/// for cross-platform JSON parity with `serde_path::serialize`). If `inst.file` is already
+/// outside `root`, the path is left unchanged.
+fn relativize_instance(inst: &CloneInstance, root: &Path) -> CloneInstance {
+    let rel = inst.file.strip_prefix(root).map_or_else(
+        |_| inst.file.clone(),
+        |p| PathBuf::from(p.to_string_lossy().replace('\\', "/")),
+    );
+    CloneInstance {
+        file: rel,
+        ..inst.clone()
     }
 }
 
@@ -829,6 +847,70 @@ mod tests {
             trace_clone(&report, root, "src/a.ts", 21)
                 .matched_instance
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn trace_clone_returns_relative_instance_paths() {
+        use crate::duplicates::{CloneGroup, CloneInstance, DuplicationReport, DuplicationStats};
+        let report = DuplicationReport {
+            clone_groups: vec![CloneGroup {
+                instances: vec![
+                    CloneInstance {
+                        file: PathBuf::from("/project/src/a.ts"),
+                        start_line: 1,
+                        end_line: 10,
+                        start_col: 0,
+                        end_col: 0,
+                        fragment: "code".to_string(),
+                    },
+                    CloneInstance {
+                        file: PathBuf::from("/project/src/b.ts"),
+                        start_line: 1,
+                        end_line: 10,
+                        start_col: 0,
+                        end_col: 0,
+                        fragment: "code".to_string(),
+                    },
+                ],
+                token_count: 50,
+                line_count: 10,
+            }],
+            clone_families: vec![],
+            mirrored_directories: vec![],
+            stats: DuplicationStats {
+                total_files: 2,
+                files_with_clones: 2,
+                total_lines: 50,
+                duplicated_lines: 20,
+                total_tokens: 100,
+                duplicated_tokens: 100,
+                clone_groups: 1,
+                clone_instances: 2,
+                duplication_percentage: 40.0,
+            },
+        };
+        let trace = trace_clone(&report, Path::new("/project"), "src/a.ts", 5);
+        let matched = trace.matched_instance.as_ref().expect("match expected");
+        assert_eq!(matched.file, PathBuf::from("src/a.ts"));
+        for group in &trace.clone_groups {
+            for inst in &group.instances {
+                let as_str = inst.file.to_string_lossy();
+                assert!(
+                    !as_str.starts_with('/'),
+                    "instance file should be relative, got {as_str}",
+                );
+                assert!(
+                    !as_str.contains(":\\") && !as_str.contains(":/"),
+                    "instance file should not have a drive letter, got {as_str}",
+                );
+            }
+        }
+
+        let json = serde_json::to_string(&trace).expect("serializes");
+        assert!(
+            !json.contains("\"/project/"),
+            "serialized trace should not leak absolute paths: {json}",
         );
     }
 }

--- a/crates/mcp/src/server/tests/args.rs
+++ b/crates/mcp/src/server/tests/args.rs
@@ -7,6 +7,28 @@ use crate::tools::{
     build_trace_dependency_args, build_trace_export_args, build_trace_file_args,
 };
 
+/// Parse a validation error body into its `message` field. Arg builders emit
+/// structured JSON (`{"error": true, "message": "...", "exit_code": 0}`) so the
+/// handler can forward it verbatim to MCP clients; tests decode it here.
+fn parse_validation_message(err: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(err)
+        .unwrap_or_else(|e| panic!("validation error should be JSON, got `{err}`: {e}"));
+    assert_eq!(
+        v["error"].as_bool(),
+        Some(true),
+        "expected error=true in {err}"
+    );
+    assert_eq!(
+        v["exit_code"].as_i64(),
+        Some(0),
+        "expected exit_code=0 in {err}"
+    );
+    v["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("expected string message in {err}"))
+        .to_string()
+}
+
 fn check_production_coverage(coverage: &str) -> CheckProductionCoverageParams {
     CheckProductionCoverageParams {
         coverage: coverage.to_string(),
@@ -148,8 +170,9 @@ fn analyze_args_invalid_issue_type_returns_error() {
         ..Default::default()
     };
     let err = build_analyze_args(&params).unwrap_err();
-    assert!(err.contains("Unknown issue type 'nonexistent-type'"));
-    assert!(err.contains("unused-files"));
+    let msg = parse_validation_message(&err);
+    assert!(msg.contains("Unknown issue type 'nonexistent-type'"));
+    assert!(msg.contains("unused-files"));
 }
 
 #[test]
@@ -182,7 +205,8 @@ fn analyze_args_mixed_valid_and_invalid_issue_types_fails_on_first_invalid() {
         ..Default::default()
     };
     let err = build_analyze_args(&params).unwrap_err();
-    assert!(err.contains("'bogus'"));
+    let msg = parse_validation_message(&err);
+    assert!(msg.contains("'bogus'"));
 }
 
 #[test]
@@ -369,11 +393,12 @@ fn find_dupes_args_invalid_mode_returns_error() {
         ..Default::default()
     };
     let err = build_find_dupes_args(&params).unwrap_err();
-    assert!(err.contains("Invalid mode 'aggressive'"));
-    assert!(err.contains("strict"));
-    assert!(err.contains("mild"));
-    assert!(err.contains("weak"));
-    assert!(err.contains("semantic"));
+    let msg = parse_validation_message(&err);
+    assert!(msg.contains("Invalid mode 'aggressive'"));
+    assert!(msg.contains("strict"));
+    assert!(msg.contains("mild"));
+    assert!(msg.contains("weak"));
+    assert!(msg.contains("semantic"));
 }
 
 #[test]
@@ -696,7 +721,7 @@ fn trace_clone_args_invalid_mode_returns_error() {
         threads: None,
     })
     .unwrap_err();
-    assert!(err.contains("Invalid mode 'bogus'"));
+    assert!(parse_validation_message(&err).contains("Invalid mode 'bogus'"));
 }
 
 #[test]
@@ -712,7 +737,10 @@ fn trace_args_reject_blank_required_values() {
         threads: None,
     })
     .unwrap_err();
-    assert_eq!(export_err, "file must not be empty");
+    assert_eq!(
+        parse_validation_message(&export_err),
+        "file must not be empty"
+    );
 
     let export_name_err = build_trace_export_args(&TraceExportParams {
         file: "src/utils.ts".to_string(),
@@ -725,7 +753,10 @@ fn trace_args_reject_blank_required_values() {
         threads: None,
     })
     .unwrap_err();
-    assert_eq!(export_name_err, "export_name must not be empty");
+    assert_eq!(
+        parse_validation_message(&export_name_err),
+        "export_name must not be empty"
+    );
 
     let file_err = build_trace_file_args(&TraceFileParams {
         file: "\t".to_string(),
@@ -737,7 +768,10 @@ fn trace_args_reject_blank_required_values() {
         threads: None,
     })
     .unwrap_err();
-    assert_eq!(file_err, "file must not be empty");
+    assert_eq!(
+        parse_validation_message(&file_err),
+        "file must not be empty"
+    );
 
     let dependency_err = build_trace_dependency_args(&TraceDependencyParams {
         package_name: String::new(),
@@ -749,7 +783,10 @@ fn trace_args_reject_blank_required_values() {
         threads: None,
     })
     .unwrap_err();
-    assert_eq!(dependency_err, "package_name must not be empty");
+    assert_eq!(
+        parse_validation_message(&dependency_err),
+        "package_name must not be empty"
+    );
 }
 
 #[test]
@@ -771,7 +808,84 @@ fn trace_clone_args_reject_zero_line() {
         threads: None,
     })
     .unwrap_err();
-    assert_eq!(err, "line must be greater than 0");
+    assert_eq!(
+        parse_validation_message(&err),
+        "line must be greater than 0"
+    );
+}
+
+// ── Validation error body shape ──────────────────────────────────
+
+#[test]
+fn validation_errors_use_structured_json_body() {
+    // Every arg-builder validation failure must emit the same JSON shape that
+    // `run_fallow` uses for CLI error exits, so MCP clients can decode one shape
+    // for both error sources. `exit_code` is 0 on validation paths (no subprocess).
+    let errors = [
+        build_trace_clone_args(&TraceCloneParams {
+            file: "src/original.ts".to_string(),
+            line: 0,
+            root: None,
+            config: None,
+            workspace: None,
+            mode: None,
+            min_tokens: None,
+            min_lines: None,
+            threshold: None,
+            skip_local: None,
+            cross_language: None,
+            ignore_imports: None,
+            no_cache: None,
+            threads: None,
+        })
+        .unwrap_err(),
+        build_trace_export_args(&TraceExportParams {
+            file: String::new(),
+            export_name: "foo".to_string(),
+            root: None,
+            config: None,
+            production: None,
+            workspace: None,
+            no_cache: None,
+            threads: None,
+        })
+        .unwrap_err(),
+        build_find_dupes_args(&FindDupesParams {
+            mode: Some("nope".to_string()),
+            ..Default::default()
+        })
+        .unwrap_err(),
+        build_analyze_args(&AnalyzeParams {
+            issue_types: Some(vec!["bogus".to_string()]),
+            ..Default::default()
+        })
+        .unwrap_err(),
+    ];
+
+    for body in &errors {
+        let v: serde_json::Value = serde_json::from_str(body)
+            .unwrap_or_else(|e| panic!("body should be valid JSON: `{body}` ({e})"));
+        assert_eq!(
+            v.as_object().map(serde_json::Map::len),
+            Some(3),
+            "exactly 3 keys expected in {body}"
+        );
+        assert_eq!(
+            v["error"],
+            serde_json::Value::Bool(true),
+            "error=true in {body}"
+        );
+        assert_eq!(
+            v["exit_code"],
+            serde_json::Value::from(0),
+            "exit_code=0 in {body}"
+        );
+        assert!(v["message"].is_string(), "message is a string in {body}");
+        assert!(
+            !v["message"].as_str().unwrap().is_empty(),
+            "message is non-empty in {body}",
+        );
+    }
 }
 
 // ── Argument building: health ─────────────────────────────────────

--- a/crates/mcp/src/server/tests/e2e.rs
+++ b/crates/mcp/src/server/tests/e2e.rs
@@ -255,6 +255,25 @@ async fn e2e_trace_clone_returns_json() {
     assert_eq!(json["line"].as_u64(), Some(2));
     assert!(json["matched_instance"].is_object());
     assert!(json["clone_groups"].is_array());
+
+    let matched_file = json["matched_instance"]["file"]
+        .as_str()
+        .expect("matched_instance.file should be a string");
+    assert!(
+        !matched_file.starts_with('/')
+            && !matched_file.contains(":\\")
+            && !matched_file.contains(":/"),
+        "matched_instance.file should be relative, got {matched_file}",
+    );
+    for group in json["clone_groups"].as_array().expect("clone_groups array") {
+        for inst in group["instances"].as_array().expect("instances array") {
+            let file = inst["file"].as_str().expect("instance.file string");
+            assert!(
+                !file.starts_with('/') && !file.contains(":\\") && !file.contains(":/"),
+                "instance.file should be relative, got {file}",
+            );
+        }
+    }
 }
 
 // ── End-to-end: health ───────────────────────────────────────────

--- a/crates/mcp/src/tools/analyze.rs
+++ b/crates/mcp/src/tools/analyze.rs
@@ -1,6 +1,9 @@
 use crate::params::AnalyzeParams;
 
-use super::{ISSUE_TYPE_FLAGS, push_baseline, push_global, push_regression, push_scope};
+use super::{
+    ISSUE_TYPE_FLAGS, push_baseline, push_global, push_regression, push_scope,
+    validation_error_body,
+};
 
 /// Build CLI arguments for the `analyze` tool.
 /// Returns `Err(message)` if an invalid issue type is provided.
@@ -41,7 +44,9 @@ pub fn build_analyze_args(params: &AnalyzeParams) -> Result<Vec<String>, String>
                     .map(|&(n, _)| n)
                     .collect::<Vec<_>>()
                     .join(", ");
-                return Err(format!("Unknown issue type '{t}'. Valid values: {valid}"));
+                return Err(validation_error_body(format!(
+                    "Unknown issue type '{t}'. Valid values: {valid}"
+                )));
             }
         }
     }

--- a/crates/mcp/src/tools/dupes.rs
+++ b/crates/mcp/src/tools/dupes.rs
@@ -1,6 +1,6 @@
 use crate::params::FindDupesParams;
 
-use super::{VALID_DUPES_MODES, push_baseline, push_global};
+use super::{VALID_DUPES_MODES, push_baseline, push_global, validation_error_body};
 
 /// Build CLI arguments for the `find_dupes` tool.
 /// Returns `Err(message)` if an invalid mode is provided.
@@ -25,9 +25,9 @@ pub fn build_find_dupes_args(params: &FindDupesParams) -> Result<Vec<String>, St
     }
     if let Some(ref mode) = params.mode {
         if !VALID_DUPES_MODES.contains(&mode.as_str()) {
-            return Err(format!(
+            return Err(validation_error_body(format!(
                 "Invalid mode '{mode}'. Valid values: strict, mild, weak, semantic"
-            ));
+            )));
         }
         args.extend(["--mode".to_string(), mode.clone()]);
     }

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -118,6 +118,22 @@ pub const ISSUE_TYPE_FLAGS: &[(&str, &str)] = &[
 /// Valid detection modes for the `find_dupes` tool.
 pub const VALID_DUPES_MODES: &[&str] = &["strict", "mild", "weak", "semantic"];
 
+/// Build a structured validation error body matching the shape `run_fallow` emits
+/// for CLI-level errors: `{"error": true, "message": "...", "exit_code": 0}`.
+///
+/// Used by arg builders to reject invalid input before spawning fallow. `exit_code`
+/// is `0` because no subprocess ran, disambiguating validation failures from CLI
+/// error exits (which use the real exit code). The returned string is compact JSON
+/// ready to be wrapped in `CallToolResult::error(vec![Content::text(body)])`.
+pub fn validation_error_body(message: impl Into<String>) -> String {
+    serde_json::json!({
+        "error": true,
+        "message": message.into(),
+        "exit_code": 0,
+    })
+    .to_string()
+}
+
 /// Read the subprocess timeout from `FALLOW_TIMEOUT_SECS` or fall back to the default.
 fn timeout_duration() -> Duration {
     std::env::var("FALLOW_TIMEOUT_SECS")

--- a/crates/mcp/src/tools/trace.rs
+++ b/crates/mcp/src/tools/trace.rs
@@ -1,6 +1,6 @@
 use crate::params::{TraceCloneParams, TraceDependencyParams, TraceExportParams, TraceFileParams};
 
-use super::{VALID_DUPES_MODES, push_global, push_scope};
+use super::{VALID_DUPES_MODES, push_global, push_scope, validation_error_body};
 
 /// Build CLI arguments for the `trace_export` tool.
 pub fn build_trace_export_args(params: &TraceExportParams) -> Result<Vec<String>, String> {
@@ -82,7 +82,7 @@ pub fn build_trace_dependency_args(params: &TraceDependencyParams) -> Result<Vec
 pub fn build_trace_clone_args(params: &TraceCloneParams) -> Result<Vec<String>, String> {
     require_non_empty("file", &params.file)?;
     if params.line == 0 {
-        return Err("line must be greater than 0".to_string());
+        return Err(validation_error_body("line must be greater than 0"));
     }
 
     let mut args = vec![
@@ -104,9 +104,9 @@ pub fn build_trace_clone_args(params: &TraceCloneParams) -> Result<Vec<String>, 
     }
     if let Some(ref mode) = params.mode {
         if !VALID_DUPES_MODES.contains(&mode.as_str()) {
-            return Err(format!(
+            return Err(validation_error_body(format!(
                 "Invalid mode '{mode}'. Valid values: strict, mild, weak, semantic"
-            ));
+            )));
         }
         args.extend(["--mode".to_string(), mode.clone()]);
     }
@@ -138,7 +138,7 @@ pub fn build_trace_clone_args(params: &TraceCloneParams) -> Result<Vec<String>, 
 
 fn require_non_empty(field: &str, value: &str) -> Result<(), String> {
     if value.trim().is_empty() {
-        return Err(format!("{field} must not be empty"));
+        return Err(validation_error_body(format!("{field} must not be empty")));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Two follow-up fixes flagged during the post-merge review of #176, plus one tiny doc drift fix.

### fix(core): strip root from trace_clone instance paths (`0725ea15`)

`trace_clone` JSON output leaked absolute paths in `matched_instance.file` and `clone_groups[].instances[].file` while the top-level `file` was already relative. MCP consumers (AI agents, editor integrations) got machine-specific paths that don't round-trip. Human renderer already stripped the root; JSON didn't.

Post-process `CloneInstance` values inside `trace_clone` to strip the project root and forward-slash normalize for Windows parity. `CloneInstance` itself is unchanged so every other consumer (dupes report, cross-reference, auto-fix) keeps its absolute paths.

### refactor(mcp): normalize validation error bodies to structured JSON (`9bdc144e`)

MCP arg-builders returned bare validator strings while `run_fallow` wraps CLI error exits as structured JSON. Clients had to handle two shapes. Added `validation_error_body` helper in `tools/mod.rs` that returns the same envelope (`{error, message, exit_code}`), with `exit_code: 0` to mark pre-spawn rejections. All four validator surfaces converted: blank required field, `line == 0`, invalid mode (trace + dupes), unknown issue type.

### docs(mcp): document validation-error envelope (`ec93a176`)

Added a line to `.claude/rules/mcp-server.md` clarifying that clients should branch on `error: true`, not `exit_code`.

## Review

| Reviewer | Verdict |
|:---------|:--------|
| rust-reviewer | APPROVE |
| mcp-reviewer | APPROVE (after doc update) |

## Test plan

- [x] `cargo test --workspace` (38 binaries, 0 failures)
- [x] `cargo test -p fallow-mcp` (275 passed, +1 new `validation_errors_use_structured_json_body`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `typos .` clean
- [x] Real CLI probe on `tests/fixtures/duplicate-code`: `matched_instance.file` = `src/original.ts` (was absolute)
- [x] Regression test in `crates/core/src/trace.rs`: `trace_clone_returns_relative_instance_paths`
- [x] E2E test in `crates/mcp/src/server/tests/e2e.rs`: asserts every `instance.file` in the JSON is relative on both Unix (`/`) and Windows (`:\\`, `:/`) shapes