### PR TITLE
[codex] resolve fallow duplicate findings

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -8,6 +8,7 @@
   "duplicates": {
     "ignore": [
       "tests/benchmark-corpus/**",
+      "crates/napi/index.js",
       "crates/napi/index.d.ts",
       "crates/napi/types/index.d.ts"
     ]

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -4,5 +4,12 @@
     "tests/fixtures/**",
     "tests/conformance/fixtures/**",
     "editors/vscode/test/integration/fixtures/**"
-  ]
+  ],
+  "duplicates": {
+    "ignore": [
+      "tests/benchmark-corpus/**",
+      "crates/napi/index.d.ts",
+      "crates/napi/types/index.d.ts"
+    ]
+  }
 }

--- a/.skill-loop-progress.md
+++ b/.skill-loop-progress.md
@@ -4,7 +4,7 @@
 # Total Passes: 5
 # Started: 2026-04-28T00:00:00+01:00
 
-## Status: IN PROGRESS - Pass 4 of 5
+## Status: IN PROGRESS - Pass 5 of 5
 
 ## Missions
 1. Intentional/generated duplicate surfaces: exclude curated duplication benchmark corpus and generated N-API declaration copy from repo-level duplicate findings.
@@ -30,3 +30,9 @@
    tsconfig writing, TS import path calculation, and timing/log loop helpers.
    Verified `node --check` on touched scripts, `git diff --check`, and `fallow
    dupes` dropped to 8 groups / 304 duplicated lines with no generator clones.
+4. N-API wrapper helpers and residual local clones: extracted
+   `createEmptyResult()` in `benchmarks/compare.mjs` and added generated
+   `crates/napi/index.js` to duplicate-only ignores instead of hand-editing
+   NAPI-RS output. Verified `node --check benchmarks/compare.mjs`, `cargo test
+   -p fallow-config duplicates --lib`, and `fallow dupes` reported no code
+   duplication.

--- a/.skill-loop-progress.md
+++ b/.skill-loop-progress.md
@@ -4,7 +4,7 @@
 # Total Passes: 5
 # Started: 2026-04-28T00:00:00+01:00
 
-## Status: IN PROGRESS - Pass 5 of 5
+## Status: COMPLETE - Pass 5 of 5
 
 ## Missions
 1. Intentional/generated duplicate surfaces: exclude curated duplication benchmark corpus and generated N-API declaration copy from repo-level duplicate findings.
@@ -36,3 +36,9 @@
    NAPI-RS output. Verified `node --check benchmarks/compare.mjs`, `cargo test
    -p fallow-config duplicates --lib`, and `fallow dupes` reported no code
    duplication.
+5. Final rescan and stabilization: saved final duplicate-scan artifacts under
+   `refactor/artifacts/dupes-2026-04-28/`, verified `fallow dupes` reports no
+   code duplication, ran JS syntax checks for all touched benchmark scripts,
+   `cargo fmt --all -- --check`, `cargo test -p fallow-config duplicates
+   --lib`, `cargo test --workspace --all-targets`, and `cargo clippy
+   --workspace --all-targets -- -D warnings`.

--- a/.skill-loop-progress.md
+++ b/.skill-loop-progress.md
@@ -4,7 +4,7 @@
 # Total Passes: 5
 # Started: 2026-04-28T00:00:00+01:00
 
-## Status: IN PROGRESS - Pass 3 of 5
+## Status: IN PROGRESS - Pass 4 of 5
 
 ## Missions
 1. Intentional/generated duplicate surfaces: exclude curated duplication benchmark corpus and generated N-API declaration copy from repo-level duplicate findings.
@@ -24,3 +24,9 @@
    source counting, timing, stats, formatting, cache clearing, and fixture
    traversal helpers. Verified `node --check` on touched scripts and `fallow
    dupes` dropped to 14 groups / 443 duplicated lines.
+3. Benchmark fixture generator helpers: extracted generator-only setup into
+   `benchmarks/fixture-generator-helpers.mjs` and updated the three synthetic
+   fixture generators to reuse seeded RNG setup, project reset, manifest and
+   tsconfig writing, TS import path calculation, and timing/log loop helpers.
+   Verified `node --check` on touched scripts, `git diff --check`, and `fallow
+   dupes` dropped to 8 groups / 304 duplicated lines with no generator clones.

--- a/.skill-loop-progress.md
+++ b/.skill-loop-progress.md
@@ -1,0 +1,20 @@
+# Skill Loop Progress
+# Skill: simplify-and-refactor-code-isomorphically
+# Target: fallow dupes findings in /Users/london_server/fallow
+# Total Passes: 5
+# Started: 2026-04-28T00:00:00+01:00
+
+## Status: IN PROGRESS - Pass 2 of 5
+
+## Missions
+1. Intentional/generated duplicate surfaces: exclude curated duplication benchmark corpus and generated N-API declaration copy from repo-level duplicate findings.
+2. Benchmark runner helpers: extract shared behavior from benchmarks/bench.mjs, benchmarks/bench-dupes.mjs, and benchmarks/bench-circular.mjs without changing commands or output shape.
+3. Benchmark fixture generator helpers: extract shared fixture-generator setup and manifest writing from benchmarks/generate-*.mjs.
+4. N-API wrapper helpers and residual local clones: simplify repeated synchronous wrapper code in crates/napi/index.js and handle any remaining small benchmark clones.
+5. Final rescan and stabilization: rerun fallow dupes, address residual actionable clones, run local verification, and prepare the PR.
+
+## Completed Passes
+1. Intentional/generated duplicate surfaces: added repo-level `duplicates.ignore`
+   entries for `tests/benchmark-corpus/**`, `crates/napi/index.d.ts`, and
+   `crates/napi/types/index.d.ts`; verified `fallow dupes` no longer reports
+   those surfaces and that non-target clone groups are unchanged.

--- a/.skill-loop-progress.md
+++ b/.skill-loop-progress.md
@@ -4,7 +4,7 @@
 # Total Passes: 5
 # Started: 2026-04-28T00:00:00+01:00
 
-## Status: IN PROGRESS - Pass 2 of 5
+## Status: IN PROGRESS - Pass 3 of 5
 
 ## Missions
 1. Intentional/generated duplicate surfaces: exclude curated duplication benchmark corpus and generated N-API declaration copy from repo-level duplicate findings.
@@ -18,3 +18,9 @@
    entries for `tests/benchmark-corpus/**`, `crates/napi/index.d.ts`, and
    `crates/napi/types/index.d.ts`; verified `fallow dupes` no longer reports
    those surfaces and that non-target clone groups are unchanged.
+2. Benchmark runner helpers: extracted shared runner mechanics into
+   `benchmarks/benchmark-helpers.mjs` and updated the three benchmark runners
+   to reuse CLI parsing, release build, version lookup, environment output,
+   source counting, timing, stats, formatting, cache clearing, and fixture
+   traversal helpers. Verified `node --check` on touched scripts and `fallow
+   dupes` dropped to 14 groups / 443 duplicated lines.

--- a/benchmarks/bench-circular.mjs
+++ b/benchmarks/bench-circular.mjs
@@ -1,23 +1,25 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, statSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import os from 'node:os';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  benchmarkDir,
+  buildFallowRelease,
+  countSourceFiles,
+  fmt,
+  fmtMem,
+  getVersion,
+  parseBenchmarkArgs,
+  printEnvironment,
+  runProjectBenchmarks,
+  stats,
+  timeRunWithMemory,
+} from './benchmark-helpers.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, '..');
-const args = process.argv.slice(2);
-const hasFilter = args.includes('--synthetic') || args.includes('--real-world');
-const runSynthetic = args.includes('--synthetic') || !hasFilter;
-const runRealWorld = args.includes('--real-world') || !hasFilter;
-const RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');
-const WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');
+const __dirname = benchmarkDir;
+const { runSynthetic, runRealWorld, RUNS, WARMUP } = parseBenchmarkArgs();
+const RUN_TIMEOUT = 600000;
 
-console.log('Building fallow (release)...');
-const buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });
-if (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }
-const fallowBin = join(rootDir, 'target', 'release', 'fallow');
+const fallowBin = buildFallowRelease();
 
 // Detect available tools
 const madgeBin = join(__dirname, 'node_modules', '.bin', 'madge');
@@ -30,71 +32,18 @@ if (!hasMadge && !hasDpdm) {
   process.exit(1);
 }
 
-const fallowVersion = spawnSync(fallowBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
-const madgeVersion = hasMadge ? spawnSync(madgeBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim() : 'n/a';
-const dpdmVersion = hasDpdm ? spawnSync(dpdmBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim() : 'n/a';
-const rustVersion = spawnSync('rustc', ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
+const fallowVersion = getVersion(fallowBin);
+const madgeVersion = hasMadge ? getVersion(madgeBin) : 'n/a';
+const dpdmVersion = hasDpdm ? getVersion(dpdmBin) : 'n/a';
+const rustVersion = getVersion('rustc');
 
 console.log(`\n=== Fallow vs madge/dpdm — Circular Dependency Detection ===\n`);
-printEnvironment();
+printEnvironment(rustVersion);
 console.log(`Tools:`);
 console.log(`  fallow dead-code --circular-deps  ${fallowVersion}`);
 if (hasMadge) console.log(`  madge --circular              ${madgeVersion}`);
 if (hasDpdm) console.log(`  dpdm                          ${dpdmVersion}`);
 console.log(`Config: ${RUNS} runs, ${WARMUP} warmup\n`);
-
-function printEnvironment() {
-  const cpus = os.cpus();
-  console.log('Environment:');
-  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);
-  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);
-  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);
-  console.log(`  Node:    ${process.version}`);
-  console.log(`  Rust:    ${rustVersion}`);
-  console.log('');
-}
-
-function countSourceFiles(dir) {
-  let count = 0;
-  const walk = d => {
-    try {
-      for (const e of readdirSync(d)) {
-        if (['node_modules', '.git', 'dist', 'report'].includes(e)) continue;
-        const f = join(d, e);
-        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}
-      }
-    } catch {}
-  };
-  walk(dir); return count;
-}
-
-function timeRunWithMemory(cmd, cmdArgs, cwd) {
-  const isLinux = process.platform === 'linux';
-  const timeBin = '/usr/bin/time';
-  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];
-
-  const start = performance.now();
-  const result = spawnSync(timeBin, timeArgs, {
-    cwd,
-    stdio: 'pipe',
-    timeout: 600000,
-    maxBuffer: 50 * 1024 * 1024,
-    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
-  });
-  const elapsed = performance.now() - start;
-  const stderr = result.stderr?.toString() ?? '';
-
-  let peakRssBytes = 0;
-  if (isLinux) {
-    const match = stderr.match(/Maximum resident set size \(kbytes\): (\d+)/);
-    if (match) peakRssBytes = parseInt(match[1]) * 1024;
-  } else {
-    const match = stderr.match(/(\d+)\s+maximum resident set size/);
-    if (match) peakRssBytes = parseInt(match[1]);
-  }
-
-  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };
-}
 
 function parseFallowCycles(stdout) {
   try {
@@ -117,23 +66,8 @@ function parseDpdmCycles(stdout) {
   } catch { return '?'; }
 }
 
-function stats(times) {
-  const sorted = [...times].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-  return {
-    min: sorted[0],
-    max: sorted.at(-1),
-    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,
-    median,
-  };
-}
-
-function fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }
-function fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }
-
 function benchmarkProject(name, dir) {
-  const files = countSourceFiles(dir);
+  const files = countSourceFiles(dir, ['node_modules', '.git', 'dist', 'report']);
   const hasTsConfig = existsSync(join(dir, 'tsconfig.json'));
   console.log(`### ${name} (${files} source files)\n`);
 
@@ -153,10 +87,10 @@ function benchmarkProject(name, dir) {
 
   // Warmup
   for (let i = 0; i < WARMUP; i++) {
-    timeRunWithMemory(fallowBin, fallowArgs, dir);
-    if (hasMadge) timeRunWithMemory(madgeBin, madgeArgs, dir);
+    timeRunWithMemory(fallowBin, fallowArgs, dir, RUN_TIMEOUT);
+    if (hasMadge) timeRunWithMemory(madgeBin, madgeArgs, dir, RUN_TIMEOUT);
     if (hasDpdm) {
-      timeRunWithMemory(dpdmBin, dpdmArgs, dir);
+      timeRunWithMemory(dpdmBin, dpdmArgs, dir, RUN_TIMEOUT);
       if (existsSync(dpdmOutputFile)) rmSync(dpdmOutputFile);
     }
   }
@@ -168,20 +102,20 @@ function benchmarkProject(name, dir) {
 
   for (let i = 0; i < RUNS; i++) {
     // fallow
-    const fr = timeRunWithMemory(fallowBin, fallowArgs, dir);
+    const fr = timeRunWithMemory(fallowBin, fallowArgs, dir, RUN_TIMEOUT);
     fallowTimes.push(fr.elapsed);
     if (i === 0) { fallowCycles = parseFallowCycles(fr.stdout); fallowRss = fr.peakRssBytes; }
 
     // madge
     if (hasMadge) {
-      const mr = timeRunWithMemory(madgeBin, madgeArgs, dir);
+      const mr = timeRunWithMemory(madgeBin, madgeArgs, dir, RUN_TIMEOUT);
       madgeTimes.push(mr.elapsed);
       if (i === 0) { madgeCycles = parseMadgeCycles(mr.stdout); madgeRss = mr.peakRssBytes; }
     }
 
     // dpdm
     if (hasDpdm) {
-      const dr = timeRunWithMemory(dpdmBin, dpdmArgs, dir);
+      const dr = timeRunWithMemory(dpdmBin, dpdmArgs, dir, RUN_TIMEOUT);
       dpdmTimes.push(dr.elapsed);
       if (i === 0) {
         try {
@@ -231,28 +165,24 @@ function benchmarkProject(name, dir) {
 
 const results = [];
 
-if (runSynthetic) {
-  const d = join(__dirname, 'fixtures', 'synthetic-circular');
-  if (!existsSync(d)) {
-    console.log('No synthetic circular fixtures. Run: npm run generate:circular\n');
-  } else {
-    console.log('--- Synthetic Projects (Circular Dependencies) ---\n');
-    const order = ['tiny', 'small', 'medium', 'large', 'xlarge'];
-    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort((a, b) => order.indexOf(a) - order.indexOf(b)))
-      results.push(benchmarkProject(p, join(d, p)));
-  }
-}
+runProjectBenchmarks({
+  enabled: runSynthetic,
+  dir: join(__dirname, 'fixtures', 'synthetic-circular'),
+  missingMessage: 'No synthetic circular fixtures. Run: npm run generate:circular\n',
+  heading: '--- Synthetic Projects (Circular Dependencies) ---\n',
+  results,
+  benchmarkProject,
+  order: ['tiny', 'small', 'medium', 'large', 'xlarge'],
+});
 
-if (runRealWorld) {
-  const d = join(__dirname, 'fixtures', 'real-world');
-  if (!existsSync(d)) {
-    console.log('No real-world fixtures. Run: npm run download-fixtures\n');
-  } else {
-    console.log('--- Real-World Projects (Circular Dependencies) ---\n');
-    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())
-      results.push(benchmarkProject(p, join(d, p)));
-  }
-}
+runProjectBenchmarks({
+  enabled: runRealWorld,
+  dir: join(__dirname, 'fixtures', 'real-world'),
+  missingMessage: 'No real-world fixtures. Run: npm run download-fixtures\n',
+  heading: '--- Real-World Projects (Circular Dependencies) ---\n',
+  results,
+  benchmarkProject,
+});
 
 if (results.length > 0) {
   console.log('\n=== Summary ===\n');

--- a/benchmarks/bench-dupes.mjs
+++ b/benchmarks/bench-dupes.mjs
@@ -1,103 +1,36 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, statSync, readFileSync, rmSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import os from 'node:os';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  benchmarkDir,
+  buildFallowRelease,
+  countSourceFiles,
+  fmt,
+  fmtMem,
+  getVersion,
+  parseBenchmarkArgs,
+  printEnvironment,
+  runProjectBenchmarks,
+  stats,
+  timeRun,
+  timeRunWithMemory,
+} from './benchmark-helpers.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, '..');
-const args = process.argv.slice(2);
-const hasFilter = args.includes('--synthetic') || args.includes('--real-world');
-const runSynthetic = args.includes('--synthetic') || !hasFilter;
-const runRealWorld = args.includes('--real-world') || !hasFilter;
-const RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');
-const WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');
+const __dirname = benchmarkDir;
+const { runSynthetic, runRealWorld, RUNS, WARMUP } = parseBenchmarkArgs();
+const RUN_TIMEOUT = 600000;
 
-console.log('Building fallow (release)...');
-const buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });
-if (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }
-const fallowBin = join(rootDir, 'target', 'release', 'fallow');
+const fallowBin = buildFallowRelease();
 const jscpdBin = join(__dirname, 'node_modules', '.bin', 'jscpd');
 if (!existsSync(jscpdBin)) { console.error('jscpd not found. Run: cd benchmarks && npm install'); process.exit(1); }
 
-const fallowVersion = spawnSync(fallowBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
-const jscpdVersion = spawnSync(jscpdBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
-const rustVersion = spawnSync('rustc', ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
+const fallowVersion = getVersion(fallowBin);
+const jscpdVersion = getVersion(jscpdBin);
+const rustVersion = getVersion('rustc');
 
 console.log(`\n=== Fallow Dupes vs jscpd Benchmark Suite ===\n`);
-printEnvironment();
+printEnvironment(rustVersion);
 console.log(`Tools:\n  fallow dupes  ${fallowVersion}\n  jscpd         ${jscpdVersion}\nConfig: ${RUNS} runs, ${WARMUP} warmup\n`);
-
-function printEnvironment() {
-  const cpus = os.cpus();
-  console.log('Environment:');
-  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);
-  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);
-  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);
-  console.log(`  Node:    ${process.version}`);
-  console.log(`  Rust:    ${rustVersion}`);
-  console.log('');
-}
-
-function countSourceFiles(dir) {
-  let count = 0;
-  const walk = d => {
-    try {
-      for (const e of readdirSync(d)) {
-        if (['node_modules', '.git', 'dist', 'report'].includes(e)) continue;
-        const f = join(d, e);
-        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}
-      }
-    } catch {}
-  };
-  walk(dir); return count;
-}
-
-function timeRun(cmd, cmdArgs, cwd) {
-  const start = performance.now();
-  const result = spawnSync(cmd, cmdArgs, {
-    cwd,
-    stdio: 'pipe',
-    timeout: 600000,
-    maxBuffer: 50 * 1024 * 1024,
-    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
-  });
-  return {
-    elapsed: performance.now() - start,
-    status: result.status,
-    stdout: result.stdout?.toString() ?? '',
-    stderr: result.stderr?.toString() ?? '',
-  };
-}
-
-function timeRunWithMemory(cmd, cmdArgs, cwd) {
-  const isLinux = process.platform === 'linux';
-  const timeBin = '/usr/bin/time';
-  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];
-
-  const start = performance.now();
-  const result = spawnSync(timeBin, timeArgs, {
-    cwd,
-    stdio: 'pipe',
-    timeout: 600000,
-    maxBuffer: 50 * 1024 * 1024,
-    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
-  });
-  const elapsed = performance.now() - start;
-  const stderr = result.stderr?.toString() ?? '';
-
-  let peakRssBytes = 0;
-  if (isLinux) {
-    const match = stderr.match(/Maximum resident set size \(kbytes\): (\d+)/);
-    if (match) peakRssBytes = parseInt(match[1]) * 1024;
-  } else {
-    const match = stderr.match(/(\d+)\s+maximum resident set size/);
-    if (match) peakRssBytes = parseInt(match[1]);
-  }
-
-  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };
-}
 
 function parseFallowCloneCount(stdout) {
   try {
@@ -124,23 +57,8 @@ function parseJscpdCloneCount(reportDir) {
   } catch { return { groups: '?', instances: '?', pct: '?' }; }
 }
 
-function stats(times) {
-  const sorted = [...times].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-  return {
-    min: sorted[0],
-    max: sorted.at(-1),
-    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,
-    median,
-  };
-}
-
-function fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }
-function fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }
-
 function benchmarkProject(name, dir) {
-  const files = countSourceFiles(dir);
+  const files = countSourceFiles(dir, ['node_modules', '.git', 'dist', 'report']);
   console.log(`### ${name} (${files} source files)\n`);
 
   // fallow dupes: JSON output, no cache (cold)
@@ -161,9 +79,9 @@ function benchmarkProject(name, dir) {
 
   // Warmup
   for (let i = 0; i < WARMUP; i++) {
-    timeRun(fallowBin, fArgsCold, dir);
+    timeRun(fallowBin, fArgsCold, dir, RUN_TIMEOUT);
     if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });
-    timeRun(jscpdBin, jArgs, dir);
+    timeRun(jscpdBin, jArgs, dir, RUN_TIMEOUT);
     if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });
   }
 
@@ -174,12 +92,12 @@ function benchmarkProject(name, dir) {
   let fPeakRss = 0, jPeakRss = 0;
 
   for (let i = 0; i < RUNS; i++) {
-    const fr = timeRunWithMemory(fallowBin, fArgsCold, dir);
+    const fr = timeRunWithMemory(fallowBin, fArgsCold, dir, RUN_TIMEOUT);
     fTimesCold.push(fr.elapsed);
     if (i === 0) { fClones = parseFallowCloneCount(fr.stdout); fPeakRss = fr.peakRssBytes; }
 
     if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });
-    const jr = timeRunWithMemory(jscpdBin, jArgs, dir);
+    const jr = timeRunWithMemory(jscpdBin, jArgs, dir, RUN_TIMEOUT);
     jTimes.push(jr.elapsed);
     if (i === 0) { jClones = parseJscpdCloneCount(jscpdReportDir); jPeakRss = jr.peakRssBytes; }
     if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });
@@ -200,28 +118,24 @@ function benchmarkProject(name, dir) {
 
 const results = [];
 
-if (runSynthetic) {
-  const d = join(__dirname, 'fixtures', 'synthetic-dupes');
-  if (!existsSync(d)) {
-    console.log('No synthetic dupes fixtures. Run: npm run generate:dupes\n');
-  } else {
-    console.log('--- Synthetic Projects (Duplication) ---\n');
-    const order = ['tiny', 'small', 'medium', 'large', 'xlarge'];
-    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort((a, b) => order.indexOf(a) - order.indexOf(b)))
-      results.push(benchmarkProject(p, join(d, p)));
-  }
-}
+runProjectBenchmarks({
+  enabled: runSynthetic,
+  dir: join(__dirname, 'fixtures', 'synthetic-dupes'),
+  missingMessage: 'No synthetic dupes fixtures. Run: npm run generate:dupes\n',
+  heading: '--- Synthetic Projects (Duplication) ---\n',
+  results,
+  benchmarkProject,
+  order: ['tiny', 'small', 'medium', 'large', 'xlarge'],
+});
 
-if (runRealWorld) {
-  const d = join(__dirname, 'fixtures', 'real-world');
-  if (!existsSync(d)) {
-    console.log('No real-world fixtures. Run: npm run download-fixtures\n');
-  } else {
-    console.log('--- Real-World Projects (Duplication) ---\n');
-    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())
-      results.push(benchmarkProject(p, join(d, p)));
-  }
-}
+runProjectBenchmarks({
+  enabled: runRealWorld,
+  dir: join(__dirname, 'fixtures', 'real-world'),
+  missingMessage: 'No real-world fixtures. Run: npm run download-fixtures\n',
+  heading: '--- Real-World Projects (Duplication) ---\n',
+  results,
+  benchmarkProject,
+});
 
 if (results.length > 0) {
   console.log('\n=== Summary ===\n');

--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -1,92 +1,40 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, statSync, rmSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import os from 'node:os';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  benchmarkDir,
+  buildFallowRelease,
+  clearFallowCache,
+  countSourceFiles,
+  fmt,
+  fmtMem,
+  getVersion,
+  parseBenchmarkArgs,
+  printEnvironment,
+  runProjectBenchmarks,
+  stats,
+  timeRun,
+  timeRunWithMemory,
+} from './benchmark-helpers.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = resolve(__dirname, '..');
-const args = process.argv.slice(2);
-const hasFilter = args.includes('--synthetic') || args.includes('--real-world');
-const runSynthetic = args.includes('--synthetic') || !hasFilter;
-const runRealWorld = args.includes('--real-world') || !hasFilter;
-const RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');
-const WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');
+const __dirname = benchmarkDir;
+const { runSynthetic, runRealWorld, RUNS, WARMUP } = parseBenchmarkArgs();
 
-console.log('Building fallow (release)...');
-const buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });
-if (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }
-const fallowBin = join(rootDir, 'target', 'release', 'fallow');
+const fallowBin = buildFallowRelease();
 const knipBin = join(__dirname, 'node_modules', '.bin', 'knip');
 const knip6Bin = join(__dirname, 'knip6', 'node_modules', '.bin', 'knip');
 if (!existsSync(knipBin)) { console.error('knip v5 not found. Run: cd benchmarks && npm install'); process.exit(1); }
 const hasKnip6 = existsSync(knip6Bin);
 if (!hasKnip6) { console.warn('knip v6 not found. Run: cd benchmarks/knip6 && npm install knip@6'); }
 
-const fallowVersion = spawnSync(fallowBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
-const knipVersion = spawnSync(knipBin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
-const knip6Version = hasKnip6 ? spawnSync(knip6Bin, ['--version'], { stdio: 'pipe' }).stdout?.toString().trim() : null;
-const rustVersion = spawnSync('rustc', ['--version'], { stdio: 'pipe' }).stdout?.toString().trim();
+const fallowVersion = getVersion(fallowBin);
+const knipVersion = getVersion(knipBin);
+const knip6Version = hasKnip6 ? getVersion(knip6Bin) : null;
+const rustVersion = getVersion('rustc');
 
 console.log(`\n=== Fallow vs Knip Benchmark Suite ===\n`);
-printEnvironment();
+printEnvironment(rustVersion);
 console.log(`Tools:\n  fallow   ${fallowVersion}\n  knip v5  ${knipVersion}${knip6Version ? `\n  knip v6  ${knip6Version}` : ''}\nConfig: ${RUNS} runs, ${WARMUP} warmup\n`);
-
-function printEnvironment() {
-  const cpus = os.cpus();
-  console.log('Environment:');
-  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);
-  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);
-  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);
-  console.log(`  Node:    ${process.version}`);
-  console.log(`  Rust:    ${rustVersion}`);
-  console.log('');
-}
-
-function countSourceFiles(dir) {
-  let count = 0;
-  const walk = d => { try { for (const e of readdirSync(d)) { if (['node_modules','.git','dist'].includes(e)) continue; const f = join(d, e); try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {} } } catch {} };
-  walk(dir); return count;
-}
-
-function timeRun(cmd, cmdArgs, cwd) {
-  const start = performance.now();
-  const result = spawnSync(cmd, cmdArgs, { cwd, stdio: 'pipe', timeout: 300000, maxBuffer: 50*1024*1024, env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' } });
-  return {
-    elapsed: performance.now() - start,
-    status: result.status,
-    signal: result.signal,
-    stdout: result.stdout?.toString() ?? '',
-    stderr: result.stderr?.toString() ?? '',
-  };
-}
-
-function timeRunWithMemory(cmd, cmdArgs, cwd) {
-  const isLinux = process.platform === 'linux';
-  const timeBin = '/usr/bin/time';
-  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];
-
-  const start = performance.now();
-  const result = spawnSync(timeBin, timeArgs, { cwd, stdio: 'pipe', timeout: 300000, maxBuffer: 50*1024*1024, env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' } });
-  const elapsed = performance.now() - start;
-  const stderr = result.stderr?.toString() ?? '';
-
-  let peakRssBytes = 0;
-  if (isLinux) {
-    const match = stderr.match(/Maximum resident set size \(kbytes\): (\d+)/);
-    if (match) peakRssBytes = parseInt(match[1]) * 1024;
-  } else {
-    // macOS: reports in bytes
-    const match = stderr.match(/(\d+)\s+maximum resident set size/);
-    if (match) peakRssBytes = parseInt(match[1]);
-  }
-
-  // stdout for fallow comes from the time wrapper's child process — it's on stdout
-  const stdout = result.stdout?.toString() ?? '';
-
-  return { elapsed, status: result.status, signal: result.signal, stdout, stderr, peakRssBytes };
-}
 
 function firstDiagnosticLine(text) {
   const lines = text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
@@ -131,21 +79,6 @@ function summarizeBenchmarkRun(result) {
     return { valid: false, issues: 'error', error: detail };
   }
   return { valid: true, issues: countIssues(parsed.data), error: null };
-}
-
-function stats(times) {
-  const sorted = [...times].sort((a,b) => a-b);
-  const mid = Math.floor(sorted.length / 2);
-  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-  return { min: sorted[0], max: sorted.at(-1), mean: sorted.reduce((a,b)=>a+b,0)/sorted.length, median };
-}
-
-function fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms/1000).toFixed(2)}s`; }
-function fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb/1024).toFixed(2)} GB`; }
-
-function clearFallowCache(dir) {
-  const cacheDir = join(dir, '.fallow');
-  if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });
 }
 
 function benchmarkProject(name, dir) {
@@ -268,25 +201,23 @@ function benchmarkProject(name, dir) {
 }
 
 const results = [];
-if (runSynthetic) {
-  const d = join(__dirname, 'fixtures', 'synthetic');
-  if (!existsSync(d)) { console.log('No synthetic fixtures. Run: npm run generate\n'); }
-  else {
-    console.log('--- Synthetic Projects ---\n');
-    const order = ['tiny','small','medium','large','xlarge'];
-    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort((a,b) => order.indexOf(a)-order.indexOf(b)))
-      results.push(benchmarkProject(p, join(d, p)));
-  }
-}
-if (runRealWorld) {
-  const d = join(__dirname, 'fixtures', 'real-world');
-  if (!existsSync(d)) { console.log('No real-world fixtures. Run: npm run download-fixtures\n'); }
-  else {
-    console.log('--- Real-World Projects ---\n');
-    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort())
-      results.push(benchmarkProject(p, join(d, p)));
-  }
-}
+runProjectBenchmarks({
+  enabled: runSynthetic,
+  dir: join(__dirname, 'fixtures', 'synthetic'),
+  missingMessage: 'No synthetic fixtures. Run: npm run generate\n',
+  heading: '--- Synthetic Projects ---\n',
+  results,
+  benchmarkProject,
+  order: ['tiny','small','medium','large','xlarge'],
+});
+runProjectBenchmarks({
+  enabled: runRealWorld,
+  dir: join(__dirname, 'fixtures', 'real-world'),
+  missingMessage: 'No real-world fixtures. Run: npm run download-fixtures\n',
+  heading: '--- Real-World Projects ---\n',
+  results,
+  benchmarkProject,
+});
 if (results.length > 0) {
   console.log('\n=== Summary ===\n');
   console.table(results.map(r => ({

--- a/benchmarks/benchmark-helpers.mjs
+++ b/benchmarks/benchmark-helpers.mjs
@@ -1,0 +1,154 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+
+export const benchmarkDir = dirname(fileURLToPath(import.meta.url));
+export const rootDir = resolve(benchmarkDir, '..');
+
+export function parseBenchmarkArgs(args = process.argv.slice(2)) {
+  const hasFilter = args.includes('--synthetic') || args.includes('--real-world');
+  return {
+    runSynthetic: args.includes('--synthetic') || !hasFilter,
+    runRealWorld: args.includes('--real-world') || !hasFilter,
+    RUNS: parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5'),
+    WARMUP: parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2'),
+  };
+}
+
+export function buildFallowRelease() {
+  console.log('Building fallow (release)...');
+  const buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });
+  if (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }
+  return join(rootDir, 'target', 'release', 'fallow');
+}
+
+export function getVersion(cmd, cmdArgs = ['--version']) {
+  return spawnSync(cmd, cmdArgs, { stdio: 'pipe' }).stdout?.toString().trim();
+}
+
+export function printEnvironment(rustVersion) {
+  const cpus = os.cpus();
+  console.log('Environment:');
+  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);
+  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);
+  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);
+  console.log(`  Node:    ${process.version}`);
+  console.log(`  Rust:    ${rustVersion}`);
+  console.log('');
+}
+
+export function countSourceFiles(dir, ignored = ['node_modules', '.git', 'dist']) {
+  let count = 0;
+  const walk = d => {
+    try {
+      for (const e of readdirSync(d)) {
+        if (ignored.includes(e)) continue;
+        const f = join(d, e);
+        try {
+          const s = statSync(f);
+          if (s.isDirectory()) walk(f);
+          else if (/\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++;
+        } catch {}
+      }
+    } catch {}
+  };
+  walk(dir);
+  return count;
+}
+
+export function timeRun(cmd, cmdArgs, cwd, timeout = 300000) {
+  const start = performance.now();
+  const result = spawnSync(cmd, cmdArgs, {
+    cwd,
+    stdio: 'pipe',
+    timeout,
+    maxBuffer: 50 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+  });
+  return {
+    elapsed: performance.now() - start,
+    status: result.status,
+    signal: result.signal,
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? '',
+  };
+}
+
+export function timeRunWithMemory(cmd, cmdArgs, cwd, timeout = 300000) {
+  const isLinux = process.platform === 'linux';
+  const timeBin = '/usr/bin/time';
+  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];
+
+  const start = performance.now();
+  const result = spawnSync(timeBin, timeArgs, {
+    cwd,
+    stdio: 'pipe',
+    timeout,
+    maxBuffer: 50 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+  });
+  const elapsed = performance.now() - start;
+  const stderr = result.stderr?.toString() ?? '';
+
+  let peakRssBytes = 0;
+  if (isLinux) {
+    const match = stderr.match(/Maximum resident set size \(kbytes\): (\d+)/);
+    if (match) peakRssBytes = parseInt(match[1]) * 1024;
+  } else {
+    const match = stderr.match(/(\d+)\s+maximum resident set size/);
+    if (match) peakRssBytes = parseInt(match[1]);
+  }
+
+  return {
+    elapsed,
+    status: result.status,
+    signal: result.signal,
+    stdout: result.stdout?.toString() ?? '',
+    stderr,
+    peakRssBytes,
+  };
+}
+
+export function stats(times) {
+  const sorted = [...times].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  return {
+    min: sorted[0],
+    max: sorted.at(-1),
+    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,
+    median,
+  };
+}
+
+export function fmt(ms) {
+  return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function fmtMem(bytes) {
+  if (bytes === 0) return '?';
+  const mb = bytes / 1024 / 1024;
+  return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`;
+}
+
+export function clearFallowCache(dir) {
+  const cacheDir = join(dir, '.fallow');
+  if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });
+}
+
+export function packageProjects(dir, order = null) {
+  const projects = readdirSync(dir).filter(x => existsSync(join(dir, x, 'package.json')));
+  return order ? projects.sort((a, b) => order.indexOf(a) - order.indexOf(b)) : projects.sort();
+}
+
+export function runProjectBenchmarks({ enabled, dir, missingMessage, heading, results, benchmarkProject, order = null }) {
+  if (!enabled) return;
+  if (!existsSync(dir)) {
+    console.log(missingMessage);
+  } else {
+    console.log(heading);
+    for (const p of packageProjects(dir, order)) results.push(benchmarkProject(p, join(dir, p)));
+  }
+}

--- a/benchmarks/compare.mjs
+++ b/benchmarks/compare.mjs
@@ -21,9 +21,8 @@ function run(cmd, args, cwd) {
   return { stdout: result.stdout?.toString() ?? '', stderr: result.stderr?.toString() ?? '', status: result.status };
 }
 
-function parseFallow(stdout, projectDir) {
-  const data = JSON.parse(stdout);
-  const result = {
+function createEmptyResult() {
+  return {
     unused_files: new Set(),
     unused_exports: new Set(),
     unused_types: new Set(),
@@ -34,6 +33,11 @@ function parseFallow(stdout, projectDir) {
     unused_enum_members: new Set(),
     duplicate_exports: new Set(),
   };
+}
+
+function parseFallow(stdout, projectDir) {
+  const data = JSON.parse(stdout);
+  const result = createEmptyResult();
   for (const f of data.unused_files ?? []) result.unused_files.add(relative(projectDir, f.path));
   for (const e of data.unused_exports ?? []) result.unused_exports.add(`${relative(projectDir, e.path)}:${e.export_name}`);
   for (const t of data.unused_types ?? []) result.unused_types.add(`${relative(projectDir, t.path)}:${t.export_name}`);
@@ -48,17 +52,7 @@ function parseFallow(stdout, projectDir) {
 
 function parseKnip(stdout, projectDir) {
   const data = JSON.parse(stdout);
-  const result = {
-    unused_files: new Set(),
-    unused_exports: new Set(),
-    unused_types: new Set(),
-    unused_dependencies: new Set(),
-    unused_dev_dependencies: new Set(),
-    unresolved_imports: new Set(),
-    unlisted_dependencies: new Set(),
-    unused_enum_members: new Set(),
-    duplicate_exports: new Set(),
-  };
+  const result = createEmptyResult();
   // Knip "files" = unused files
   for (const f of data.files ?? []) result.unused_files.add(f);
   // Knip "issues" = per-file issues

--- a/benchmarks/fixture-generator-helpers.mjs
+++ b/benchmarks/fixture-generator-helpers.mjs
@@ -1,0 +1,61 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const benchmarkDir = dirname(fileURLToPath(import.meta.url));
+export const STANDARD_DIRS = ['components', 'utils', 'hooks', 'services', 'types', 'models', 'helpers', 'lib'];
+
+export function mulberry32(seed) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function resetProject(projectDir, seed, dirs = STANDARD_DIRS) {
+  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });
+  const rand = mulberry32(seed);
+  const srcDir = join(projectDir, 'src');
+  for (const dir of dirs) mkdirSync(join(srcDir, dir), { recursive: true });
+  return { rand, srcDir };
+}
+
+export function writePackageManifest(projectDir, packageName) {
+  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({
+    name: packageName,
+    version: '1.0.0',
+    private: true,
+    main: 'src/index.ts',
+  }, null, 2) + '\n');
+}
+
+export function writeTsConfig(projectDir) {
+  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({
+    compilerOptions: {
+      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',
+      strict: true, esModuleInterop: true, skipLibCheck: true,
+      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',
+    },
+    include: ['src'],
+  }, null, 2) + '\n');
+}
+
+export function relativeTsImport(fromFile, toFile) {
+  const fromDir = dirname(fromFile);
+  let rel = relative(fromDir, toFile).replace(/\.ts$/, '');
+  if (!rel.startsWith('.')) rel = './' + rel;
+  return rel;
+}
+
+export function runGenerator({ heading, sizes, generateProject, formatStats, doneCommand }) {
+  console.log(`${heading}\n`);
+  for (const size of sizes) {
+    const start = performance.now();
+    const stats = generateProject(size);
+    const elapsed = performance.now() - start;
+    console.log(formatStats(stats, elapsed));
+  }
+  console.log(`\nDone. Run: ${doneCommand}`);
+}

--- a/benchmarks/generate-circular-fixtures.mjs
+++ b/benchmarks/generate-circular-fixtures.mjs
@@ -1,19 +1,17 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
-import { join, dirname, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  benchmarkDir,
+  relativeTsImport,
+  resetProject,
+  runGenerator,
+  STANDARD_DIRS,
+  writePackageManifest,
+  writeTsConfig,
+} from './fixture-generator-helpers.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const fixturesDir = join(__dirname, 'fixtures', 'synthetic-circular');
-
-function mulberry32(seed) {
-  return function () {
-    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
-    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+const fixturesDir = join(benchmarkDir, 'fixtures', 'synthetic-circular');
 
 const SIZES = [
   { name: 'tiny',   files: 10,   cycleCount: 2,   maxCycleLen: 3  },
@@ -23,7 +21,7 @@ const SIZES = [
   { name: 'xlarge', files: 5000, cycleCount: 200, maxCycleLen: 8  },
 ];
 
-const DIRS = ['components', 'utils', 'hooks', 'services', 'types', 'models', 'helpers', 'lib'];
+const DIRS = STANDARD_DIRS;
 const ENTITIES = ['User', 'Order', 'Product', 'Invoice', 'Payment', 'Session', 'Account', 'Report'];
 const ACTIONS = ['validate', 'transform', 'process', 'normalize', 'sanitize', 'format', 'parse', 'convert'];
 
@@ -33,20 +31,13 @@ function filePath(i) {
 }
 
 function relImport(fromIdx, toIdx) {
-  const from = filePath(fromIdx);
-  const to = filePath(toIdx);
-  let rel = relative(dirname(from), to).replace(/\.ts$/, '');
-  if (!rel.startsWith('.')) rel = './' + rel;
-  return rel;
+  return relativeTsImport(filePath(fromIdx), filePath(toIdx));
 }
 
 function generateProject(size) {
   const { name, files: fileCount, cycleCount, maxCycleLen } = size;
   const projectDir = join(fixturesDir, name);
-  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });
-  const rand = mulberry32(42 + fileCount);
-  const srcDir = join(projectDir, 'src');
-  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });
+  const { rand, srcDir } = resetProject(projectDir, 42 + fileCount, DIRS);
 
   // Build import graph: each file imports from a few others (acyclic forward references)
   const imports = new Map(); // fileIndex -> Set<fileIndex>
@@ -147,30 +138,16 @@ function generateProject(size) {
     '',
   ].join('\n'));
 
-  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({
-    name: `bench-circular-${name}`,
-    version: '1.0.0',
-    private: true,
-    main: 'src/index.ts',
-  }, null, 2) + '\n');
-
-  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({
-    compilerOptions: {
-      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',
-      strict: true, esModuleInterop: true, skipLibCheck: true,
-      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',
-    },
-    include: ['src'],
-  }, null, 2) + '\n');
+  writePackageManifest(projectDir, `bench-circular-${name}`);
+  writeTsConfig(projectDir);
 
   return { name, fileCount, actualCycles, totalLines };
 }
 
-console.log('Generating synthetic circular dependency benchmark fixtures...\n');
-for (const size of SIZES) {
-  const start = performance.now();
-  const stats = generateProject(size);
-  const elapsed = performance.now() - start;
-  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats.actualCycles).padStart(4)} cycles  ${String(stats.totalLines).padStart(7)} lines  (${elapsed.toFixed(0)}ms)`);
-}
-console.log('\nDone. Run: npm run bench:circular:synthetic');
+runGenerator({
+  heading: 'Generating synthetic circular dependency benchmark fixtures...',
+  sizes: SIZES,
+  generateProject,
+  formatStats: (stats, elapsed) => `  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats.actualCycles).padStart(4)} cycles  ${String(stats.totalLines).padStart(7)} lines  (${elapsed.toFixed(0)}ms)`,
+  doneCommand: 'npm run bench:circular:synthetic',
+});

--- a/benchmarks/generate-dupes-fixtures.mjs
+++ b/benchmarks/generate-dupes-fixtures.mjs
@@ -1,19 +1,16 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
-import { join, dirname, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  benchmarkDir,
+  resetProject,
+  runGenerator,
+  STANDARD_DIRS,
+  writePackageManifest,
+  writeTsConfig,
+} from './fixture-generator-helpers.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const fixturesDir = join(__dirname, 'fixtures', 'synthetic-dupes');
-
-function mulberry32(seed) {
-  return function () {
-    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
-    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+const fixturesDir = join(benchmarkDir, 'fixtures', 'synthetic-dupes');
 
 const SIZES = [
   { name: 'tiny', files: 10, dupeGroups: 2, linesPerBlock: 15 },
@@ -23,7 +20,7 @@ const SIZES = [
   { name: 'xlarge', files: 5000, dupeGroups: 300, linesPerBlock: 30 },
 ];
 
-const DIRS = ['components', 'utils', 'hooks', 'services', 'types', 'models', 'helpers', 'lib'];
+const DIRS = STANDARD_DIRS;
 const TYPES = ['string', 'number', 'boolean', 'string[]', 'Record<string, unknown>'];
 const STATUSES = ['active', 'inactive', 'pending', 'archived', 'deleted'];
 const ACTIONS = ['validate', 'transform', 'process', 'normalize', 'sanitize', 'format', 'parse', 'convert'];
@@ -88,10 +85,7 @@ function generateUniqueBlock(rand, fileId) {
 function generateProject(size) {
   const { name, files: fileCount, dupeGroups, linesPerBlock } = size;
   const projectDir = join(fixturesDir, name);
-  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });
-  const rand = mulberry32(42 + fileCount);
-  const srcDir = join(projectDir, 'src');
-  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });
+  const { rand, srcDir } = resetProject(projectDir, 42 + fileCount, DIRS);
 
   // Pre-generate duplicated code blocks
   const blocks = [];
@@ -160,30 +154,16 @@ function generateProject(size) {
   ].join('\n');
   writeFileSync(join(srcDir, 'index.ts'), entryContent);
 
-  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({
-    name: `bench-dupes-${name}`,
-    version: '1.0.0',
-    private: true,
-    main: 'src/index.ts',
-  }, null, 2) + '\n');
-
-  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({
-    compilerOptions: {
-      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',
-      strict: true, esModuleInterop: true, skipLibCheck: true,
-      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',
-    },
-    include: ['src'],
-  }, null, 2) + '\n');
+  writePackageManifest(projectDir, `bench-dupes-${name}`);
+  writeTsConfig(projectDir);
 
   return { name, fileCount, dupeGroups, totalDuplicatedBlocks, totalLines };
 }
 
-console.log('Generating synthetic duplication benchmark fixtures...\n');
-for (const size of SIZES) {
-  const start = performance.now();
-  const stats = generateProject(size);
-  const elapsed = performance.now() - start;
-  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats.dupeGroups).padStart(4)} clone groups  ${String(stats.totalDuplicatedBlocks).padStart(5)} dupe blocks  ${String(stats.totalLines).padStart(7)} lines  (${elapsed.toFixed(0)}ms)`);
-}
-console.log('\nDone. Run: npm run bench:dupes:synthetic');
+runGenerator({
+  heading: 'Generating synthetic duplication benchmark fixtures...',
+  sizes: SIZES,
+  generateProject,
+  formatStats: (stats, elapsed) => `  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats.dupeGroups).padStart(4)} clone groups  ${String(stats.totalDuplicatedBlocks).padStart(5)} dupe blocks  ${String(stats.totalLines).padStart(7)} lines  (${elapsed.toFixed(0)}ms)`,
+  doneCommand: 'npm run bench:dupes:synthetic',
+});

--- a/benchmarks/generate-fixtures.mjs
+++ b/benchmarks/generate-fixtures.mjs
@@ -1,19 +1,17 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
-import { join, dirname, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  benchmarkDir,
+  relativeTsImport,
+  resetProject,
+  runGenerator,
+  STANDARD_DIRS,
+  writePackageManifest,
+  writeTsConfig,
+} from './fixture-generator-helpers.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const fixturesDir = join(__dirname, 'fixtures', 'synthetic');
-
-function mulberry32(seed) {
-  return function () {
-    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
-    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+const fixturesDir = join(benchmarkDir, 'fixtures', 'synthetic');
 
 const SIZES = [
   { name: 'tiny', files: 10, exportsPerFile: 3 },
@@ -23,17 +21,14 @@ const SIZES = [
   { name: 'xlarge', files: 5000, exportsPerFile: 5 },
 ];
 
-const DIRS = ['components','utils','hooks','services','types','models','helpers','lib'];
+const DIRS = STANDARD_DIRS;
 const TYPES = ['string','number','boolean','string[]','Record<string, unknown>'];
 const STATUSES = ['active','inactive','pending','archived','deleted'];
 
 function generateProject(size) {
   const { name, files: fileCount, exportsPerFile } = size;
   const projectDir = join(fixturesDir, name);
-  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });
-  const rand = mulberry32(42 + fileCount);
-  const srcDir = join(projectDir, 'src');
-  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });
+  const { rand, srcDir } = resetProject(projectDir, 42 + fileCount, DIRS);
 
   const usedCount = Math.floor(fileCount * 0.8);
   const fileInfos = [];
@@ -83,7 +78,7 @@ function generateProject(size) {
         const exp = target.exports[e];
         importedNames.push(exp.kind === 'type' || exp.kind === 'interface' ? `type ${exp.name}` : exp.name);
       }
-      content += `import { ${importedNames.join(', ')} } from '${relativePath(file.path, target.path)}';\n`;
+      content += `import { ${importedNames.join(', ')} } from '${relativeTsImport(file.path, target.path)}';\n`;
     }
     if (file.imports.length > 0) content += '\n';
     for (const exp of file.exports) {
@@ -101,7 +96,7 @@ function generateProject(size) {
   for (const targetIdx of entryImports) {
     const target = fileInfos[targetIdx]; const exp = target.exports[0];
     const importName = exp.kind === 'type' || exp.kind === 'interface' ? `type ${exp.name}` : exp.name;
-    entryContent += `import { ${importName} } from '${relativePath('src/index.ts', target.path)}';\n`;
+    entryContent += `import { ${importName} } from '${relativeTsImport('src/index.ts', target.path)}';\n`;
   }
   entryContent += '\n';
   for (const targetIdx of entryImports) {
@@ -109,25 +104,17 @@ function generateProject(size) {
     if (exp.kind !== 'type' && exp.kind !== 'interface') entryContent += `console.log(${exp.name});\n`;
   }
   writeFileSync(join(srcDir, 'index.ts'), entryContent);
-  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({ name: `bench-${name}`, version: '1.0.0', private: true, main: 'src/index.ts' }, null, 2) + '\n');
-  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler', strict: true, esModuleInterop: true, skipLibCheck: true, outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.' }, include: ['src'] }, null, 2) + '\n');
+  writePackageManifest(projectDir, `bench-${name}`);
+  writeTsConfig(projectDir);
 
   const totalExports = fileInfos.reduce((s, f) => s + f.exports.length, 0);
   return { name, fileCount, totalExports, unusedFiles: fileInfos.filter(f => !f.isUsed).length, unusedExports: totalExports - importedExports.size };
 }
 
-function relativePath(fromFile, toFile) {
-  const fromDir = dirname(fromFile);
-  let rel = relative(fromDir, toFile).replace(/\.ts$/, '');
-  if (!rel.startsWith('.')) rel = './' + rel;
-  return rel;
-}
-
-console.log('Generating synthetic fixture projects...\n');
-for (const size of SIZES) {
-  const start = performance.now();
-  const stats = generateProject(size);
-  const elapsed = performance.now() - start;
-  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats.totalExports).padStart(6)} exports  ${String(stats.unusedFiles).padStart(4)} unused files  ${String(stats.unusedExports).padStart(5)} unused exports  (${elapsed.toFixed(0)}ms)`);
-}
-console.log('\nDone. Run: npm run bench:synthetic');
+runGenerator({
+  heading: 'Generating synthetic fixture projects...',
+  sizes: SIZES,
+  generateProject,
+  formatStats: (stats, elapsed) => `  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats.totalExports).padStart(6)} exports  ${String(stats.unusedFiles).padStart(4)} unused files  ${String(stats.unusedExports).padStart(5)} unused exports  (${elapsed.toFixed(0)}ms)`,
+  doneCommand: 'npm run bench:synthetic',
+});

--- a/crates/config/src/config/parsing.rs
+++ b/crates/config/src/config/parsing.rs
@@ -2700,6 +2700,7 @@ minTokens = 100
         assert_eq!(config.duplicates.min_tokens, 200);
         assert_eq!(config.duplicates.min_lines, 20);
         assert!((config.duplicates.threshold - 10.5).abs() < f64::EPSILON);
+        assert_eq!(config.duplicates.ignore, vec!["**/*.test.ts"]);
         assert!(config.duplicates.skip_local);
         assert!(config.duplicates.cross_language);
         assert_eq!(

--- a/refactor/artifacts/dupes-2026-04-28/final-dupes.json
+++ b/refactor/artifacts/dupes-2026-04-28/final-dupes.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 4,
+  "version": "2.54.2",
+  "elapsed_ms": 63,
+  "clone_groups": [],
+  "clone_families": [],
+  "stats": {
+    "total_files": 40,
+    "files_with_clones": 0,
+    "total_lines": 5726,
+    "duplicated_lines": 0,
+    "total_tokens": 32425,
+    "duplicated_tokens": 0,
+    "clone_groups": 0,
+    "clone_instances": 0,
+    "duplication_percentage": 0.0
+  }
+}

--- a/refactor/artifacts/dupes-2026-04-28/final-dupes.txt
+++ b/refactor/artifacts/dupes-2026-04-28/final-dupes.txt
@@ -1,0 +1,3 @@
+loaded config: /Users/london_server/fallow/.fallowrc.json
+
+✓ No code duplication found (0.02s)

--- a/refactor/artifacts/dupes-2026-04-28/initial-dupes.json
+++ b/refactor/artifacts/dupes-2026-04-28/initial-dupes.json
@@ -1,0 +1,3547 @@
+{
+  "schema_version": 4,
+  "version": "2.54.2",
+  "elapsed_ms": 20,
+  "clone_groups": [
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 3,
+          "end_line": 23,
+          "start_col": 87,
+          "end_col": 66,
+          "fragment": "'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\n\n// Detect available tools\nconst madgeBin = join(__dirname, 'node_modules', '.bin', 'madge');"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 3,
+          "end_line": 21,
+          "start_col": 72,
+          "end_col": 66,
+          "fragment": "'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst jscpdBin = join(__dirname, 'node_modules', '.bin', 'jscpd');"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 3,
+          "end_line": 21,
+          "start_col": 58,
+          "end_col": 64,
+          "fragment": "'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst knipBin = join(__dirname, 'node_modules', '.bin', 'knip');"
+        }
+      ],
+      "token_count": 270,
+      "line_count": 21,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (21 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 44,
+          "end_line": 97,
+          "start_col": 23,
+          "end_col": 1,
+          "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist', 'report'].includes(e)) continue;\n        const f = join(d, e);\n        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}\n      }\n    } catch {}\n  };\n  walk(dir); return count;\n}\n\nfunction timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }\n\n  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };\n}"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 30,
+          "end_line": 72,
+          "start_col": 98,
+          "end_col": 1,
+          "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist', 'report'].includes(e)) continue;\n        const f = join(d, e);\n        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}\n      }\n    } catch {}\n  };\n  walk(dir); return count;\n}\n\nfunction timeRun(cmd, cmdArgs, cwd) {\n  const start = performance.now();\n  const result = spawnSync(cmd, cmdArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  return {\n    elapsed: performance.now() - start,\n    status: result.status,\n    stdout: result.stdout?.toString() ?? '',\n    stderr: result.stderr?.toString() ?? '',\n  };\n}"
+        }
+      ],
+      "token_count": 246,
+      "line_count": 54,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (54 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 44,
+          "end_line": 62,
+          "start_col": 23,
+          "end_col": 43,
+          "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist'"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 30,
+          "end_line": 48,
+          "start_col": 98,
+          "end_col": 43,
+          "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist'"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 34,
+          "end_line": 49,
+          "start_col": 140,
+          "end_col": 95,
+          "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => { try { for (const e of readdirSync(d)) { if (['node_modules','.git','dist'"
+        }
+      ],
+      "token_count": 167,
+      "line_count": 19,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (19 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 71,
+          "end_line": 104,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }\n\n  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };\n}\n\nfunction parseFallowCycles(stdout) {\n  try {\n    const data = JSON.parse(stdout);\n    return data.circular_dependencies?.length ?? 0;\n  } catch { return '?'; }\n}"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 74,
+          "end_line": 111,
+          "start_col": 0,
+          "end_col": 1,
+          "fragment": "function timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }\n\n  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };\n}\n\nfunction parseFallowCloneCount(stdout) {\n  try {\n    const data = JSON.parse(stdout);\n    return {\n      groups: data.stats?.clone_groups ?? data.clone_groups?.length ?? '?',\n      instances: data.stats?.clone_instances ?? '?',\n      pct: data.stats?.duplication_percentage?.toFixed(1) ?? '?',\n    };\n  } catch { return { groups: '?', instances: '?', pct: '?' }; }\n}"
+        }
+      ],
+      "token_count": 209,
+      "line_count": 38,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (38 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 81,
+          "end_line": 94,
+          "start_col": 4,
+          "end_col": 3,
+          "fragment": "maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 84,
+          "end_line": 97,
+          "start_col": 4,
+          "end_col": 3,
+          "fragment": "maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 71,
+          "end_line": 83,
+          "start_col": 85,
+          "end_col": 3,
+          "fragment": "maxBuffer: 50*1024*1024, env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' } });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    // macOS: reports in bytes\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }"
+        }
+      ],
+      "token_count": 113,
+      "line_count": 14,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (14 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 117,
+          "end_line": 136,
+          "start_col": 10,
+          "end_col": 37,
+          "fragment": "{ return '?'; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir)"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 124,
+          "end_line": 143,
+          "start_col": 10,
+          "end_col": 37,
+          "fragment": "{ return { groups: '?', instances: '?', pct: '?' }; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir)"
+        }
+      ],
+      "token_count": 226,
+      "line_count": 20,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (20 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 117,
+          "end_line": 230,
+          "start_col": 10,
+          "end_col": 1,
+          "fragment": "{ return '?'; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir);\n  const hasTsConfig = existsSync(join(dir, 'tsconfig.json'));\n  console.log(`### ${name} (${files} source files)\\n`);\n\n  // fallow: JSON output, only circular deps, no cache\n  const fallowArgs = ['dead-code', '--format', 'json', '--quiet', '--no-cache', '--circular-deps'];\n\n  // madge: circular detection with JSON output\n  const madgeArgs = ['--circular', '--json', '--extensions', 'ts,tsx,js,jsx,mjs,cjs', '--no-spinner'];\n  if (hasTsConfig) madgeArgs.push('--ts-config', 'tsconfig.json');\n  madgeArgs.push('src/');\n\n  // dpdm: circular detection with JSON output to stdout\n  const dpdmOutputFile = join(dir, '.dpdm-output.json');\n  const dpdmArgs = ['--no-tree', '--no-warning', '--no-progress', '--output', dpdmOutputFile];\n  if (hasTsConfig) dpdmArgs.push('--tsconfig', 'tsconfig.json');\n  dpdmArgs.push('src/index.ts');\n\n  // Warmup\n  for (let i = 0; i < WARMUP; i++) {\n    timeRunWithMemory(fallowBin, fallowArgs, dir);\n    if (hasMadge) timeRunWithMemory(madgeBin, madgeArgs, dir);\n    if (hasDpdm) {\n      timeRunWithMemory(dpdmBin, dpdmArgs, dir);\n      if (existsSync(dpdmOutputFile)) rmSync(dpdmOutputFile);\n    }\n  }\n\n  // --- Measured runs ---\n  const fallowTimes = [], madgeTimes = [], dpdmTimes = [];\n  let fallowCycles = '?', madgeCycles = '?', dpdmCycles = '?';\n  let fallowRss = 0, madgeRss = 0, dpdmRss = 0;\n\n  for (let i = 0; i < RUNS; i++) {\n    // fallow\n    const fr = timeRunWithMemory(fallowBin, fallowArgs, dir);\n    fallowTimes.push(fr.elapsed);\n    if (i === 0) { fallowCycles = parseFallowCycles(fr.stdout); fallowRss = fr.peakRssBytes; }\n\n    // madge\n    if (hasMadge) {\n      const mr = timeRunWithMemory(madgeBin, madgeArgs, dir);\n      madgeTimes.push(mr.elapsed);\n      if (i === 0) { madgeCycles = parseMadgeCycles(mr.stdout); madgeRss = mr.peakRssBytes; }\n    }\n\n    // dpdm\n    if (hasDpdm) {\n      const dr = timeRunWithMemory(dpdmBin, dpdmArgs, dir);\n      dpdmTimes.push(dr.elapsed);\n      if (i === 0) {\n        try {\n          dpdmCycles = parseDpdmCycles(readFileSync(dpdmOutputFile, 'utf8'));\n        } catch { dpdmCycles = '?'; }\n        dpdmRss = dr.peakRssBytes;\n      }\n      if (existsSync(dpdmOutputFile)) rmSync(dpdmOutputFile);\n    }\n  }\n\n  const fs = stats(fallowTimes);\n  const rows = [\n    { Tool: 'fallow', Min: fmt(fs.min), Mean: fmt(fs.mean), Median: fmt(fs.median), Max: fmt(fs.max), Speedup: '—', Memory: fmtMem(fallowRss), Cycles: fallowCycles },\n  ];\n\n  const result = { name, files, fallow: fs, fallowCycles, fallowRss };\n\n  if (hasMadge && madgeTimes.length > 0) {\n    const ms = stats(madgeTimes);\n    const speedup = ms.median / fs.median;\n    rows.push({ Tool: 'madge', Min: fmt(ms.min), Mean: fmt(ms.mean), Median: fmt(ms.median), Max: fmt(ms.max), Speedup: `1/${speedup.toFixed(1)}x`, Memory: fmtMem(madgeRss), Cycles: madgeCycles });\n    result.madge = ms;\n    result.madgeSpeedup = speedup;\n    result.madgeCycles = madgeCycles;\n    result.madgeRss = madgeRss;\n  }\n\n  if (hasDpdm && dpdmTimes.length > 0) {\n    const ds = stats(dpdmTimes);\n    const speedup = ds.median / fs.median;\n    rows.push({ Tool: 'dpdm', Min: fmt(ds.min), Mean: fmt(ds.mean), Median: fmt(ds.median), Max: fmt(ds.max), Speedup: `1/${speedup.toFixed(1)}x`, Memory: fmtMem(dpdmRss), Cycles: dpdmCycles });\n    result.dpdm = ds;\n    result.dpdmSpeedup = speedup;\n    result.dpdmCycles = dpdmCycles;\n    result.dpdmRss = dpdmRss;\n  }\n\n  console.table(rows);\n  console.log(`  fallow: [${fallowTimes.map(t => t.toFixed(0)).join(', ')}]`);\n  if (hasMadge && madgeTimes.length > 0) console.log(`  madge:  [${madgeTimes.map(t => t.toFixed(0)).join(', ')}]`);\n  if (hasDpdm && dpdmTimes.length > 0) console.log(`  dpdm:   [${dpdmTimes.map(t => t.toFixed(0)).join(', ')}]`);\n  console.log('');\n\n  return result;\n}"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 124,
+          "end_line": 199,
+          "start_col": 10,
+          "end_col": 1,
+          "fragment": "{ return { groups: '?', instances: '?', pct: '?' }; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir);\n  console.log(`### ${name} (${files} source files)\\n`);\n\n  // fallow dupes: JSON output, no cache (cold)\n  const fArgsCold = ['dupes', '--format', 'json', '--no-cache'];\n\n  // jscpd: JSON reporter, output to temp dir\n  const jscpdReportDir = join(dir, 'report');\n  const jArgs = [\n    '--reporters', 'json',\n    '--format', 'typescript,javascript',\n    '--output', jscpdReportDir,\n    '--min-tokens', '50',\n    '--min-lines', '5',\n    '--ignore', '**/node_modules/**,**/dist/**,**/.git/**',\n    '--silent',\n    '.',\n  ];\n\n  // Warmup\n  for (let i = 0; i < WARMUP; i++) {\n    timeRun(fallowBin, fArgsCold, dir);\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n    timeRun(jscpdBin, jArgs, dir);\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n  }\n\n  // --- Cold runs ---\n  const fTimesCold = [], jTimes = [];\n  let fClones = { groups: '?', instances: '?', pct: '?' };\n  let jClones = { groups: '?', instances: '?', pct: '?' };\n  let fPeakRss = 0, jPeakRss = 0;\n\n  for (let i = 0; i < RUNS; i++) {\n    const fr = timeRunWithMemory(fallowBin, fArgsCold, dir);\n    fTimesCold.push(fr.elapsed);\n    if (i === 0) { fClones = parseFallowCloneCount(fr.stdout); fPeakRss = fr.peakRssBytes; }\n\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n    const jr = timeRunWithMemory(jscpdBin, jArgs, dir);\n    jTimes.push(jr.elapsed);\n    if (i === 0) { jClones = parseJscpdCloneCount(jscpdReportDir); jPeakRss = jr.peakRssBytes; }\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n  }\n\n  const fsCold = stats(fTimesCold), js = stats(jTimes);\n  const speedup = js.median / fsCold.median;\n\n  console.table([\n    { Tool: 'fallow dupes', Min: fmt(fsCold.min), Mean: fmt(fsCold.mean), Median: fmt(fsCold.median), Max: fmt(fsCold.max), Speedup: `${speedup.toFixed(1)}x`, Memory: fmtMem(fPeakRss), 'Clone Groups': fClones.groups, 'Dup %': `${fClones.pct}%` },\n    { Tool: 'jscpd',        Min: fmt(js.min),     Mean: fmt(js.mean),     Median: fmt(js.median),     Max: fmt(js.max),     Speedup: '1.0x',                       Memory: fmtMem(jPeakRss), 'Clone Groups': jClones.groups, 'Dup %': `${jClones.pct}%` },\n  ]);\n  console.log(`  fallow: [${fTimesCold.map(t => t.toFixed(0)).join(', ')}]`);\n  console.log(`  jscpd:  [${jTimes.map(t => t.toFixed(0)).join(', ')}]\\n`);\n\n  return { name, files, fallow: fsCold, jscpd: js, speedup, fClones, jClones, fPeakRss, jPeakRss };\n}"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 133,
+          "end_line": 149,
+          "start_col": 9,
+          "end_col": 1,
+          "fragment": "{ valid: true, issues: countIssues(parsed.data), error: null };\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a,b) => a-b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return { min: sorted[0], max: sorted.at(-1), mean: sorted.reduce((a,b)=>a+b,0)/sorted.length, median };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms/1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb/1024).toFixed(2)} GB`; }\n\nfunction clearFallowCache(dir) {\n  const cacheDir = join(dir, '.fallow');\n  if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });\n}"
+        }
+      ],
+      "token_count": 207,
+      "line_count": 114,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (114 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 239,
+          "end_line": 251,
+          "start_col": 70,
+          "end_col": 16,
+          "fragment": ");\n    const order = ['tiny', 'small', 'medium', 'large', 'xlarge'];\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort((a, b) => order.indexOf(a) - order.indexOf(b)))\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (runRealWorld) {\n  const d = join(__dirname, 'fixtures', 'real-world');\n  if (!existsSync(d)) {\n    console.log('No real-world fixtures. Run: npm run download-fixtures\\n');\n  } else {\n    console.log("
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 208,
+          "end_line": 220,
+          "start_col": 60,
+          "end_col": 16,
+          "fragment": ");\n    const order = ['tiny', 'small', 'medium', 'large', 'xlarge'];\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort((a, b) => order.indexOf(a) - order.indexOf(b)))\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (runRealWorld) {\n  const d = join(__dirname, 'fixtures', 'real-world');\n  if (!existsSync(d)) {\n    console.log('No real-world fixtures. Run: npm run download-fixtures\\n');\n  } else {\n    console.log("
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 275,
+          "end_line": 285,
+          "start_col": 46,
+          "end_col": 16,
+          "fragment": ");\n    const order = ['tiny','small','medium','large','xlarge'];\n    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort((a,b) => order.indexOf(a)-order.indexOf(b)))\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\nif (runRealWorld) {\n  const d = join(__dirname, 'fixtures', 'real-world');\n  if (!existsSync(d)) { console.log('No real-world fixtures. Run: npm run download-fixtures\\n'); }\n  else {\n    console.log("
+        }
+      ],
+      "token_count": 146,
+      "line_count": 13,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (13 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-circular.mjs",
+          "start_line": 251,
+          "end_line": 258,
+          "start_col": 71,
+          "end_col": 37,
+          "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');"
+        },
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 220,
+          "end_line": 227,
+          "start_col": 61,
+          "end_col": 37,
+          "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 285,
+          "end_line": 291,
+          "start_col": 47,
+          "end_col": 37,
+          "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');"
+        }
+      ],
+      "token_count": 83,
+      "line_count": 8,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (8 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 3,
+          "end_line": 21,
+          "start_col": 58,
+          "end_col": 66,
+          "fragment": "rmSync } from 'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst jscpdBin = join(__dirname, 'node_modules', '.bin', 'jscpd');"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 3,
+          "end_line": 21,
+          "start_col": 44,
+          "end_col": 64,
+          "fragment": "rmSync } from 'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst knipBin = join(__dirname, 'node_modules', '.bin', 'knip');"
+        }
+      ],
+      "token_count": 272,
+      "line_count": 19,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (19 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 48,
+          "end_line": 62,
+          "start_col": 12,
+          "end_col": 11,
+          "fragment": "['node_modules', '.git', 'dist', 'report'].includes(e)) continue;\n        const f = join(d, e);\n        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}\n      }\n    } catch {}\n  };\n  walk(dir); return count;\n}\n\nfunction timeRun(cmd, cmdArgs, cwd) {\n  const start = performance.now();\n  const result = spawnSync(cmd, cmdArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 49,
+          "end_line": 55,
+          "start_col": 66,
+          "end_col": 70,
+          "fragment": "['node_modules','.git','dist'].includes(e)) continue; const f = join(d, e); try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {} } } catch {} };\n  walk(dir); return count;\n}\n\nfunction timeRun(cmd, cmdArgs, cwd) {\n  const start = performance.now();\n  const result = spawnSync(cmd, cmdArgs, { cwd, stdio: 'pipe', timeout"
+        }
+      ],
+      "token_count": 115,
+      "line_count": 15,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (15 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 69,
+          "end_line": 83,
+          "start_col": 4,
+          "end_col": 11,
+          "fragment": "stdout: result.stdout?.toString() ?? '',\n    stderr: result.stderr?.toString() ?? '',\n  };\n}\n\nfunction timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 60,
+          "end_line": 71,
+          "start_col": 4,
+          "end_col": 75,
+          "fragment": "stdout: result.stdout?.toString() ?? '',\n    stderr: result.stderr?.toString() ?? '',\n  };\n}\n\nfunction timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, { cwd, stdio: 'pipe', timeout"
+        }
+      ],
+      "token_count": 92,
+      "line_count": 15,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (15 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/bench-dupes.mjs",
+          "start_line": 220,
+          "end_line": 230,
+          "start_col": 61,
+          "end_col": 18,
+          "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');\n  console.table(results.map(r => ({\n    Project: r.name,\n    Files: r.files"
+        },
+        {
+          "file": "benchmarks/bench.mjs",
+          "start_line": 285,
+          "end_line": 294,
+          "start_col": 47,
+          "end_col": 18,
+          "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');\n  console.table(results.map(r => ({\n    Project: r.name,\n    Files: r.files"
+        }
+      ],
+      "token_count": 106,
+      "line_count": 11,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (11 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/compare.mjs",
+          "start_line": 24,
+          "end_line": 37,
+          "start_col": 21,
+          "end_col": 23,
+          "fragment": "stdout, projectDir) {\n  const data = JSON.parse(stdout);\n  const result = {\n    unused_files: new Set(),\n    unused_exports: new Set(),\n    unused_types: new Set(),\n    unused_dependencies: new Set(),\n    unused_dev_dependencies: new Set(),\n    unresolved_imports: new Set(),\n    unlisted_dependencies: new Set(),\n    unused_enum_members: new Set(),\n    duplicate_exports: new Set(),\n  };\n  for (const f of data."
+        },
+        {
+          "file": "benchmarks/compare.mjs",
+          "start_line": 49,
+          "end_line": 63,
+          "start_col": 19,
+          "end_col": 23,
+          "fragment": "stdout, projectDir) {\n  const data = JSON.parse(stdout);\n  const result = {\n    unused_files: new Set(),\n    unused_exports: new Set(),\n    unused_types: new Set(),\n    unused_dependencies: new Set(),\n    unused_dev_dependencies: new Set(),\n    unresolved_imports: new Set(),\n    unlisted_dependencies: new Set(),\n    unused_enum_members: new Set(),\n    duplicate_exports: new Set(),\n  };\n  // Knip \"files\" = unused files\n  for (const f of data."
+        }
+      ],
+      "token_count": 72,
+      "line_count": 15,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (15 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/generate-circular-fixtures.mjs",
+          "start_line": 2,
+          "end_line": 7,
+          "start_col": 0,
+          "end_col": 47,
+          "fragment": "import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';\nimport { join, dirname, relative } from 'node:path';\nimport { fileURLToPath } from 'node:url';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst fixturesDir = join(__dirname, 'fixtures',"
+        },
+        {
+          "file": "benchmarks/generate-dupes-fixtures.mjs",
+          "start_line": 2,
+          "end_line": 7,
+          "start_col": 0,
+          "end_col": 47,
+          "fragment": "import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';\nimport { join, dirname, relative } from 'node:path';\nimport { fileURLToPath } from 'node:url';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst fixturesDir = join(__dirname, 'fixtures',"
+        },
+        {
+          "file": "benchmarks/generate-fixtures.mjs",
+          "start_line": 2,
+          "end_line": 7,
+          "start_col": 0,
+          "end_col": 47,
+          "fragment": "import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';\nimport { join, dirname, relative } from 'node:path';\nimport { fileURLToPath } from 'node:url';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst fixturesDir = join(__dirname, 'fixtures',"
+        }
+      ],
+      "token_count": 53,
+      "line_count": 6,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (6 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/generate-circular-fixtures.mjs",
+          "start_line": 7,
+          "end_line": 19,
+          "start_col": 68,
+          "end_col": 29,
+          "fragment": ");\n\nfunction mulberry32(seed) {\n  return function () {\n    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;\n    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);\n    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;\n    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;\n  };\n}\n\nconst SIZES = [\n  { name: 'tiny',   files: 10"
+        },
+        {
+          "file": "benchmarks/generate-dupes-fixtures.mjs",
+          "start_line": 7,
+          "end_line": 19,
+          "start_col": 65,
+          "end_col": 27,
+          "fragment": ");\n\nfunction mulberry32(seed) {\n  return function () {\n    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;\n    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);\n    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;\n    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;\n  };\n}\n\nconst SIZES = [\n  { name: 'tiny', files: 10"
+        },
+        {
+          "file": "benchmarks/generate-fixtures.mjs",
+          "start_line": 7,
+          "end_line": 19,
+          "start_col": 59,
+          "end_col": 27,
+          "fragment": ");\n\nfunction mulberry32(seed) {\n  return function () {\n    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;\n    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);\n    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;\n    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;\n  };\n}\n\nconst SIZES = [\n  { name: 'tiny', files: 10"
+        }
+      ],
+      "token_count": 87,
+      "line_count": 13,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (13 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/generate-circular-fixtures.mjs",
+          "start_line": 44,
+          "end_line": 52,
+          "start_col": 8,
+          "end_col": 28,
+          "fragment": "{ name, files: fileCount, cycleCount, maxCycleLen } = size;\n  const projectDir = join(fixturesDir, name);\n  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });\n  const rand = mulberry32(42 + fileCount);\n  const srcDir = join(projectDir, 'src');\n  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });\n\n  // Build import graph: each file imports from a few others (acyclic forward references)\n  const imports = new Map();"
+        },
+        {
+          "file": "benchmarks/generate-dupes-fixtures.mjs",
+          "start_line": 89,
+          "end_line": 97,
+          "start_col": 8,
+          "end_col": 20,
+          "fragment": "{ name, files: fileCount, dupeGroups, linesPerBlock } = size;\n  const projectDir = join(fixturesDir, name);\n  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });\n  const rand = mulberry32(42 + fileCount);\n  const srcDir = join(projectDir, 'src');\n  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });\n\n  // Pre-generate duplicated code blocks\n  const blocks = [];"
+        },
+        {
+          "file": "benchmarks/generate-fixtures.mjs",
+          "start_line": 31,
+          "end_line": 38,
+          "start_col": 8,
+          "end_col": 48,
+          "fragment": "{ name, files: fileCount, exportsPerFile } = size;\n  const projectDir = join(fixturesDir, name);\n  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });\n  const rand = mulberry32(42 + fileCount);\n  const srcDir = join(projectDir, 'src');\n  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });\n\n  const usedCount = Math.floor(fileCount * 0.8);"
+        }
+      ],
+      "token_count": 81,
+      "line_count": 9,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/generate-circular-fixtures.mjs",
+          "start_line": 148,
+          "end_line": 166,
+          "start_col": 14,
+          "end_col": 26,
+          "fragment": ");\n\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({\n    name: `bench-circular-${name}`,\n    version: '1.0.0',\n    private: true,\n    main: 'src/index.ts',\n  }, null, 2) + '\\n');\n\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({\n    compilerOptions: {\n      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',\n      strict: true, esModuleInterop: true, skipLibCheck: true,\n      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',\n    },\n    include: ['src'],\n  }, null, 2) + '\\n');\n\n  return { name, fileCount"
+        },
+        {
+          "file": "benchmarks/generate-dupes-fixtures.mjs",
+          "start_line": 161,
+          "end_line": 179,
+          "start_col": 54,
+          "end_col": 26,
+          "fragment": ");\n\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({\n    name: `bench-dupes-${name}`,\n    version: '1.0.0',\n    private: true,\n    main: 'src/index.ts',\n  }, null, 2) + '\\n');\n\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({\n    compilerOptions: {\n      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',\n      strict: true, esModuleInterop: true, skipLibCheck: true,\n      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',\n    },\n    include: ['src'],\n  }, null, 2) + '\\n');\n\n  return { name, fileCount"
+        }
+      ],
+      "token_count": 99,
+      "line_count": 19,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (19 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/generate-circular-fixtures.mjs",
+          "start_line": 169,
+          "end_line": 174,
+          "start_col": 78,
+          "end_col": 102,
+          "fragment": ");\nfor (const size of SIZES) {\n  const start = performance.now();\n  const stats = generateProject(size);\n  const elapsed = performance.now() - start;\n  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats."
+        },
+        {
+          "file": "benchmarks/generate-dupes-fixtures.mjs",
+          "start_line": 182,
+          "end_line": 187,
+          "start_col": 70,
+          "end_col": 102,
+          "fragment": ");\nfor (const size of SIZES) {\n  const start = performance.now();\n  const stats = generateProject(size);\n  const elapsed = performance.now() - start;\n  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats."
+        },
+        {
+          "file": "benchmarks/generate-fixtures.mjs",
+          "start_line": 126,
+          "end_line": 131,
+          "start_col": 56,
+          "end_col": 102,
+          "fragment": ");\nfor (const size of SIZES) {\n  const start = performance.now();\n  const stats = generateProject(size);\n  const elapsed = performance.now() - start;\n  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats."
+        }
+      ],
+      "token_count": 72,
+      "line_count": 6,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (6 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "benchmarks/generate-dupes-fixtures.mjs",
+          "start_line": 161,
+          "end_line": 177,
+          "start_col": 2,
+          "end_col": 22,
+          "fragment": "writeFileSync(join(srcDir, 'index.ts'), entryContent);\n\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({\n    name: `bench-dupes-${name}`,\n    version: '1.0.0',\n    private: true,\n    main: 'src/index.ts',\n  }, null, 2) + '\\n');\n\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({\n    compilerOptions: {\n      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',\n      strict: true, esModuleInterop: true, skipLibCheck: true,\n      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',\n    },\n    include: ['src'],\n  }, null, 2) + '\\n');"
+        },
+        {
+          "file": "benchmarks/generate-fixtures.mjs",
+          "start_line": 111,
+          "end_line": 113,
+          "start_col": 2,
+          "end_col": 313,
+          "fragment": "writeFileSync(join(srcDir, 'index.ts'), entryContent);\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({ name: `bench-${name}`, version: '1.0.0', private: true, main: 'src/index.ts' }, null, 2) + '\\n');\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler', strict: true, esModuleInterop: true, skipLibCheck: true, outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.' }, include: ['src'] }, null, 2) + '\\n');"
+        }
+      ],
+      "token_count": 104,
+      "line_count": 17,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (17 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.d.ts",
+          "start_line": 1,
+          "end_line": 363,
+          "start_col": 0,
+          "end_col": 80,
+          "fragment": "export interface AnalysisOptions {\n  root?: string;\n  configPath?: string;\n  noCache?: boolean;\n  threads?: number;\n  production?: boolean;\n  changedSince?: string;\n  workspace?: string[];\n  changedWorkspaces?: string;\n  explain?: boolean;\n}\n\nexport interface DeadCodeOptions extends AnalysisOptions {\n  unusedFiles?: boolean;\n  unusedExports?: boolean;\n  unusedDeps?: boolean;\n  unusedTypes?: boolean;\n  unusedEnumMembers?: boolean;\n  unusedClassMembers?: boolean;\n  unresolvedImports?: boolean;\n  unlistedDeps?: boolean;\n  duplicateExports?: boolean;\n  circularDeps?: boolean;\n  boundaryViolations?: boolean;\n  staleSuppressions?: boolean;\n  files?: string[];\n  includeEntryExports?: boolean;\n}\n\nexport type DuplicationMode = 'strict' | 'mild' | 'weak' | 'semantic';\n\nexport interface DuplicationOptions extends AnalysisOptions {\n  mode?: DuplicationMode;\n  minTokens?: number;\n  minLines?: number;\n  threshold?: number;\n  skipLocal?: boolean;\n  crossLanguage?: boolean;\n  ignoreImports?: boolean;\n  top?: number;\n}\n\nexport type ComplexitySort = 'cyclomatic' | 'cognitive' | 'lines' | 'severity';\nexport type OwnershipEmailMode = 'raw' | 'handle' | 'hash';\nexport type TargetEffort = 'low' | 'medium' | 'high';\n\nexport interface ComplexityOptions extends AnalysisOptions {\n  maxCyclomatic?: number;\n  maxCognitive?: number;\n  maxCrap?: number;\n  top?: number;\n  sort?: ComplexitySort;\n  complexity?: boolean;\n  fileScores?: boolean;\n  coverageGaps?: boolean;\n  hotspots?: boolean;\n  ownership?: boolean;\n  ownershipEmails?: OwnershipEmailMode;\n  targets?: boolean;\n  effort?: TargetEffort;\n  score?: boolean;\n  since?: string;\n  minCommits?: number;\n  coverage?: string;\n  coverageRoot?: string;\n}\n\nexport interface AnalysisAction {\n  type?: string;\n  auto_fixable?: boolean;\n  description?: string;\n  comment?: string;\n  note?: string;\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeSummary {\n  total_issues: number;\n  unused_files: number;\n  unused_exports: number;\n  unused_types: number;\n  unused_dependencies: number;\n  unused_enum_members: number;\n  unused_class_members: number;\n  unresolved_imports: number;\n  unlisted_dependencies: number;\n  duplicate_exports: number;\n  type_only_dependencies: number;\n  test_only_dependencies: number;\n  circular_dependencies: number;\n  boundary_violations: number;\n  stale_suppressions: number;\n}\n\nexport interface EntryPointSummary {\n  total: number;\n  sources: Record<string, number>;\n}\n\nexport interface UnusedFileFinding {\n  path: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedExportFinding {\n  path: string;\n  export_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  used_in_workspaces?: string[];\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedMemberFinding {\n  path: string;\n  parent_name: string;\n  member_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnresolvedImportFinding {\n  path: string;\n  specifier: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnlistedDependencyFinding {\n  package_name: string;\n  imported_from: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicateExportFinding {\n  export_name: string;\n  locations: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TypeOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TestOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface CircularDependencyFinding {\n  files: string[];\n  length: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface BoundaryViolationFinding {\n  from_path: string;\n  to_path: string;\n  line: number;\n  col: number;\n  from_zone?: string;\n  to_zone?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface StaleSuppressionFinding {\n  path: string;\n  line: number;\n  col: number;\n  issue_kind?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  total_issues: number;\n  summary: DeadCodeSummary;\n  entry_points?: EntryPointSummary;\n  unused_files: UnusedFileFinding[];\n  unused_exports: UnusedExportFinding[];\n  unused_types: UnusedExportFinding[];\n  unused_dependencies: UnusedDependencyFinding[];\n  unused_dev_dependencies: UnusedDependencyFinding[];\n  unused_optional_dependencies: UnusedDependencyFinding[];\n  unused_enum_members: UnusedMemberFinding[];\n  unused_class_members: UnusedMemberFinding[];\n  unresolved_imports: UnresolvedImportFinding[];\n  unlisted_dependencies: UnlistedDependencyFinding[];\n  duplicate_exports: DuplicateExportFinding[];\n  type_only_dependencies: TypeOnlyDependencyFinding[];\n  test_only_dependencies: TestOnlyDependencyFinding[];\n  circular_dependencies: CircularDependencyFinding[];\n  boundary_violations: BoundaryViolationFinding[];\n  stale_suppressions: StaleSuppressionFinding[];\n  _meta?: Record<string, unknown>;\n}\n\nexport interface CloneInstance {\n  file: string;\n  start_line: number;\n  end_line: number;\n  start_col: number;\n  end_col: number;\n  fragment?: string;\n  [key: string]: unknown;\n}\n\nexport interface CloneGroup {\n  instances: CloneInstance[];\n  token_count: number;\n  line_count: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicationStats {\n  total_files: number;\n  files_with_clones: number;\n  total_lines: number;\n  duplicated_lines: number;\n  total_tokens: number;\n  duplicated_tokens: number;\n  clone_groups: number;\n  clone_instances: number;\n  duplication_percentage: number;\n}\n\nexport interface DuplicationReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  clone_groups: CloneGroup[];\n  clone_families?: Record<string, unknown>[];\n  mirrored_directories?: Record<string, unknown>[];\n  stats: DuplicationStats;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface HealthFinding {\n  path: string;\n  name: string;\n  line: number;\n  col: number;\n  cyclomatic: number;\n  cognitive: number;\n  line_count: number;\n  param_count: number;\n  exceeded: string;\n  severity: string;\n  crap?: number;\n  coverage_pct?: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface FileHealthScore {\n  path: string;\n  fan_in: number;\n  fan_out: number;\n  dead_code_ratio: number;\n  complexity_density: number;\n  maintainability_index: number;\n  total_cyclomatic: number;\n  total_cognitive: number;\n  function_count: number;\n  lines: number;\n  crap_max: number;\n  crap_above_threshold: number;\n  [key: string]: unknown;\n}\n\nexport interface CoverageGaps {\n  summary: {\n    runtime_files: number;\n    covered_files: number;\n    file_coverage_pct: number;\n    untested_files: number;\n    untested_exports: number;\n  };\n  files?: Array<{ path: string; value_export_count: number; [key: string]: unknown }>;\n  exports?: Array<{ path: string; export_name: string; line: number; col: number; [key: string]: unknown }>;\n}\n\nexport interface RefactoringTarget {\n  path: string;\n  priority: number;\n  efficiency: number;\n  recommendation: string;\n  category: string;\n  effort: string;\n  confidence: string;\n  factors?: Array<Record<string, unknown>>;\n  evidence?: Record<string, unknown>;\n  [key: string]: unknown;\n}\n\nexport interface HealthReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  findings: HealthFinding[];\n  summary: Record<string, unknown>;\n  vital_signs?: Record<string, unknown>;\n  health_score?: Record<string, unknown>;\n  file_scores?: FileHealthScore[];\n  coverage_gaps?: CoverageGaps;\n  hotspots?: Array<Record<string, unknown>>;\n  hotspot_summary?: Record<string, unknown>;\n  runtime_coverage?: Record<string, unknown>;\n  large_functions?: Array<Record<string, unknown>>;\n  targets?: RefactoringTarget[];\n  target_thresholds?: Record<string, unknown>;\n  health_trend?: Record<string, unknown>;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface FallowNodeErrorShape {\n  message: string;\n  exitCode: number;\n  code?: string;\n  help?: string;\n  context?: string;\n}\n\nexport type FallowNodeError = Error & FallowNodeErrorShape;\n\nexport function detectDeadCode(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectCircularDependencies(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectBoundaryViolations(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectDuplication(options?: DuplicationOptions): Promise<DuplicationReport>;\nexport function computeComplexity(options?: ComplexityOptions): Promise<HealthReport>;\nexport function computeHealth(options?: ComplexityOptions): Promise<HealthReport"
+        },
+        {
+          "file": "crates/napi/types/index.d.ts",
+          "start_line": 1,
+          "end_line": 363,
+          "start_col": 0,
+          "end_col": 80,
+          "fragment": "export interface AnalysisOptions {\n  root?: string;\n  configPath?: string;\n  noCache?: boolean;\n  threads?: number;\n  production?: boolean;\n  changedSince?: string;\n  workspace?: string[];\n  changedWorkspaces?: string;\n  explain?: boolean;\n}\n\nexport interface DeadCodeOptions extends AnalysisOptions {\n  unusedFiles?: boolean;\n  unusedExports?: boolean;\n  unusedDeps?: boolean;\n  unusedTypes?: boolean;\n  unusedEnumMembers?: boolean;\n  unusedClassMembers?: boolean;\n  unresolvedImports?: boolean;\n  unlistedDeps?: boolean;\n  duplicateExports?: boolean;\n  circularDeps?: boolean;\n  boundaryViolations?: boolean;\n  staleSuppressions?: boolean;\n  files?: string[];\n  includeEntryExports?: boolean;\n}\n\nexport type DuplicationMode = 'strict' | 'mild' | 'weak' | 'semantic';\n\nexport interface DuplicationOptions extends AnalysisOptions {\n  mode?: DuplicationMode;\n  minTokens?: number;\n  minLines?: number;\n  threshold?: number;\n  skipLocal?: boolean;\n  crossLanguage?: boolean;\n  ignoreImports?: boolean;\n  top?: number;\n}\n\nexport type ComplexitySort = 'cyclomatic' | 'cognitive' | 'lines' | 'severity';\nexport type OwnershipEmailMode = 'raw' | 'handle' | 'hash';\nexport type TargetEffort = 'low' | 'medium' | 'high';\n\nexport interface ComplexityOptions extends AnalysisOptions {\n  maxCyclomatic?: number;\n  maxCognitive?: number;\n  maxCrap?: number;\n  top?: number;\n  sort?: ComplexitySort;\n  complexity?: boolean;\n  fileScores?: boolean;\n  coverageGaps?: boolean;\n  hotspots?: boolean;\n  ownership?: boolean;\n  ownershipEmails?: OwnershipEmailMode;\n  targets?: boolean;\n  effort?: TargetEffort;\n  score?: boolean;\n  since?: string;\n  minCommits?: number;\n  coverage?: string;\n  coverageRoot?: string;\n}\n\nexport interface AnalysisAction {\n  type?: string;\n  auto_fixable?: boolean;\n  description?: string;\n  comment?: string;\n  note?: string;\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeSummary {\n  total_issues: number;\n  unused_files: number;\n  unused_exports: number;\n  unused_types: number;\n  unused_dependencies: number;\n  unused_enum_members: number;\n  unused_class_members: number;\n  unresolved_imports: number;\n  unlisted_dependencies: number;\n  duplicate_exports: number;\n  type_only_dependencies: number;\n  test_only_dependencies: number;\n  circular_dependencies: number;\n  boundary_violations: number;\n  stale_suppressions: number;\n}\n\nexport interface EntryPointSummary {\n  total: number;\n  sources: Record<string, number>;\n}\n\nexport interface UnusedFileFinding {\n  path: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedExportFinding {\n  path: string;\n  export_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  used_in_workspaces?: string[];\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedMemberFinding {\n  path: string;\n  parent_name: string;\n  member_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnresolvedImportFinding {\n  path: string;\n  specifier: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnlistedDependencyFinding {\n  package_name: string;\n  imported_from: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicateExportFinding {\n  export_name: string;\n  locations: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TypeOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TestOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface CircularDependencyFinding {\n  files: string[];\n  length: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface BoundaryViolationFinding {\n  from_path: string;\n  to_path: string;\n  line: number;\n  col: number;\n  from_zone?: string;\n  to_zone?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface StaleSuppressionFinding {\n  path: string;\n  line: number;\n  col: number;\n  issue_kind?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  total_issues: number;\n  summary: DeadCodeSummary;\n  entry_points?: EntryPointSummary;\n  unused_files: UnusedFileFinding[];\n  unused_exports: UnusedExportFinding[];\n  unused_types: UnusedExportFinding[];\n  unused_dependencies: UnusedDependencyFinding[];\n  unused_dev_dependencies: UnusedDependencyFinding[];\n  unused_optional_dependencies: UnusedDependencyFinding[];\n  unused_enum_members: UnusedMemberFinding[];\n  unused_class_members: UnusedMemberFinding[];\n  unresolved_imports: UnresolvedImportFinding[];\n  unlisted_dependencies: UnlistedDependencyFinding[];\n  duplicate_exports: DuplicateExportFinding[];\n  type_only_dependencies: TypeOnlyDependencyFinding[];\n  test_only_dependencies: TestOnlyDependencyFinding[];\n  circular_dependencies: CircularDependencyFinding[];\n  boundary_violations: BoundaryViolationFinding[];\n  stale_suppressions: StaleSuppressionFinding[];\n  _meta?: Record<string, unknown>;\n}\n\nexport interface CloneInstance {\n  file: string;\n  start_line: number;\n  end_line: number;\n  start_col: number;\n  end_col: number;\n  fragment?: string;\n  [key: string]: unknown;\n}\n\nexport interface CloneGroup {\n  instances: CloneInstance[];\n  token_count: number;\n  line_count: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicationStats {\n  total_files: number;\n  files_with_clones: number;\n  total_lines: number;\n  duplicated_lines: number;\n  total_tokens: number;\n  duplicated_tokens: number;\n  clone_groups: number;\n  clone_instances: number;\n  duplication_percentage: number;\n}\n\nexport interface DuplicationReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  clone_groups: CloneGroup[];\n  clone_families?: Record<string, unknown>[];\n  mirrored_directories?: Record<string, unknown>[];\n  stats: DuplicationStats;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface HealthFinding {\n  path: string;\n  name: string;\n  line: number;\n  col: number;\n  cyclomatic: number;\n  cognitive: number;\n  line_count: number;\n  param_count: number;\n  exceeded: string;\n  severity: string;\n  crap?: number;\n  coverage_pct?: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface FileHealthScore {\n  path: string;\n  fan_in: number;\n  fan_out: number;\n  dead_code_ratio: number;\n  complexity_density: number;\n  maintainability_index: number;\n  total_cyclomatic: number;\n  total_cognitive: number;\n  function_count: number;\n  lines: number;\n  crap_max: number;\n  crap_above_threshold: number;\n  [key: string]: unknown;\n}\n\nexport interface CoverageGaps {\n  summary: {\n    runtime_files: number;\n    covered_files: number;\n    file_coverage_pct: number;\n    untested_files: number;\n    untested_exports: number;\n  };\n  files?: Array<{ path: string; value_export_count: number; [key: string]: unknown }>;\n  exports?: Array<{ path: string; export_name: string; line: number; col: number; [key: string]: unknown }>;\n}\n\nexport interface RefactoringTarget {\n  path: string;\n  priority: number;\n  efficiency: number;\n  recommendation: string;\n  category: string;\n  effort: string;\n  confidence: string;\n  factors?: Array<Record<string, unknown>>;\n  evidence?: Record<string, unknown>;\n  [key: string]: unknown;\n}\n\nexport interface HealthReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  findings: HealthFinding[];\n  summary: Record<string, unknown>;\n  vital_signs?: Record<string, unknown>;\n  health_score?: Record<string, unknown>;\n  file_scores?: FileHealthScore[];\n  coverage_gaps?: CoverageGaps;\n  hotspots?: Array<Record<string, unknown>>;\n  hotspot_summary?: Record<string, unknown>;\n  runtime_coverage?: Record<string, unknown>;\n  large_functions?: Array<Record<string, unknown>>;\n  targets?: RefactoringTarget[];\n  target_thresholds?: Record<string, unknown>;\n  health_trend?: Record<string, unknown>;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface FallowNodeErrorShape {\n  message: string;\n  exitCode: number;\n  code?: string;\n  help?: string;\n  context?: string;\n}\n\nexport type FallowNodeError = Error & FallowNodeErrorShape;\n\nexport function detectDeadCode(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectCircularDependencies(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectBoundaryViolations(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectDuplication(options?: DuplicationOptions): Promise<DuplicationReport>;\nexport function computeComplexity(options?: ComplexityOptions): Promise<HealthReport>;\nexport function computeHealth(options?: ComplexityOptions): Promise<HealthReport"
+        }
+      ],
+      "token_count": 1392,
+      "line_count": 363,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (363 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 79,
+          "end_line": 89,
+          "start_col": 98,
+          "end_col": 23,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm') {\n      try {\n        return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 494,
+          "end_line": 504,
+          "start_col": 100,
+          "end_col": 23,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm') {\n      try {\n        return require("
+        }
+      ],
+      "token_count": 66,
+      "line_count": 11,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (11 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 79,
+          "end_line": 86,
+          "start_col": 98,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 95,
+          "end_line": 102,
+          "start_col": 101,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 116,
+          "end_line": 123,
+          "start_col": 98,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 132,
+          "end_line": 139,
+          "start_col": 99,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 149,
+          "end_line": 156,
+          "start_col": 100,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 165,
+          "end_line": 172,
+          "start_col": 101,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 184,
+          "end_line": 191,
+          "start_col": 99,
+          "end_col": 5,
+          "fragment": ").version\n      if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n        throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n      }\n      return binding\n    } catch (e) {\n      loadErrors.push(e)\n    }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 200,
+          "end_line": 207,
+          "start_col": 95,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 216,
+          "end_line": 223,
+          "start_col": 97,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 236,
+          "end_line": 243,
+          "start_col": 96,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 252,
+          "end_line": 259,
+          "start_col": 98,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 273,
+          "end_line": 280,
+          "start_col": 101,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 289,
+          "end_line": 296,
+          "start_col": 100,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 307,
+          "end_line": 314,
+          "start_col": 103,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 323,
+          "end_line": 330,
+          "start_col": 102,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 341,
+          "end_line": 348,
+          "start_col": 107,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 357,
+          "end_line": 364,
+          "start_col": 106,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 375,
+          "end_line": 382,
+          "start_col": 105,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 391,
+          "end_line": 398,
+          "start_col": 104,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 409,
+          "end_line": 416,
+          "start_col": 105,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 425,
+          "end_line": 432,
+          "start_col": 104,
+          "end_col": 9,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 442,
+          "end_line": 449,
+          "start_col": 100,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 458,
+          "end_line": 465,
+          "start_col": 100,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 478,
+          "end_line": 485,
+          "start_col": 102,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 494,
+          "end_line": 501,
+          "start_col": 100,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 510,
+          "end_line": 517,
+          "start_col": 100,
+          "end_col": 7,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+        }
+      ],
+      "token_count": 50,
+      "line_count": 8,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (8 lines, 26 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 95,
+          "end_line": 106,
+          "start_col": 101,
+          "end_col": 41,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on Android ${process.arch}`))\n    }\n  } else if (process.platform === 'win32'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 165,
+          "end_line": 176,
+          "start_col": 101,
+          "end_col": 42,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on Windows: ${process.arch}`))\n    }\n  } else if (process.platform === 'darwin'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 216,
+          "end_line": 227,
+          "start_col": 97,
+          "end_col": 43,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on macOS: ${process.arch}`))\n    }\n  } else if (process.platform === 'freebsd'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 252,
+          "end_line": 263,
+          "start_col": 98,
+          "end_col": 41,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on FreeBSD: ${process.arch}`))\n    }\n  } else if (process.platform === 'linux'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 458,
+          "end_line": 469,
+          "start_col": 100,
+          "end_col": 47,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on Linux: ${process.arch}`))\n    }\n  } else if (process.platform === 'openharmony'"
+        }
+      ],
+      "token_count": 78,
+      "line_count": 12,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (12 lines, 5 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 116,
+          "end_line": 126,
+          "start_col": 98,
+          "end_col": 23,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n      } else {\n        try {\n        return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 273,
+          "end_line": 283,
+          "start_col": 101,
+          "end_col": 25,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 307,
+          "end_line": 317,
+          "start_col": 103,
+          "end_col": 25,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 341,
+          "end_line": 351,
+          "start_col": 107,
+          "end_col": 25,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 375,
+          "end_line": 385,
+          "start_col": 105,
+          "end_col": 25,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 409,
+          "end_line": 419,
+          "start_col": 105,
+          "end_col": 25,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+        }
+      ],
+      "token_count": 58,
+      "line_count": 11,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (11 lines, 6 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 132,
+          "end_line": 141,
+          "start_col": 99,
+          "end_col": 38,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n      }\n    } else if (process.arch === 'ia32'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 289,
+          "end_line": 298,
+          "start_col": 100,
+          "end_col": 39,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'arm64'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 323,
+          "end_line": 332,
+          "start_col": 102,
+          "end_col": 37,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'arm'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 357,
+          "end_line": 366,
+          "start_col": 106,
+          "end_col": 41,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'loong64'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 391,
+          "end_line": 400,
+          "start_col": 104,
+          "end_col": 41,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'riscv64'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 425,
+          "end_line": 434,
+          "start_col": 104,
+          "end_col": 39,
+          "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'ppc64'"
+        }
+      ],
+      "token_count": 59,
+      "line_count": 10,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (10 lines, 6 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 149,
+          "end_line": 159,
+          "start_col": 100,
+          "end_col": 23,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm64') {\n      try {\n        return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 200,
+          "end_line": 210,
+          "start_col": 95,
+          "end_col": 23,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm64') {\n      try {\n        return require("
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 236,
+          "end_line": 246,
+          "start_col": 96,
+          "end_col": 23,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm64') {\n      try {\n        return require("
+        }
+      ],
+      "token_count": 66,
+      "line_count": 11,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (11 lines, 3 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 442,
+          "end_line": 450,
+          "start_col": 100,
+          "end_col": 39,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 's390x'"
+        },
+        {
+          "file": "crates/napi/index.js",
+          "start_line": 478,
+          "end_line": 486,
+          "start_col": 102,
+          "end_col": 37,
+          "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'x64'"
+        }
+      ],
+      "token_count": 58,
+      "line_count": 9,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type1-exact/cache-manager-a.ts",
+          "start_line": 2,
+          "end_line": 133,
+          "start_col": 0,
+          "end_col": 26,
+          "fragment": "interface CacheEntry<T> {\n  value: T;\n  expiresAt: number;\n  createdAt: number;\n  accessCount: number;\n}\n\ninterface CacheStats {\n  hits: number;\n  misses: number;\n  evictions: number;\n  size: number;\n}\n\nexport class LRUCache<T> {\n  private cache = new Map<string, CacheEntry<T>>();\n  private readonly maxSize: number;\n  private readonly defaultTTL: number;\n  private stats: CacheStats = { hits: 0, misses: 0, evictions: 0, size: 0 };\n\n  constructor(maxSize = 500, defaultTTL = 300000) {\n    this.maxSize = maxSize;\n    this.defaultTTL = defaultTTL;\n  }\n\n  get(key: string): T | undefined {\n    const entry = this.cache.get(key);\n    if (!entry) {\n      this.stats.misses++;\n      return undefined;\n    }\n\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.misses++;\n      this.stats.size--;\n      return undefined;\n    }\n\n    // Move to end (most recently used)\n    this.cache.delete(key);\n    entry.accessCount++;\n    this.cache.set(key, entry);\n    this.stats.hits++;\n    return entry.value;\n  }\n\n  set(key: string, value: T, ttl?: number): void {\n    if (this.cache.has(key)) {\n      this.cache.delete(key);\n    } else if (this.cache.size >= this.maxSize) {\n      this.evictOldest();\n    }\n\n    const entry: CacheEntry<T> = {\n      value,\n      expiresAt: Date.now() + (ttl ?? this.defaultTTL),\n      createdAt: Date.now(),\n      accessCount: 0,\n    };\n\n    this.cache.set(key, entry);\n    this.stats.size = this.cache.size;\n  }\n\n  delete(key: string): boolean {\n    const deleted = this.cache.delete(key);\n    if (deleted) {\n      this.stats.size = this.cache.size;\n    }\n    return deleted;\n  }\n\n  clear(): void {\n    this.cache.clear();\n    this.stats.size = 0;\n  }\n\n  has(key: string): boolean {\n    const entry = this.cache.get(key);\n    if (!entry) return false;\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.size--;\n      return false;\n    }\n    return true;\n  }\n\n  private evictOldest(): void {\n    const firstKey = this.cache.keys().next().value;\n    if (firstKey !== undefined) {\n      this.cache.delete(firstKey);\n      this.stats.evictions++;\n      this.stats.size--;\n    }\n  }\n\n  getStats(): CacheStats {\n    return { ...this.stats };\n  }\n\n  prune(): number {\n    let pruned = 0;\n    const now = Date.now();\n    for (const [key, entry] of this.cache) {\n      if (now > entry.expiresAt) {\n        this.cache.delete(key);\n        pruned++;\n      }\n    }\n    this.stats.size = this.cache.size;\n    return pruned;\n  }\n\n  keys(): string[] {\n    return Array.from(this.cache.keys());\n  }\n\n  values(): T[] {\n    const result: T[] = [];\n    const now = Date.now();\n    for (const entry of this.cache.values()) {\n      if (now <= entry.expiresAt) {\n        result.push(entry.value);\n      }\n    }\n    return result;\n  }\n\n  get size(): number {\n    return this.cache.size"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type1-exact/cache-manager-b.ts",
+          "start_line": 2,
+          "end_line": 133,
+          "start_col": 0,
+          "end_col": 26,
+          "fragment": "interface CacheEntry<T> {\n  value: T;\n  expiresAt: number;\n  createdAt: number;\n  accessCount: number;\n}\n\ninterface CacheStats {\n  hits: number;\n  misses: number;\n  evictions: number;\n  size: number;\n}\n\nexport class LRUCache<T> {\n  private cache = new Map<string, CacheEntry<T>>();\n  private readonly maxSize: number;\n  private readonly defaultTTL: number;\n  private stats: CacheStats = { hits: 0, misses: 0, evictions: 0, size: 0 };\n\n  constructor(maxSize = 500, defaultTTL = 300000) {\n    this.maxSize = maxSize;\n    this.defaultTTL = defaultTTL;\n  }\n\n  get(key: string): T | undefined {\n    const entry = this.cache.get(key);\n    if (!entry) {\n      this.stats.misses++;\n      return undefined;\n    }\n\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.misses++;\n      this.stats.size--;\n      return undefined;\n    }\n\n    // Move to end (most recently used)\n    this.cache.delete(key);\n    entry.accessCount++;\n    this.cache.set(key, entry);\n    this.stats.hits++;\n    return entry.value;\n  }\n\n  set(key: string, value: T, ttl?: number): void {\n    if (this.cache.has(key)) {\n      this.cache.delete(key);\n    } else if (this.cache.size >= this.maxSize) {\n      this.evictOldest();\n    }\n\n    const entry: CacheEntry<T> = {\n      value,\n      expiresAt: Date.now() + (ttl ?? this.defaultTTL),\n      createdAt: Date.now(),\n      accessCount: 0,\n    };\n\n    this.cache.set(key, entry);\n    this.stats.size = this.cache.size;\n  }\n\n  delete(key: string): boolean {\n    const deleted = this.cache.delete(key);\n    if (deleted) {\n      this.stats.size = this.cache.size;\n    }\n    return deleted;\n  }\n\n  clear(): void {\n    this.cache.clear();\n    this.stats.size = 0;\n  }\n\n  has(key: string): boolean {\n    const entry = this.cache.get(key);\n    if (!entry) return false;\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.size--;\n      return false;\n    }\n    return true;\n  }\n\n  private evictOldest(): void {\n    const firstKey = this.cache.keys().next().value;\n    if (firstKey !== undefined) {\n      this.cache.delete(firstKey);\n      this.stats.evictions++;\n      this.stats.size--;\n    }\n  }\n\n  getStats(): CacheStats {\n    return { ...this.stats };\n  }\n\n  prune(): number {\n    let pruned = 0;\n    const now = Date.now();\n    for (const [key, entry] of this.cache) {\n      if (now > entry.expiresAt) {\n        this.cache.delete(key);\n        pruned++;\n      }\n    }\n    this.stats.size = this.cache.size;\n    return pruned;\n  }\n\n  keys(): string[] {\n    return Array.from(this.cache.keys());\n  }\n\n  values(): T[] {\n    const result: T[] = [];\n    const now = Date.now();\n    for (const entry of this.cache.values()) {\n      if (now <= entry.expiresAt) {\n        result.push(entry.value);\n      }\n    }\n    return result;\n  }\n\n  get size(): number {\n    return this.cache.size"
+        }
+      ],
+      "token_count": 692,
+      "line_count": 132,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (132 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type1-exact/data-processor-a.ts",
+          "start_line": 2,
+          "end_line": 144,
+          "start_col": 0,
+          "end_col": 30,
+          "fragment": "import { EventEmitter } from 'events';\n\ninterface DataRecord {\n  id: string;\n  timestamp: number;\n  payload: Record<string, unknown>;\n  metadata: {\n    source: string;\n    version: number;\n    tags: string[];\n  };\n}\n\ninterface ProcessingResult {\n  processed: number;\n  failed: number;\n  skipped: number;\n  duration: number;\n}\n\nexport class DataProcessor extends EventEmitter {\n  private buffer: DataRecord[] = [];\n  private readonly maxBufferSize: number;\n  private readonly flushInterval: number;\n  private timer: ReturnType<typeof setInterval> | null = null;\n  private isProcessing = false;\n\n  constructor(maxBufferSize = 1000, flushInterval = 5000) {\n    super();\n    this.maxBufferSize = maxBufferSize;\n    this.flushInterval = flushInterval;\n  }\n\n  async start(): Promise<void> {\n    if (this.timer) {\n      throw new Error('Processor already started');\n    }\n    this.timer = setInterval(() => this.flush(), this.flushInterval);\n    this.emit('started');\n  }\n\n  async stop(): Promise<void> {\n    if (this.timer) {\n      clearInterval(this.timer);\n      this.timer = null;\n    }\n    await this.flush();\n    this.emit('stopped');\n  }\n\n  async ingest(record: DataRecord): Promise<void> {\n    if (!this.validateRecord(record)) {\n      this.emit('invalid', record);\n      return;\n    }\n\n    this.buffer.push(record);\n\n    if (this.buffer.length >= this.maxBufferSize) {\n      await this.flush();\n    }\n  }\n\n  async flush(): Promise<ProcessingResult> {\n    if (this.isProcessing || this.buffer.length === 0) {\n      return { processed: 0, failed: 0, skipped: 0, duration: 0 };\n    }\n\n    this.isProcessing = true;\n    const batch = this.buffer.splice(0);\n    const startTime = Date.now();\n\n    let processed = 0;\n    let failed = 0;\n    let skipped = 0;\n\n    for (const record of batch) {\n      try {\n        if (this.shouldSkip(record)) {\n          skipped++;\n          continue;\n        }\n\n        const transformed = this.transform(record);\n        await this.persist(transformed);\n        processed++;\n      } catch (error) {\n        failed++;\n        this.emit('error', { record, error });\n      }\n    }\n\n    const duration = Date.now() - startTime;\n    this.isProcessing = false;\n\n    const result: ProcessingResult = { processed, failed, skipped, duration };\n    this.emit('flushed', result);\n    return result;\n  }\n\n  private validateRecord(record: DataRecord): boolean {\n    if (!record.id || typeof record.id !== 'string') return false;\n    if (!record.timestamp || record.timestamp <= 0) return false;\n    if (!record.payload || typeof record.payload !== 'object') return false;\n    if (!record.metadata?.source) return false;\n    return true;\n  }\n\n  private shouldSkip(record: DataRecord): boolean {\n    const age = Date.now() - record.timestamp;\n    const maxAge = 24 * 60 * 60 * 1000; // 24 hours\n    if (age > maxAge) return true;\n    if (record.metadata.tags.includes('test')) return true;\n    return false;\n  }\n\n  private transform(record: DataRecord): DataRecord {\n    return {\n      ...record,\n      payload: {\n        ...record.payload,\n        processedAt: Date.now(),\n        processorVersion: '2.0',\n      },\n      metadata: {\n        ...record.metadata,\n        version: record.metadata.version + 1,\n      },\n    };\n  }\n\n  private async persist(record: DataRecord): Promise<void> {\n    // Simulate async persistence\n    await new Promise((resolve) => setTimeout(resolve, 1));\n    this.emit('persisted', record.id);\n  }\n\n  getBufferSize(): number {\n    return this.buffer.length;\n  }\n\n  isRunning(): boolean {\n    return this.timer !== null"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type1-exact/data-processor-b.ts",
+          "start_line": 2,
+          "end_line": 144,
+          "start_col": 0,
+          "end_col": 30,
+          "fragment": "import { EventEmitter } from 'events';\n\ninterface DataRecord {\n  id: string;\n  timestamp: number;\n  payload: Record<string, unknown>;\n  metadata: {\n    source: string;\n    version: number;\n    tags: string[];\n  };\n}\n\ninterface ProcessingResult {\n  processed: number;\n  failed: number;\n  skipped: number;\n  duration: number;\n}\n\nexport class DataProcessor extends EventEmitter {\n  private buffer: DataRecord[] = [];\n  private readonly maxBufferSize: number;\n  private readonly flushInterval: number;\n  private timer: ReturnType<typeof setInterval> | null = null;\n  private isProcessing = false;\n\n  constructor(maxBufferSize = 1000, flushInterval = 5000) {\n    super();\n    this.maxBufferSize = maxBufferSize;\n    this.flushInterval = flushInterval;\n  }\n\n  async start(): Promise<void> {\n    if (this.timer) {\n      throw new Error('Processor already started');\n    }\n    this.timer = setInterval(() => this.flush(), this.flushInterval);\n    this.emit('started');\n  }\n\n  async stop(): Promise<void> {\n    if (this.timer) {\n      clearInterval(this.timer);\n      this.timer = null;\n    }\n    await this.flush();\n    this.emit('stopped');\n  }\n\n  async ingest(record: DataRecord): Promise<void> {\n    if (!this.validateRecord(record)) {\n      this.emit('invalid', record);\n      return;\n    }\n\n    this.buffer.push(record);\n\n    if (this.buffer.length >= this.maxBufferSize) {\n      await this.flush();\n    }\n  }\n\n  async flush(): Promise<ProcessingResult> {\n    if (this.isProcessing || this.buffer.length === 0) {\n      return { processed: 0, failed: 0, skipped: 0, duration: 0 };\n    }\n\n    this.isProcessing = true;\n    const batch = this.buffer.splice(0);\n    const startTime = Date.now();\n\n    let processed = 0;\n    let failed = 0;\n    let skipped = 0;\n\n    for (const record of batch) {\n      try {\n        if (this.shouldSkip(record)) {\n          skipped++;\n          continue;\n        }\n\n        const transformed = this.transform(record);\n        await this.persist(transformed);\n        processed++;\n      } catch (error) {\n        failed++;\n        this.emit('error', { record, error });\n      }\n    }\n\n    const duration = Date.now() - startTime;\n    this.isProcessing = false;\n\n    const result: ProcessingResult = { processed, failed, skipped, duration };\n    this.emit('flushed', result);\n    return result;\n  }\n\n  private validateRecord(record: DataRecord): boolean {\n    if (!record.id || typeof record.id !== 'string') return false;\n    if (!record.timestamp || record.timestamp <= 0) return false;\n    if (!record.payload || typeof record.payload !== 'object') return false;\n    if (!record.metadata?.source) return false;\n    return true;\n  }\n\n  private shouldSkip(record: DataRecord): boolean {\n    const age = Date.now() - record.timestamp;\n    const maxAge = 24 * 60 * 60 * 1000; // 24 hours\n    if (age > maxAge) return true;\n    if (record.metadata.tags.includes('test')) return true;\n    return false;\n  }\n\n  private transform(record: DataRecord): DataRecord {\n    return {\n      ...record,\n      payload: {\n        ...record.payload,\n        processedAt: Date.now(),\n        processorVersion: '2.0',\n      },\n      metadata: {\n        ...record.metadata,\n        version: record.metadata.version + 1,\n      },\n    };\n  }\n\n  private async persist(record: DataRecord): Promise<void> {\n    // Simulate async persistence\n    await new Promise((resolve) => setTimeout(resolve, 1));\n    this.emit('persisted', record.id);\n  }\n\n  getBufferSize(): number {\n    return this.buffer.length;\n  }\n\n  isRunning(): boolean {\n    return this.timer !== null"
+        }
+      ],
+      "token_count": 721,
+      "line_count": 143,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (143 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-a.ts",
+          "start_line": 29,
+          "end_line": 37,
+          "start_col": 6,
+          "end_col": 13,
+          "fragment": "priority,\n    };\n\n    const existing = this.subscriptions.get(event) ?? [];\n    existing.push(subscription);\n    existing.sort((a, b) => b.priority - a.priority);\n    this.subscriptions.set(event, existing);\n\n    return id"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-a.ts",
+          "start_line": 47,
+          "end_line": 55,
+          "start_col": 6,
+          "end_col": 13,
+          "fragment": "priority,\n    };\n\n    const existing = this.subscriptions.get(event) ?? [];\n    existing.push(subscription);\n    existing.sort((a, b) => b.priority - a.priority);\n    this.subscriptions.set(event, existing);\n\n    return id"
+        }
+      ],
+      "token_count": 66,
+      "line_count": 9,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-b.ts",
+          "start_line": 29,
+          "end_line": 37,
+          "start_col": 6,
+          "end_col": 14,
+          "fragment": "weight,\n    };\n\n    const current = this.registrations.get(channel) ?? [];\n    current.push(registration);\n    current.sort((a, b) => b.weight - a.weight);\n    this.registrations.set(channel, current);\n\n    return uid"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-b.ts",
+          "start_line": 47,
+          "end_line": 55,
+          "start_col": 6,
+          "end_col": 14,
+          "fragment": "weight,\n    };\n\n    const current = this.registrations.get(channel) ?? [];\n    current.push(registration);\n    current.sort((a, b) => b.weight - a.weight);\n    this.registrations.set(channel, current);\n\n    return uid"
+        }
+      ],
+      "token_count": 66,
+      "line_count": 9,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (9 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+          "start_line": 15,
+          "end_line": 39,
+          "start_col": 31,
+          "end_col": 35,
+          "fragment": "{\n      data,\n      priority,\n      addedAt: Date.now(),\n      id,\n    };\n\n    // Binary search for insertion point\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > priority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return id;\n  }\n\n  dequeue(): T | undefined {\n    const item = this.items.shift()"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+          "start_line": 17,
+          "end_line": 42,
+          "start_col": 31,
+          "end_col": 35,
+          "fragment": "{\n      data,\n      priority,\n      addedAt: Date.now(),\n      id,\n      retryCount: 0,\n    };\n\n    // Binary search for insertion point\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > priority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return id;\n  }\n\n  dequeue(): T | undefined {\n    const item = this.items.shift()"
+        }
+      ],
+      "token_count": 95,
+      "line_count": 26,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (26 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+          "start_line": 47,
+          "end_line": 51,
+          "start_col": 2,
+          "end_col": 15,
+          "fragment": "remove(id: string): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n    this.items.splice(index, 1);\n    return true"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+          "start_line": 57,
+          "end_line": 61,
+          "start_col": 2,
+          "end_col": 15,
+          "fragment": "remove(id: string): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n    this.items.splice(index, 1);\n    return true"
+        }
+      ],
+      "token_count": 58,
+      "line_count": 5,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (5 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+          "start_line": 56,
+          "end_line": 74,
+          "start_col": 4,
+          "end_col": 17,
+          "fragment": "this.nextId = 0;\n  }\n\n  get size(): number {\n    return this.items.length;\n  }\n\n  isEmpty(): boolean {\n    return this.items.length === 0;\n  }\n\n  toArray(): T[] {\n    return this.items.map((item) => item.data);\n  }\n\n  drain(): T[] {\n    const result = this.items.map((item) => item.data);\n    this.items = [];\n    return result"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+          "start_line": 88,
+          "end_line": 106,
+          "start_col": 4,
+          "end_col": 17,
+          "fragment": "this.processedCount = 0;\n  }\n\n  get size(): number {\n    return this.items.length;\n  }\n\n  isEmpty(): boolean {\n    return this.items.length === 0;\n  }\n\n  toArray(): T[] {\n    return this.items.map((item) => item.data);\n  }\n\n  drain(): T[] {\n    const result = this.items.map((item) => item.data);\n    this.items = [];\n    return result"
+        }
+      ],
+      "token_count": 91,
+      "line_count": 19,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (19 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+          "start_line": 77,
+          "end_line": 98,
+          "start_col": 2,
+          "end_col": 15,
+          "fragment": "updatePriority(id: string, newPriority: number): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n\n    const item = this.items[index];\n    this.items.splice(index, 1);\n\n    item.priority = newPriority;\n\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > newPriority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return true"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+          "start_line": 113,
+          "end_line": 134,
+          "start_col": 2,
+          "end_col": 15,
+          "fragment": "updatePriority(id: string, newPriority: number): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n\n    const item = this.items[index];\n    this.items.splice(index, 1);\n\n    item.priority = newPriority;\n\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > newPriority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return true"
+        }
+      ],
+      "token_count": 152,
+      "line_count": 22,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (22 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+          "start_line": 34,
+          "end_line": 43,
+          "start_col": 10,
+          "end_col": 9,
+          "fragment": "errors: ValidationError[] = [];\n\n    for (const [field, rules] of this.rules) {\n      const value = data[field];\n\n      for (const rule of rules) {\n        const error = this.checkRule(field, value, rule);\n        if (error) {\n          errors.push(error);\n        }"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts",
+          "start_line": 43,
+          "end_line": 56,
+          "start_col": 10,
+          "end_col": 9,
+          "fragment": "warnings: ValidationError[] = [];\n\n    for (const [field, rules] of this.rules) {\n      const value = data[field];\n\n      for (const rule of rules) {\n        const error = this.checkRule(field, value, rule);\n        if (error) {\n          if (error.severity === 'warning') {\n            warnings.push(error);\n          } else {\n            errors.push(error);\n          }\n        }"
+        }
+      ],
+      "token_count": 53,
+      "line_count": 14,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (14 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+          "start_line": 47,
+          "end_line": 54,
+          "start_col": 11,
+          "end_col": 65,
+          "fragment": "{ valid: errors.length === 0, errors };\n  }\n\n  private checkRule(field: string, value: unknown, rule: ValidationRule): ValidationError | null {\n    switch (rule.type) {\n      case 'required':\n        if (value === undefined || value === null || value === '') {\n          return { field, rule: 'required', message: rule.message"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts",
+          "start_line": 60,
+          "end_line": 67,
+          "start_col": 11,
+          "end_col": 65,
+          "fragment": "{ valid: errors.length === 0, errors, warnings, validatedAt: Date.now() };\n  }\n\n  private checkRule(field: string, value: unknown, rule: ValidationRule): ValidationError | null {\n    switch (rule.type) {\n      case 'required':\n        if (value === undefined || value === null || value === '') {\n          return { field, rule: 'required', message: rule.message"
+        }
+      ],
+      "token_count": 56,
+      "line_count": 8,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (8 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "instances": [
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+          "start_line": 78,
+          "end_line": 109,
+          "start_col": 17,
+          "end_col": 16,
+          "fragment": "{ field, rule: 'custom', message: rule.message };\n        }\n        break;\n    }\n\n    return null;\n  }\n\n  validateField(field: string, value: unknown): ValidationError[] {\n    const rules = this.rules.get(field);\n    if (!rules) return [];\n\n    const errors: ValidationError[] = [];\n    for (const rule of rules) {\n      const error = this.checkRule(field, value, rule);\n      if (error) {\n        errors.push(error);\n      }\n    }\n    return errors;\n  }\n\n  hasRules(field: string): boolean {\n    return this.rules.has(field) && (this.rules.get(field)?.length ?? 0) > 0;\n  }\n\n  getRuleCount(): number {\n    let count = 0;\n    for (const rules of this.rules.values()) {\n      count += rules.length;\n    }\n    return count"
+        },
+        {
+          "file": "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts",
+          "start_line": 107,
+          "end_line": 138,
+          "start_col": 17,
+          "end_col": 16,
+          "fragment": "{ field, rule: 'custom', message: rule.message, severity: 'error', timestamp: Date.now() };\n        }\n        break;\n    }\n\n    return null;\n  }\n\n  validateField(field: string, value: unknown): ValidationError[] {\n    const rules = this.rules.get(field);\n    if (!rules) return [];\n\n    const errors: ValidationError[] = [];\n    for (const rule of rules) {\n      const error = this.checkRule(field, value, rule);\n      if (error) {\n        errors.push(error);\n      }\n    }\n    return errors;\n  }\n\n  hasRules(field: string): boolean {\n    return this.rules.has(field) && (this.rules.get(field)?.length ?? 0) > 0;\n  }\n\n  getRuleCount(): number {\n    let count = 0;\n    for (const rules of this.rules.values()) {\n      count += rules.length;\n    }\n    return count"
+        }
+      ],
+      "token_count": 162,
+      "line_count": 32,
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract duplicated code (32 lines, 2 instances) into a shared function"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    }
+  ],
+  "clone_families": [
+    {
+      "files": [
+        "benchmarks/bench-circular.mjs",
+        "benchmarks/bench-dupes.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 44,
+              "end_line": 97,
+              "start_col": 23,
+              "end_col": 1,
+              "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist', 'report'].includes(e)) continue;\n        const f = join(d, e);\n        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}\n      }\n    } catch {}\n  };\n  walk(dir); return count;\n}\n\nfunction timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }\n\n  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };\n}"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 30,
+              "end_line": 72,
+              "start_col": 98,
+              "end_col": 1,
+              "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist', 'report'].includes(e)) continue;\n        const f = join(d, e);\n        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}\n      }\n    } catch {}\n  };\n  walk(dir); return count;\n}\n\nfunction timeRun(cmd, cmdArgs, cwd) {\n  const start = performance.now();\n  const result = spawnSync(cmd, cmdArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  return {\n    elapsed: performance.now() - start,\n    status: result.status,\n    stdout: result.stdout?.toString() ?? '',\n    stderr: result.stderr?.toString() ?? '',\n  };\n}"
+            }
+          ],
+          "token_count": 246,
+          "line_count": 54
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 71,
+              "end_line": 104,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }\n\n  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };\n}\n\nfunction parseFallowCycles(stdout) {\n  try {\n    const data = JSON.parse(stdout);\n    return data.circular_dependencies?.length ?? 0;\n  } catch { return '?'; }\n}"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 74,
+              "end_line": 111,
+              "start_col": 0,
+              "end_col": 1,
+              "fragment": "function timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout: 600000,\n    maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }\n\n  return { elapsed, status: result.status, stdout: result.stdout?.toString() ?? '', stderr, peakRssBytes };\n}\n\nfunction parseFallowCloneCount(stdout) {\n  try {\n    const data = JSON.parse(stdout);\n    return {\n      groups: data.stats?.clone_groups ?? data.clone_groups?.length ?? '?',\n      instances: data.stats?.clone_instances ?? '?',\n      pct: data.stats?.duplication_percentage?.toFixed(1) ?? '?',\n    };\n  } catch { return { groups: '?', instances: '?', pct: '?' }; }\n}"
+            }
+          ],
+          "token_count": 209,
+          "line_count": 38
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 117,
+              "end_line": 136,
+              "start_col": 10,
+              "end_col": 37,
+              "fragment": "{ return '?'; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir)"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 124,
+              "end_line": 143,
+              "start_col": 10,
+              "end_col": 37,
+              "fragment": "{ return { groups: '?', instances: '?', pct: '?' }; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir)"
+            }
+          ],
+          "token_count": 226,
+          "line_count": 20
+        }
+      ],
+      "total_duplicated_lines": 112,
+      "total_duplicated_tokens": 681,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 3 shared clone groups (112 lines) from bench-circular.mjs, bench-dupes.mjs into benchmarks",
+          "estimated_savings": 112
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 3 duplicated code blocks (112 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 3 shared clone groups (112 lines) from bench-circular.mjs, bench-dupes.mjs into benchmarks"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "benchmarks/bench-circular.mjs",
+        "benchmarks/bench-dupes.mjs",
+        "benchmarks/bench.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 3,
+              "end_line": 23,
+              "start_col": 87,
+              "end_col": 66,
+              "fragment": "'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\n\n// Detect available tools\nconst madgeBin = join(__dirname, 'node_modules', '.bin', 'madge');"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 3,
+              "end_line": 21,
+              "start_col": 72,
+              "end_col": 66,
+              "fragment": "'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst jscpdBin = join(__dirname, 'node_modules', '.bin', 'jscpd');"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 3,
+              "end_line": 21,
+              "start_col": 58,
+              "end_col": 64,
+              "fragment": "'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst knipBin = join(__dirname, 'node_modules', '.bin', 'knip');"
+            }
+          ],
+          "token_count": 270,
+          "line_count": 21
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 44,
+              "end_line": 62,
+              "start_col": 23,
+              "end_col": 43,
+              "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist'"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 30,
+              "end_line": 48,
+              "start_col": 98,
+              "end_col": 43,
+              "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => {\n    try {\n      for (const e of readdirSync(d)) {\n        if (['node_modules', '.git', 'dist'"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 34,
+              "end_line": 49,
+              "start_col": 140,
+              "end_col": 95,
+              "fragment": "RUNS} runs, ${WARMUP} warmup\\n`);\n\nfunction printEnvironment() {\n  const cpus = os.cpus();\n  console.log('Environment:');\n  console.log(`  CPU:     ${cpus[0].model.trim()} (${cpus.length} logical cores)`);\n  console.log(`  RAM:     ${(os.totalmem() / 1024 / 1024 / 1024).toFixed(1)} GB`);\n  console.log(`  OS:      ${os.platform()} ${os.release()} ${os.arch()}`);\n  console.log(`  Node:    ${process.version}`);\n  console.log(`  Rust:    ${rustVersion}`);\n  console.log('');\n}\n\nfunction countSourceFiles(dir) {\n  let count = 0;\n  const walk = d => { try { for (const e of readdirSync(d)) { if (['node_modules','.git','dist'"
+            }
+          ],
+          "token_count": 167,
+          "line_count": 19
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 81,
+              "end_line": 94,
+              "start_col": 4,
+              "end_col": 3,
+              "fragment": "maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 84,
+              "end_line": 97,
+              "start_col": 4,
+              "end_col": 3,
+              "fragment": "maxBuffer: 50 * 1024 * 1024,\n    env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },\n  });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 71,
+              "end_line": 83,
+              "start_col": 85,
+              "end_col": 3,
+              "fragment": "maxBuffer: 50*1024*1024, env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' } });\n  const elapsed = performance.now() - start;\n  const stderr = result.stderr?.toString() ?? '';\n\n  let peakRssBytes = 0;\n  if (isLinux) {\n    const match = stderr.match(/Maximum resident set size \\(kbytes\\): (\\d+)/);\n    if (match) peakRssBytes = parseInt(match[1]) * 1024;\n  } else {\n    // macOS: reports in bytes\n    const match = stderr.match(/(\\d+)\\s+maximum resident set size/);\n    if (match) peakRssBytes = parseInt(match[1]);\n  }"
+            }
+          ],
+          "token_count": 113,
+          "line_count": 14
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 117,
+              "end_line": 230,
+              "start_col": 10,
+              "end_col": 1,
+              "fragment": "{ return '?'; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir);\n  const hasTsConfig = existsSync(join(dir, 'tsconfig.json'));\n  console.log(`### ${name} (${files} source files)\\n`);\n\n  // fallow: JSON output, only circular deps, no cache\n  const fallowArgs = ['dead-code', '--format', 'json', '--quiet', '--no-cache', '--circular-deps'];\n\n  // madge: circular detection with JSON output\n  const madgeArgs = ['--circular', '--json', '--extensions', 'ts,tsx,js,jsx,mjs,cjs', '--no-spinner'];\n  if (hasTsConfig) madgeArgs.push('--ts-config', 'tsconfig.json');\n  madgeArgs.push('src/');\n\n  // dpdm: circular detection with JSON output to stdout\n  const dpdmOutputFile = join(dir, '.dpdm-output.json');\n  const dpdmArgs = ['--no-tree', '--no-warning', '--no-progress', '--output', dpdmOutputFile];\n  if (hasTsConfig) dpdmArgs.push('--tsconfig', 'tsconfig.json');\n  dpdmArgs.push('src/index.ts');\n\n  // Warmup\n  for (let i = 0; i < WARMUP; i++) {\n    timeRunWithMemory(fallowBin, fallowArgs, dir);\n    if (hasMadge) timeRunWithMemory(madgeBin, madgeArgs, dir);\n    if (hasDpdm) {\n      timeRunWithMemory(dpdmBin, dpdmArgs, dir);\n      if (existsSync(dpdmOutputFile)) rmSync(dpdmOutputFile);\n    }\n  }\n\n  // --- Measured runs ---\n  const fallowTimes = [], madgeTimes = [], dpdmTimes = [];\n  let fallowCycles = '?', madgeCycles = '?', dpdmCycles = '?';\n  let fallowRss = 0, madgeRss = 0, dpdmRss = 0;\n\n  for (let i = 0; i < RUNS; i++) {\n    // fallow\n    const fr = timeRunWithMemory(fallowBin, fallowArgs, dir);\n    fallowTimes.push(fr.elapsed);\n    if (i === 0) { fallowCycles = parseFallowCycles(fr.stdout); fallowRss = fr.peakRssBytes; }\n\n    // madge\n    if (hasMadge) {\n      const mr = timeRunWithMemory(madgeBin, madgeArgs, dir);\n      madgeTimes.push(mr.elapsed);\n      if (i === 0) { madgeCycles = parseMadgeCycles(mr.stdout); madgeRss = mr.peakRssBytes; }\n    }\n\n    // dpdm\n    if (hasDpdm) {\n      const dr = timeRunWithMemory(dpdmBin, dpdmArgs, dir);\n      dpdmTimes.push(dr.elapsed);\n      if (i === 0) {\n        try {\n          dpdmCycles = parseDpdmCycles(readFileSync(dpdmOutputFile, 'utf8'));\n        } catch { dpdmCycles = '?'; }\n        dpdmRss = dr.peakRssBytes;\n      }\n      if (existsSync(dpdmOutputFile)) rmSync(dpdmOutputFile);\n    }\n  }\n\n  const fs = stats(fallowTimes);\n  const rows = [\n    { Tool: 'fallow', Min: fmt(fs.min), Mean: fmt(fs.mean), Median: fmt(fs.median), Max: fmt(fs.max), Speedup: '—', Memory: fmtMem(fallowRss), Cycles: fallowCycles },\n  ];\n\n  const result = { name, files, fallow: fs, fallowCycles, fallowRss };\n\n  if (hasMadge && madgeTimes.length > 0) {\n    const ms = stats(madgeTimes);\n    const speedup = ms.median / fs.median;\n    rows.push({ Tool: 'madge', Min: fmt(ms.min), Mean: fmt(ms.mean), Median: fmt(ms.median), Max: fmt(ms.max), Speedup: `1/${speedup.toFixed(1)}x`, Memory: fmtMem(madgeRss), Cycles: madgeCycles });\n    result.madge = ms;\n    result.madgeSpeedup = speedup;\n    result.madgeCycles = madgeCycles;\n    result.madgeRss = madgeRss;\n  }\n\n  if (hasDpdm && dpdmTimes.length > 0) {\n    const ds = stats(dpdmTimes);\n    const speedup = ds.median / fs.median;\n    rows.push({ Tool: 'dpdm', Min: fmt(ds.min), Mean: fmt(ds.mean), Median: fmt(ds.median), Max: fmt(ds.max), Speedup: `1/${speedup.toFixed(1)}x`, Memory: fmtMem(dpdmRss), Cycles: dpdmCycles });\n    result.dpdm = ds;\n    result.dpdmSpeedup = speedup;\n    result.dpdmCycles = dpdmCycles;\n    result.dpdmRss = dpdmRss;\n  }\n\n  console.table(rows);\n  console.log(`  fallow: [${fallowTimes.map(t => t.toFixed(0)).join(', ')}]`);\n  if (hasMadge && madgeTimes.length > 0) console.log(`  madge:  [${madgeTimes.map(t => t.toFixed(0)).join(', ')}]`);\n  if (hasDpdm && dpdmTimes.length > 0) console.log(`  dpdm:   [${dpdmTimes.map(t => t.toFixed(0)).join(', ')}]`);\n  console.log('');\n\n  return result;\n}"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 124,
+              "end_line": 199,
+              "start_col": 10,
+              "end_col": 1,
+              "fragment": "{ return { groups: '?', instances: '?', pct: '?' }; }\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a, b) => a - b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return {\n    min: sorted[0],\n    max: sorted.at(-1),\n    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,\n    median,\n  };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb / 1024).toFixed(2)} GB`; }\n\nfunction benchmarkProject(name, dir) {\n  const files = countSourceFiles(dir);\n  console.log(`### ${name} (${files} source files)\\n`);\n\n  // fallow dupes: JSON output, no cache (cold)\n  const fArgsCold = ['dupes', '--format', 'json', '--no-cache'];\n\n  // jscpd: JSON reporter, output to temp dir\n  const jscpdReportDir = join(dir, 'report');\n  const jArgs = [\n    '--reporters', 'json',\n    '--format', 'typescript,javascript',\n    '--output', jscpdReportDir,\n    '--min-tokens', '50',\n    '--min-lines', '5',\n    '--ignore', '**/node_modules/**,**/dist/**,**/.git/**',\n    '--silent',\n    '.',\n  ];\n\n  // Warmup\n  for (let i = 0; i < WARMUP; i++) {\n    timeRun(fallowBin, fArgsCold, dir);\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n    timeRun(jscpdBin, jArgs, dir);\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n  }\n\n  // --- Cold runs ---\n  const fTimesCold = [], jTimes = [];\n  let fClones = { groups: '?', instances: '?', pct: '?' };\n  let jClones = { groups: '?', instances: '?', pct: '?' };\n  let fPeakRss = 0, jPeakRss = 0;\n\n  for (let i = 0; i < RUNS; i++) {\n    const fr = timeRunWithMemory(fallowBin, fArgsCold, dir);\n    fTimesCold.push(fr.elapsed);\n    if (i === 0) { fClones = parseFallowCloneCount(fr.stdout); fPeakRss = fr.peakRssBytes; }\n\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n    const jr = timeRunWithMemory(jscpdBin, jArgs, dir);\n    jTimes.push(jr.elapsed);\n    if (i === 0) { jClones = parseJscpdCloneCount(jscpdReportDir); jPeakRss = jr.peakRssBytes; }\n    if (existsSync(jscpdReportDir)) rmSync(jscpdReportDir, { recursive: true });\n  }\n\n  const fsCold = stats(fTimesCold), js = stats(jTimes);\n  const speedup = js.median / fsCold.median;\n\n  console.table([\n    { Tool: 'fallow dupes', Min: fmt(fsCold.min), Mean: fmt(fsCold.mean), Median: fmt(fsCold.median), Max: fmt(fsCold.max), Speedup: `${speedup.toFixed(1)}x`, Memory: fmtMem(fPeakRss), 'Clone Groups': fClones.groups, 'Dup %': `${fClones.pct}%` },\n    { Tool: 'jscpd',        Min: fmt(js.min),     Mean: fmt(js.mean),     Median: fmt(js.median),     Max: fmt(js.max),     Speedup: '1.0x',                       Memory: fmtMem(jPeakRss), 'Clone Groups': jClones.groups, 'Dup %': `${jClones.pct}%` },\n  ]);\n  console.log(`  fallow: [${fTimesCold.map(t => t.toFixed(0)).join(', ')}]`);\n  console.log(`  jscpd:  [${jTimes.map(t => t.toFixed(0)).join(', ')}]\\n`);\n\n  return { name, files, fallow: fsCold, jscpd: js, speedup, fClones, jClones, fPeakRss, jPeakRss };\n}"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 133,
+              "end_line": 149,
+              "start_col": 9,
+              "end_col": 1,
+              "fragment": "{ valid: true, issues: countIssues(parsed.data), error: null };\n}\n\nfunction stats(times) {\n  const sorted = [...times].sort((a,b) => a-b);\n  const mid = Math.floor(sorted.length / 2);\n  const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];\n  return { min: sorted[0], max: sorted.at(-1), mean: sorted.reduce((a,b)=>a+b,0)/sorted.length, median };\n}\n\nfunction fmt(ms) { return ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms/1000).toFixed(2)}s`; }\nfunction fmtMem(bytes) { if (bytes === 0) return '?'; const mb = bytes / 1024 / 1024; return mb < 1024 ? `${mb.toFixed(1)} MB` : `${(mb/1024).toFixed(2)} GB`; }\n\nfunction clearFallowCache(dir) {\n  const cacheDir = join(dir, '.fallow');\n  if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });\n}"
+            }
+          ],
+          "token_count": 207,
+          "line_count": 114
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 239,
+              "end_line": 251,
+              "start_col": 70,
+              "end_col": 16,
+              "fragment": ");\n    const order = ['tiny', 'small', 'medium', 'large', 'xlarge'];\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort((a, b) => order.indexOf(a) - order.indexOf(b)))\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (runRealWorld) {\n  const d = join(__dirname, 'fixtures', 'real-world');\n  if (!existsSync(d)) {\n    console.log('No real-world fixtures. Run: npm run download-fixtures\\n');\n  } else {\n    console.log("
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 208,
+              "end_line": 220,
+              "start_col": 60,
+              "end_col": 16,
+              "fragment": ");\n    const order = ['tiny', 'small', 'medium', 'large', 'xlarge'];\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort((a, b) => order.indexOf(a) - order.indexOf(b)))\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (runRealWorld) {\n  const d = join(__dirname, 'fixtures', 'real-world');\n  if (!existsSync(d)) {\n    console.log('No real-world fixtures. Run: npm run download-fixtures\\n');\n  } else {\n    console.log("
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 275,
+              "end_line": 285,
+              "start_col": 46,
+              "end_col": 16,
+              "fragment": ");\n    const order = ['tiny','small','medium','large','xlarge'];\n    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort((a,b) => order.indexOf(a)-order.indexOf(b)))\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\nif (runRealWorld) {\n  const d = join(__dirname, 'fixtures', 'real-world');\n  if (!existsSync(d)) { console.log('No real-world fixtures. Run: npm run download-fixtures\\n'); }\n  else {\n    console.log("
+            }
+          ],
+          "token_count": 146,
+          "line_count": 13
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-circular.mjs",
+              "start_line": 251,
+              "end_line": 258,
+              "start_col": 71,
+              "end_col": 37,
+              "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');"
+            },
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 220,
+              "end_line": 227,
+              "start_col": 61,
+              "end_col": 37,
+              "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 285,
+              "end_line": 291,
+              "start_col": 47,
+              "end_col": 37,
+              "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');"
+            }
+          ],
+          "token_count": 83,
+          "line_count": 8
+        }
+      ],
+      "total_duplicated_lines": 189,
+      "total_duplicated_tokens": 986,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 6 shared clone groups (189 lines) from bench-circular.mjs, bench-dupes.mjs, bench.mjs into benchmarks",
+          "estimated_savings": 378
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 6 duplicated code blocks (189 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 6 shared clone groups (189 lines) from bench-circular.mjs, bench-dupes.mjs, bench.mjs into benchmarks"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "benchmarks/bench-dupes.mjs",
+        "benchmarks/bench.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 3,
+              "end_line": 21,
+              "start_col": 58,
+              "end_col": 66,
+              "fragment": "rmSync } from 'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst jscpdBin = join(__dirname, 'node_modules', '.bin', 'jscpd');"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 3,
+              "end_line": 21,
+              "start_col": 44,
+              "end_col": 64,
+              "fragment": "rmSync } from 'node:fs';\nimport { join, resolve, dirname } from 'node:path';\nimport { fileURLToPath } from 'node:url';\nimport os from 'node:os';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst rootDir = resolve(__dirname, '..');\nconst args = process.argv.slice(2);\nconst hasFilter = args.includes('--synthetic') || args.includes('--real-world');\nconst runSynthetic = args.includes('--synthetic') || !hasFilter;\nconst runRealWorld = args.includes('--real-world') || !hasFilter;\nconst RUNS = parseInt(args.find(a => a.startsWith('--runs='))?.split('=')[1] ?? '5');\nconst WARMUP = parseInt(args.find(a => a.startsWith('--warmup='))?.split('=')[1] ?? '2');\n\nconsole.log('Building fallow (release)...');\nconst buildResult = spawnSync('cargo', ['build', '--release'], { cwd: rootDir, stdio: 'pipe', timeout: 300000 });\nif (buildResult.status !== 0) { console.error('Build failed:', buildResult.stderr?.toString()); process.exit(1); }\nconst fallowBin = join(rootDir, 'target', 'release', 'fallow');\nconst knipBin = join(__dirname, 'node_modules', '.bin', 'knip');"
+            }
+          ],
+          "token_count": 272,
+          "line_count": 19
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 48,
+              "end_line": 62,
+              "start_col": 12,
+              "end_col": 11,
+              "fragment": "['node_modules', '.git', 'dist', 'report'].includes(e)) continue;\n        const f = join(d, e);\n        try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {}\n      }\n    } catch {}\n  };\n  walk(dir); return count;\n}\n\nfunction timeRun(cmd, cmdArgs, cwd) {\n  const start = performance.now();\n  const result = spawnSync(cmd, cmdArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 49,
+              "end_line": 55,
+              "start_col": 66,
+              "end_col": 70,
+              "fragment": "['node_modules','.git','dist'].includes(e)) continue; const f = join(d, e); try { const s = statSync(f); if (s.isDirectory()) walk(f); else if (/\\.(ts|tsx|js|jsx|mjs|cjs)$/.test(e)) count++; } catch {} } } catch {} };\n  walk(dir); return count;\n}\n\nfunction timeRun(cmd, cmdArgs, cwd) {\n  const start = performance.now();\n  const result = spawnSync(cmd, cmdArgs, { cwd, stdio: 'pipe', timeout"
+            }
+          ],
+          "token_count": 115,
+          "line_count": 15
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 69,
+              "end_line": 83,
+              "start_col": 4,
+              "end_col": 11,
+              "fragment": "stdout: result.stdout?.toString() ?? '',\n    stderr: result.stderr?.toString() ?? '',\n  };\n}\n\nfunction timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, {\n    cwd,\n    stdio: 'pipe',\n    timeout"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 60,
+              "end_line": 71,
+              "start_col": 4,
+              "end_col": 75,
+              "fragment": "stdout: result.stdout?.toString() ?? '',\n    stderr: result.stderr?.toString() ?? '',\n  };\n}\n\nfunction timeRunWithMemory(cmd, cmdArgs, cwd) {\n  const isLinux = process.platform === 'linux';\n  const timeBin = '/usr/bin/time';\n  const timeArgs = isLinux ? ['-v', cmd, ...cmdArgs] : ['-l', cmd, ...cmdArgs];\n\n  const start = performance.now();\n  const result = spawnSync(timeBin, timeArgs, { cwd, stdio: 'pipe', timeout"
+            }
+          ],
+          "token_count": 92,
+          "line_count": 15
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/bench-dupes.mjs",
+              "start_line": 220,
+              "end_line": 230,
+              "start_col": 61,
+              "end_col": 18,
+              "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d, x, 'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\n\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');\n  console.table(results.map(r => ({\n    Project: r.name,\n    Files: r.files"
+            },
+            {
+              "file": "benchmarks/bench.mjs",
+              "start_line": 285,
+              "end_line": 294,
+              "start_col": 47,
+              "end_col": 18,
+              "fragment": ");\n    for (const p of readdirSync(d).filter(x => existsSync(join(d,x,'package.json'))).sort())\n      results.push(benchmarkProject(p, join(d, p)));\n  }\n}\nif (results.length > 0) {\n  console.log('\\n=== Summary ===\\n');\n  console.table(results.map(r => ({\n    Project: r.name,\n    Files: r.files"
+            }
+          ],
+          "token_count": 106,
+          "line_count": 11
+        }
+      ],
+      "total_duplicated_lines": 60,
+      "total_duplicated_tokens": 585,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 4 shared clone groups (60 lines) from bench-dupes.mjs, bench.mjs into benchmarks",
+          "estimated_savings": 60
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 4 duplicated code blocks (60 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 4 shared clone groups (60 lines) from bench-dupes.mjs, bench.mjs into benchmarks"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "benchmarks/compare.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/compare.mjs",
+              "start_line": 24,
+              "end_line": 37,
+              "start_col": 21,
+              "end_col": 23,
+              "fragment": "stdout, projectDir) {\n  const data = JSON.parse(stdout);\n  const result = {\n    unused_files: new Set(),\n    unused_exports: new Set(),\n    unused_types: new Set(),\n    unused_dependencies: new Set(),\n    unused_dev_dependencies: new Set(),\n    unresolved_imports: new Set(),\n    unlisted_dependencies: new Set(),\n    unused_enum_members: new Set(),\n    duplicate_exports: new Set(),\n  };\n  for (const f of data."
+            },
+            {
+              "file": "benchmarks/compare.mjs",
+              "start_line": 49,
+              "end_line": 63,
+              "start_col": 19,
+              "end_col": 23,
+              "fragment": "stdout, projectDir) {\n  const data = JSON.parse(stdout);\n  const result = {\n    unused_files: new Set(),\n    unused_exports: new Set(),\n    unused_types: new Set(),\n    unused_dependencies: new Set(),\n    unused_dev_dependencies: new Set(),\n    unresolved_imports: new Set(),\n    unlisted_dependencies: new Set(),\n    unused_enum_members: new Set(),\n    duplicate_exports: new Set(),\n  };\n  // Knip \"files\" = unused files\n  for (const f of data."
+            }
+          ],
+          "token_count": 72,
+          "line_count": 15
+        }
+      ],
+      "total_duplicated_lines": 15,
+      "total_duplicated_tokens": 72,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (15 lines) from compare.mjs, compare.mjs",
+          "estimated_savings": 15
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (15 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (15 lines) from compare.mjs, compare.mjs"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "benchmarks/generate-circular-fixtures.mjs",
+        "benchmarks/generate-dupes-fixtures.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/generate-circular-fixtures.mjs",
+              "start_line": 148,
+              "end_line": 166,
+              "start_col": 14,
+              "end_col": 26,
+              "fragment": ");\n\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({\n    name: `bench-circular-${name}`,\n    version: '1.0.0',\n    private: true,\n    main: 'src/index.ts',\n  }, null, 2) + '\\n');\n\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({\n    compilerOptions: {\n      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',\n      strict: true, esModuleInterop: true, skipLibCheck: true,\n      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',\n    },\n    include: ['src'],\n  }, null, 2) + '\\n');\n\n  return { name, fileCount"
+            },
+            {
+              "file": "benchmarks/generate-dupes-fixtures.mjs",
+              "start_line": 161,
+              "end_line": 179,
+              "start_col": 54,
+              "end_col": 26,
+              "fragment": ");\n\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({\n    name: `bench-dupes-${name}`,\n    version: '1.0.0',\n    private: true,\n    main: 'src/index.ts',\n  }, null, 2) + '\\n');\n\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({\n    compilerOptions: {\n      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',\n      strict: true, esModuleInterop: true, skipLibCheck: true,\n      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',\n    },\n    include: ['src'],\n  }, null, 2) + '\\n');\n\n  return { name, fileCount"
+            }
+          ],
+          "token_count": 99,
+          "line_count": 19
+        }
+      ],
+      "total_duplicated_lines": 19,
+      "total_duplicated_tokens": 99,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (19 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs",
+          "estimated_savings": 19
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (19 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (19 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "benchmarks/generate-circular-fixtures.mjs",
+        "benchmarks/generate-dupes-fixtures.mjs",
+        "benchmarks/generate-fixtures.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/generate-circular-fixtures.mjs",
+              "start_line": 2,
+              "end_line": 7,
+              "start_col": 0,
+              "end_col": 47,
+              "fragment": "import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';\nimport { join, dirname, relative } from 'node:path';\nimport { fileURLToPath } from 'node:url';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst fixturesDir = join(__dirname, 'fixtures',"
+            },
+            {
+              "file": "benchmarks/generate-dupes-fixtures.mjs",
+              "start_line": 2,
+              "end_line": 7,
+              "start_col": 0,
+              "end_col": 47,
+              "fragment": "import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';\nimport { join, dirname, relative } from 'node:path';\nimport { fileURLToPath } from 'node:url';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst fixturesDir = join(__dirname, 'fixtures',"
+            },
+            {
+              "file": "benchmarks/generate-fixtures.mjs",
+              "start_line": 2,
+              "end_line": 7,
+              "start_col": 0,
+              "end_col": 47,
+              "fragment": "import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';\nimport { join, dirname, relative } from 'node:path';\nimport { fileURLToPath } from 'node:url';\n\nconst __dirname = dirname(fileURLToPath(import.meta.url));\nconst fixturesDir = join(__dirname, 'fixtures',"
+            }
+          ],
+          "token_count": 53,
+          "line_count": 6
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/generate-circular-fixtures.mjs",
+              "start_line": 7,
+              "end_line": 19,
+              "start_col": 68,
+              "end_col": 29,
+              "fragment": ");\n\nfunction mulberry32(seed) {\n  return function () {\n    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;\n    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);\n    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;\n    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;\n  };\n}\n\nconst SIZES = [\n  { name: 'tiny',   files: 10"
+            },
+            {
+              "file": "benchmarks/generate-dupes-fixtures.mjs",
+              "start_line": 7,
+              "end_line": 19,
+              "start_col": 65,
+              "end_col": 27,
+              "fragment": ");\n\nfunction mulberry32(seed) {\n  return function () {\n    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;\n    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);\n    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;\n    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;\n  };\n}\n\nconst SIZES = [\n  { name: 'tiny', files: 10"
+            },
+            {
+              "file": "benchmarks/generate-fixtures.mjs",
+              "start_line": 7,
+              "end_line": 19,
+              "start_col": 59,
+              "end_col": 27,
+              "fragment": ");\n\nfunction mulberry32(seed) {\n  return function () {\n    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;\n    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);\n    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;\n    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;\n  };\n}\n\nconst SIZES = [\n  { name: 'tiny', files: 10"
+            }
+          ],
+          "token_count": 87,
+          "line_count": 13
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/generate-circular-fixtures.mjs",
+              "start_line": 44,
+              "end_line": 52,
+              "start_col": 8,
+              "end_col": 28,
+              "fragment": "{ name, files: fileCount, cycleCount, maxCycleLen } = size;\n  const projectDir = join(fixturesDir, name);\n  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });\n  const rand = mulberry32(42 + fileCount);\n  const srcDir = join(projectDir, 'src');\n  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });\n\n  // Build import graph: each file imports from a few others (acyclic forward references)\n  const imports = new Map();"
+            },
+            {
+              "file": "benchmarks/generate-dupes-fixtures.mjs",
+              "start_line": 89,
+              "end_line": 97,
+              "start_col": 8,
+              "end_col": 20,
+              "fragment": "{ name, files: fileCount, dupeGroups, linesPerBlock } = size;\n  const projectDir = join(fixturesDir, name);\n  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });\n  const rand = mulberry32(42 + fileCount);\n  const srcDir = join(projectDir, 'src');\n  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });\n\n  // Pre-generate duplicated code blocks\n  const blocks = [];"
+            },
+            {
+              "file": "benchmarks/generate-fixtures.mjs",
+              "start_line": 31,
+              "end_line": 38,
+              "start_col": 8,
+              "end_col": 48,
+              "fragment": "{ name, files: fileCount, exportsPerFile } = size;\n  const projectDir = join(fixturesDir, name);\n  if (existsSync(projectDir)) rmSync(projectDir, { recursive: true });\n  const rand = mulberry32(42 + fileCount);\n  const srcDir = join(projectDir, 'src');\n  for (const dir of DIRS) mkdirSync(join(srcDir, dir), { recursive: true });\n\n  const usedCount = Math.floor(fileCount * 0.8);"
+            }
+          ],
+          "token_count": 81,
+          "line_count": 9
+        },
+        {
+          "instances": [
+            {
+              "file": "benchmarks/generate-circular-fixtures.mjs",
+              "start_line": 169,
+              "end_line": 174,
+              "start_col": 78,
+              "end_col": 102,
+              "fragment": ");\nfor (const size of SIZES) {\n  const start = performance.now();\n  const stats = generateProject(size);\n  const elapsed = performance.now() - start;\n  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats."
+            },
+            {
+              "file": "benchmarks/generate-dupes-fixtures.mjs",
+              "start_line": 182,
+              "end_line": 187,
+              "start_col": 70,
+              "end_col": 102,
+              "fragment": ");\nfor (const size of SIZES) {\n  const start = performance.now();\n  const stats = generateProject(size);\n  const elapsed = performance.now() - start;\n  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats."
+            },
+            {
+              "file": "benchmarks/generate-fixtures.mjs",
+              "start_line": 126,
+              "end_line": 131,
+              "start_col": 56,
+              "end_col": 102,
+              "fragment": ");\nfor (const size of SIZES) {\n  const start = performance.now();\n  const stats = generateProject(size);\n  const elapsed = performance.now() - start;\n  console.log(`  ${stats.name.padEnd(8)} ${String(stats.fileCount).padStart(5)} files  ${String(stats."
+            }
+          ],
+          "token_count": 72,
+          "line_count": 6
+        }
+      ],
+      "total_duplicated_lines": 34,
+      "total_duplicated_tokens": 293,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (13 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs",
+          "estimated_savings": 26
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs",
+          "estimated_savings": 18
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (6 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs",
+          "estimated_savings": 12
+        },
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (6 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs",
+          "estimated_savings": 12
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 4 duplicated code blocks (34 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (13 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (6 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (6 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "benchmarks/generate-dupes-fixtures.mjs",
+        "benchmarks/generate-fixtures.mjs"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "benchmarks/generate-dupes-fixtures.mjs",
+              "start_line": 161,
+              "end_line": 177,
+              "start_col": 2,
+              "end_col": 22,
+              "fragment": "writeFileSync(join(srcDir, 'index.ts'), entryContent);\n\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({\n    name: `bench-dupes-${name}`,\n    version: '1.0.0',\n    private: true,\n    main: 'src/index.ts',\n  }, null, 2) + '\\n');\n\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({\n    compilerOptions: {\n      target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler',\n      strict: true, esModuleInterop: true, skipLibCheck: true,\n      outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.',\n    },\n    include: ['src'],\n  }, null, 2) + '\\n');"
+            },
+            {
+              "file": "benchmarks/generate-fixtures.mjs",
+              "start_line": 111,
+              "end_line": 113,
+              "start_col": 2,
+              "end_col": 313,
+              "fragment": "writeFileSync(join(srcDir, 'index.ts'), entryContent);\n  writeFileSync(join(projectDir, 'package.json'), JSON.stringify({ name: `bench-${name}`, version: '1.0.0', private: true, main: 'src/index.ts' }, null, 2) + '\\n');\n  writeFileSync(join(projectDir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { target: 'ES2022', module: 'ESNext', moduleResolution: 'bundler', strict: true, esModuleInterop: true, skipLibCheck: true, outDir: 'dist', rootDir: 'src', declaration: true, baseUrl: '.' }, include: ['src'] }, null, 2) + '\\n');"
+            }
+          ],
+          "token_count": 104,
+          "line_count": 17
+        }
+      ],
+      "total_duplicated_lines": 17,
+      "total_duplicated_tokens": 104,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (17 lines) from generate-dupes-fixtures.mjs, generate-fixtures.mjs",
+          "estimated_savings": 17
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (17 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (17 lines) from generate-dupes-fixtures.mjs, generate-fixtures.mjs"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "crates/napi/index.d.ts",
+        "crates/napi/types/index.d.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.d.ts",
+              "start_line": 1,
+              "end_line": 363,
+              "start_col": 0,
+              "end_col": 80,
+              "fragment": "export interface AnalysisOptions {\n  root?: string;\n  configPath?: string;\n  noCache?: boolean;\n  threads?: number;\n  production?: boolean;\n  changedSince?: string;\n  workspace?: string[];\n  changedWorkspaces?: string;\n  explain?: boolean;\n}\n\nexport interface DeadCodeOptions extends AnalysisOptions {\n  unusedFiles?: boolean;\n  unusedExports?: boolean;\n  unusedDeps?: boolean;\n  unusedTypes?: boolean;\n  unusedEnumMembers?: boolean;\n  unusedClassMembers?: boolean;\n  unresolvedImports?: boolean;\n  unlistedDeps?: boolean;\n  duplicateExports?: boolean;\n  circularDeps?: boolean;\n  boundaryViolations?: boolean;\n  staleSuppressions?: boolean;\n  files?: string[];\n  includeEntryExports?: boolean;\n}\n\nexport type DuplicationMode = 'strict' | 'mild' | 'weak' | 'semantic';\n\nexport interface DuplicationOptions extends AnalysisOptions {\n  mode?: DuplicationMode;\n  minTokens?: number;\n  minLines?: number;\n  threshold?: number;\n  skipLocal?: boolean;\n  crossLanguage?: boolean;\n  ignoreImports?: boolean;\n  top?: number;\n}\n\nexport type ComplexitySort = 'cyclomatic' | 'cognitive' | 'lines' | 'severity';\nexport type OwnershipEmailMode = 'raw' | 'handle' | 'hash';\nexport type TargetEffort = 'low' | 'medium' | 'high';\n\nexport interface ComplexityOptions extends AnalysisOptions {\n  maxCyclomatic?: number;\n  maxCognitive?: number;\n  maxCrap?: number;\n  top?: number;\n  sort?: ComplexitySort;\n  complexity?: boolean;\n  fileScores?: boolean;\n  coverageGaps?: boolean;\n  hotspots?: boolean;\n  ownership?: boolean;\n  ownershipEmails?: OwnershipEmailMode;\n  targets?: boolean;\n  effort?: TargetEffort;\n  score?: boolean;\n  since?: string;\n  minCommits?: number;\n  coverage?: string;\n  coverageRoot?: string;\n}\n\nexport interface AnalysisAction {\n  type?: string;\n  auto_fixable?: boolean;\n  description?: string;\n  comment?: string;\n  note?: string;\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeSummary {\n  total_issues: number;\n  unused_files: number;\n  unused_exports: number;\n  unused_types: number;\n  unused_dependencies: number;\n  unused_enum_members: number;\n  unused_class_members: number;\n  unresolved_imports: number;\n  unlisted_dependencies: number;\n  duplicate_exports: number;\n  type_only_dependencies: number;\n  test_only_dependencies: number;\n  circular_dependencies: number;\n  boundary_violations: number;\n  stale_suppressions: number;\n}\n\nexport interface EntryPointSummary {\n  total: number;\n  sources: Record<string, number>;\n}\n\nexport interface UnusedFileFinding {\n  path: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedExportFinding {\n  path: string;\n  export_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  used_in_workspaces?: string[];\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedMemberFinding {\n  path: string;\n  parent_name: string;\n  member_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnresolvedImportFinding {\n  path: string;\n  specifier: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnlistedDependencyFinding {\n  package_name: string;\n  imported_from: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicateExportFinding {\n  export_name: string;\n  locations: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TypeOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TestOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface CircularDependencyFinding {\n  files: string[];\n  length: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface BoundaryViolationFinding {\n  from_path: string;\n  to_path: string;\n  line: number;\n  col: number;\n  from_zone?: string;\n  to_zone?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface StaleSuppressionFinding {\n  path: string;\n  line: number;\n  col: number;\n  issue_kind?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  total_issues: number;\n  summary: DeadCodeSummary;\n  entry_points?: EntryPointSummary;\n  unused_files: UnusedFileFinding[];\n  unused_exports: UnusedExportFinding[];\n  unused_types: UnusedExportFinding[];\n  unused_dependencies: UnusedDependencyFinding[];\n  unused_dev_dependencies: UnusedDependencyFinding[];\n  unused_optional_dependencies: UnusedDependencyFinding[];\n  unused_enum_members: UnusedMemberFinding[];\n  unused_class_members: UnusedMemberFinding[];\n  unresolved_imports: UnresolvedImportFinding[];\n  unlisted_dependencies: UnlistedDependencyFinding[];\n  duplicate_exports: DuplicateExportFinding[];\n  type_only_dependencies: TypeOnlyDependencyFinding[];\n  test_only_dependencies: TestOnlyDependencyFinding[];\n  circular_dependencies: CircularDependencyFinding[];\n  boundary_violations: BoundaryViolationFinding[];\n  stale_suppressions: StaleSuppressionFinding[];\n  _meta?: Record<string, unknown>;\n}\n\nexport interface CloneInstance {\n  file: string;\n  start_line: number;\n  end_line: number;\n  start_col: number;\n  end_col: number;\n  fragment?: string;\n  [key: string]: unknown;\n}\n\nexport interface CloneGroup {\n  instances: CloneInstance[];\n  token_count: number;\n  line_count: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicationStats {\n  total_files: number;\n  files_with_clones: number;\n  total_lines: number;\n  duplicated_lines: number;\n  total_tokens: number;\n  duplicated_tokens: number;\n  clone_groups: number;\n  clone_instances: number;\n  duplication_percentage: number;\n}\n\nexport interface DuplicationReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  clone_groups: CloneGroup[];\n  clone_families?: Record<string, unknown>[];\n  mirrored_directories?: Record<string, unknown>[];\n  stats: DuplicationStats;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface HealthFinding {\n  path: string;\n  name: string;\n  line: number;\n  col: number;\n  cyclomatic: number;\n  cognitive: number;\n  line_count: number;\n  param_count: number;\n  exceeded: string;\n  severity: string;\n  crap?: number;\n  coverage_pct?: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface FileHealthScore {\n  path: string;\n  fan_in: number;\n  fan_out: number;\n  dead_code_ratio: number;\n  complexity_density: number;\n  maintainability_index: number;\n  total_cyclomatic: number;\n  total_cognitive: number;\n  function_count: number;\n  lines: number;\n  crap_max: number;\n  crap_above_threshold: number;\n  [key: string]: unknown;\n}\n\nexport interface CoverageGaps {\n  summary: {\n    runtime_files: number;\n    covered_files: number;\n    file_coverage_pct: number;\n    untested_files: number;\n    untested_exports: number;\n  };\n  files?: Array<{ path: string; value_export_count: number; [key: string]: unknown }>;\n  exports?: Array<{ path: string; export_name: string; line: number; col: number; [key: string]: unknown }>;\n}\n\nexport interface RefactoringTarget {\n  path: string;\n  priority: number;\n  efficiency: number;\n  recommendation: string;\n  category: string;\n  effort: string;\n  confidence: string;\n  factors?: Array<Record<string, unknown>>;\n  evidence?: Record<string, unknown>;\n  [key: string]: unknown;\n}\n\nexport interface HealthReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  findings: HealthFinding[];\n  summary: Record<string, unknown>;\n  vital_signs?: Record<string, unknown>;\n  health_score?: Record<string, unknown>;\n  file_scores?: FileHealthScore[];\n  coverage_gaps?: CoverageGaps;\n  hotspots?: Array<Record<string, unknown>>;\n  hotspot_summary?: Record<string, unknown>;\n  runtime_coverage?: Record<string, unknown>;\n  large_functions?: Array<Record<string, unknown>>;\n  targets?: RefactoringTarget[];\n  target_thresholds?: Record<string, unknown>;\n  health_trend?: Record<string, unknown>;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface FallowNodeErrorShape {\n  message: string;\n  exitCode: number;\n  code?: string;\n  help?: string;\n  context?: string;\n}\n\nexport type FallowNodeError = Error & FallowNodeErrorShape;\n\nexport function detectDeadCode(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectCircularDependencies(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectBoundaryViolations(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectDuplication(options?: DuplicationOptions): Promise<DuplicationReport>;\nexport function computeComplexity(options?: ComplexityOptions): Promise<HealthReport>;\nexport function computeHealth(options?: ComplexityOptions): Promise<HealthReport"
+            },
+            {
+              "file": "crates/napi/types/index.d.ts",
+              "start_line": 1,
+              "end_line": 363,
+              "start_col": 0,
+              "end_col": 80,
+              "fragment": "export interface AnalysisOptions {\n  root?: string;\n  configPath?: string;\n  noCache?: boolean;\n  threads?: number;\n  production?: boolean;\n  changedSince?: string;\n  workspace?: string[];\n  changedWorkspaces?: string;\n  explain?: boolean;\n}\n\nexport interface DeadCodeOptions extends AnalysisOptions {\n  unusedFiles?: boolean;\n  unusedExports?: boolean;\n  unusedDeps?: boolean;\n  unusedTypes?: boolean;\n  unusedEnumMembers?: boolean;\n  unusedClassMembers?: boolean;\n  unresolvedImports?: boolean;\n  unlistedDeps?: boolean;\n  duplicateExports?: boolean;\n  circularDeps?: boolean;\n  boundaryViolations?: boolean;\n  staleSuppressions?: boolean;\n  files?: string[];\n  includeEntryExports?: boolean;\n}\n\nexport type DuplicationMode = 'strict' | 'mild' | 'weak' | 'semantic';\n\nexport interface DuplicationOptions extends AnalysisOptions {\n  mode?: DuplicationMode;\n  minTokens?: number;\n  minLines?: number;\n  threshold?: number;\n  skipLocal?: boolean;\n  crossLanguage?: boolean;\n  ignoreImports?: boolean;\n  top?: number;\n}\n\nexport type ComplexitySort = 'cyclomatic' | 'cognitive' | 'lines' | 'severity';\nexport type OwnershipEmailMode = 'raw' | 'handle' | 'hash';\nexport type TargetEffort = 'low' | 'medium' | 'high';\n\nexport interface ComplexityOptions extends AnalysisOptions {\n  maxCyclomatic?: number;\n  maxCognitive?: number;\n  maxCrap?: number;\n  top?: number;\n  sort?: ComplexitySort;\n  complexity?: boolean;\n  fileScores?: boolean;\n  coverageGaps?: boolean;\n  hotspots?: boolean;\n  ownership?: boolean;\n  ownershipEmails?: OwnershipEmailMode;\n  targets?: boolean;\n  effort?: TargetEffort;\n  score?: boolean;\n  since?: string;\n  minCommits?: number;\n  coverage?: string;\n  coverageRoot?: string;\n}\n\nexport interface AnalysisAction {\n  type?: string;\n  auto_fixable?: boolean;\n  description?: string;\n  comment?: string;\n  note?: string;\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeSummary {\n  total_issues: number;\n  unused_files: number;\n  unused_exports: number;\n  unused_types: number;\n  unused_dependencies: number;\n  unused_enum_members: number;\n  unused_class_members: number;\n  unresolved_imports: number;\n  unlisted_dependencies: number;\n  duplicate_exports: number;\n  type_only_dependencies: number;\n  test_only_dependencies: number;\n  circular_dependencies: number;\n  boundary_violations: number;\n  stale_suppressions: number;\n}\n\nexport interface EntryPointSummary {\n  total: number;\n  sources: Record<string, number>;\n}\n\nexport interface UnusedFileFinding {\n  path: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedExportFinding {\n  path: string;\n  export_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  used_in_workspaces?: string[];\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnusedMemberFinding {\n  path: string;\n  parent_name: string;\n  member_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnresolvedImportFinding {\n  path: string;\n  specifier: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface UnlistedDependencyFinding {\n  package_name: string;\n  imported_from: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicateExportFinding {\n  export_name: string;\n  locations: Array<{ path: string; line: number; [key: string]: unknown }>;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TypeOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface TestOnlyDependencyFinding {\n  path: string;\n  package_name: string;\n  line: number;\n  col: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface CircularDependencyFinding {\n  files: string[];\n  length: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface BoundaryViolationFinding {\n  from_path: string;\n  to_path: string;\n  line: number;\n  col: number;\n  from_zone?: string;\n  to_zone?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface StaleSuppressionFinding {\n  path: string;\n  line: number;\n  col: number;\n  issue_kind?: string;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DeadCodeReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  total_issues: number;\n  summary: DeadCodeSummary;\n  entry_points?: EntryPointSummary;\n  unused_files: UnusedFileFinding[];\n  unused_exports: UnusedExportFinding[];\n  unused_types: UnusedExportFinding[];\n  unused_dependencies: UnusedDependencyFinding[];\n  unused_dev_dependencies: UnusedDependencyFinding[];\n  unused_optional_dependencies: UnusedDependencyFinding[];\n  unused_enum_members: UnusedMemberFinding[];\n  unused_class_members: UnusedMemberFinding[];\n  unresolved_imports: UnresolvedImportFinding[];\n  unlisted_dependencies: UnlistedDependencyFinding[];\n  duplicate_exports: DuplicateExportFinding[];\n  type_only_dependencies: TypeOnlyDependencyFinding[];\n  test_only_dependencies: TestOnlyDependencyFinding[];\n  circular_dependencies: CircularDependencyFinding[];\n  boundary_violations: BoundaryViolationFinding[];\n  stale_suppressions: StaleSuppressionFinding[];\n  _meta?: Record<string, unknown>;\n}\n\nexport interface CloneInstance {\n  file: string;\n  start_line: number;\n  end_line: number;\n  start_col: number;\n  end_col: number;\n  fragment?: string;\n  [key: string]: unknown;\n}\n\nexport interface CloneGroup {\n  instances: CloneInstance[];\n  token_count: number;\n  line_count: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface DuplicationStats {\n  total_files: number;\n  files_with_clones: number;\n  total_lines: number;\n  duplicated_lines: number;\n  total_tokens: number;\n  duplicated_tokens: number;\n  clone_groups: number;\n  clone_instances: number;\n  duplication_percentage: number;\n}\n\nexport interface DuplicationReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  clone_groups: CloneGroup[];\n  clone_families?: Record<string, unknown>[];\n  mirrored_directories?: Record<string, unknown>[];\n  stats: DuplicationStats;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface HealthFinding {\n  path: string;\n  name: string;\n  line: number;\n  col: number;\n  cyclomatic: number;\n  cognitive: number;\n  line_count: number;\n  param_count: number;\n  exceeded: string;\n  severity: string;\n  crap?: number;\n  coverage_pct?: number;\n  actions?: AnalysisAction[];\n  [key: string]: unknown;\n}\n\nexport interface FileHealthScore {\n  path: string;\n  fan_in: number;\n  fan_out: number;\n  dead_code_ratio: number;\n  complexity_density: number;\n  maintainability_index: number;\n  total_cyclomatic: number;\n  total_cognitive: number;\n  function_count: number;\n  lines: number;\n  crap_max: number;\n  crap_above_threshold: number;\n  [key: string]: unknown;\n}\n\nexport interface CoverageGaps {\n  summary: {\n    runtime_files: number;\n    covered_files: number;\n    file_coverage_pct: number;\n    untested_files: number;\n    untested_exports: number;\n  };\n  files?: Array<{ path: string; value_export_count: number; [key: string]: unknown }>;\n  exports?: Array<{ path: string; export_name: string; line: number; col: number; [key: string]: unknown }>;\n}\n\nexport interface RefactoringTarget {\n  path: string;\n  priority: number;\n  efficiency: number;\n  recommendation: string;\n  category: string;\n  effort: string;\n  confidence: string;\n  factors?: Array<Record<string, unknown>>;\n  evidence?: Record<string, unknown>;\n  [key: string]: unknown;\n}\n\nexport interface HealthReport {\n  schema_version: number;\n  version: string;\n  elapsed_ms: number;\n  findings: HealthFinding[];\n  summary: Record<string, unknown>;\n  vital_signs?: Record<string, unknown>;\n  health_score?: Record<string, unknown>;\n  file_scores?: FileHealthScore[];\n  coverage_gaps?: CoverageGaps;\n  hotspots?: Array<Record<string, unknown>>;\n  hotspot_summary?: Record<string, unknown>;\n  runtime_coverage?: Record<string, unknown>;\n  large_functions?: Array<Record<string, unknown>>;\n  targets?: RefactoringTarget[];\n  target_thresholds?: Record<string, unknown>;\n  health_trend?: Record<string, unknown>;\n  _meta?: Record<string, unknown>;\n}\n\nexport interface FallowNodeErrorShape {\n  message: string;\n  exitCode: number;\n  code?: string;\n  help?: string;\n  context?: string;\n}\n\nexport type FallowNodeError = Error & FallowNodeErrorShape;\n\nexport function detectDeadCode(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectCircularDependencies(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectBoundaryViolations(options?: DeadCodeOptions): Promise<DeadCodeReport>;\nexport function detectDuplication(options?: DuplicationOptions): Promise<DuplicationReport>;\nexport function computeComplexity(options?: ComplexityOptions): Promise<HealthReport>;\nexport function computeHealth(options?: ComplexityOptions): Promise<HealthReport"
+            }
+          ],
+          "token_count": 1392,
+          "line_count": 363
+        }
+      ],
+      "total_duplicated_lines": 363,
+      "total_duplicated_tokens": 1392,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 1 shared clone group (363 lines) from index.d.ts, index.d.ts into a shared directory",
+          "estimated_savings": 363
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (363 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 1 shared clone group (363 lines) from index.d.ts, index.d.ts into a shared directory"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "crates/napi/index.js"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 79,
+              "end_line": 89,
+              "start_col": 98,
+              "end_col": 23,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm') {\n      try {\n        return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 494,
+              "end_line": 504,
+              "start_col": 100,
+              "end_col": 23,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm') {\n      try {\n        return require("
+            }
+          ],
+          "token_count": 66,
+          "line_count": 11
+        },
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 79,
+              "end_line": 86,
+              "start_col": 98,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 95,
+              "end_line": 102,
+              "start_col": 101,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 116,
+              "end_line": 123,
+              "start_col": 98,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 132,
+              "end_line": 139,
+              "start_col": 99,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 149,
+              "end_line": 156,
+              "start_col": 100,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 165,
+              "end_line": 172,
+              "start_col": 101,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 184,
+              "end_line": 191,
+              "start_col": 99,
+              "end_col": 5,
+              "fragment": ").version\n      if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n        throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n      }\n      return binding\n    } catch (e) {\n      loadErrors.push(e)\n    }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 200,
+              "end_line": 207,
+              "start_col": 95,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 216,
+              "end_line": 223,
+              "start_col": 97,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 236,
+              "end_line": 243,
+              "start_col": 96,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 252,
+              "end_line": 259,
+              "start_col": 98,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 273,
+              "end_line": 280,
+              "start_col": 101,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 289,
+              "end_line": 296,
+              "start_col": 100,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 307,
+              "end_line": 314,
+              "start_col": 103,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 323,
+              "end_line": 330,
+              "start_col": 102,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 341,
+              "end_line": 348,
+              "start_col": 107,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 357,
+              "end_line": 364,
+              "start_col": 106,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 375,
+              "end_line": 382,
+              "start_col": 105,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 391,
+              "end_line": 398,
+              "start_col": 104,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 409,
+              "end_line": 416,
+              "start_col": 105,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 425,
+              "end_line": 432,
+              "start_col": 104,
+              "end_col": 9,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 442,
+              "end_line": 449,
+              "start_col": 100,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 458,
+              "end_line": 465,
+              "start_col": 100,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 478,
+              "end_line": 485,
+              "start_col": 102,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 494,
+              "end_line": 501,
+              "start_col": 100,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 510,
+              "end_line": 517,
+              "start_col": 100,
+              "end_col": 7,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }"
+            }
+          ],
+          "token_count": 50,
+          "line_count": 8
+        },
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 95,
+              "end_line": 106,
+              "start_col": 101,
+              "end_col": 41,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on Android ${process.arch}`))\n    }\n  } else if (process.platform === 'win32'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 165,
+              "end_line": 176,
+              "start_col": 101,
+              "end_col": 42,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on Windows: ${process.arch}`))\n    }\n  } else if (process.platform === 'darwin'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 216,
+              "end_line": 227,
+              "start_col": 97,
+              "end_col": 43,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on macOS: ${process.arch}`))\n    }\n  } else if (process.platform === 'freebsd'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 252,
+              "end_line": 263,
+              "start_col": 98,
+              "end_col": 41,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on FreeBSD: ${process.arch}`))\n    }\n  } else if (process.platform === 'linux'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 458,
+              "end_line": 469,
+              "start_col": 100,
+              "end_col": 47,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else {\n      loadErrors.push(new Error(`Unsupported architecture on Linux: ${process.arch}`))\n    }\n  } else if (process.platform === 'openharmony'"
+            }
+          ],
+          "token_count": 78,
+          "line_count": 12
+        },
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 116,
+              "end_line": 126,
+              "start_col": 98,
+              "end_col": 23,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n      } else {\n        try {\n        return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 273,
+              "end_line": 283,
+              "start_col": 101,
+              "end_col": 25,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 307,
+              "end_line": 317,
+              "start_col": 103,
+              "end_col": 25,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 341,
+              "end_line": 351,
+              "start_col": 107,
+              "end_col": 25,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 375,
+              "end_line": 385,
+              "start_col": 105,
+              "end_col": 25,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 409,
+              "end_line": 419,
+              "start_col": 105,
+              "end_col": 25,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      } else {\n        try {\n          return require("
+            }
+          ],
+          "token_count": 58,
+          "line_count": 11
+        },
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 132,
+              "end_line": 141,
+              "start_col": 99,
+              "end_col": 38,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n      }\n    } else if (process.arch === 'ia32'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 289,
+              "end_line": 298,
+              "start_col": 100,
+              "end_col": 39,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'arm64'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 323,
+              "end_line": 332,
+              "start_col": 102,
+              "end_col": 37,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'arm'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 357,
+              "end_line": 366,
+              "start_col": 106,
+              "end_col": 41,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'loong64'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 391,
+              "end_line": 400,
+              "start_col": 104,
+              "end_col": 41,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'riscv64'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 425,
+              "end_line": 434,
+              "start_col": 104,
+              "end_col": 39,
+              "fragment": ").version\n          if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n            throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n          }\n          return binding\n        } catch (e) {\n          loadErrors.push(e)\n        }\n      }\n    } else if (process.arch === 'ppc64'"
+            }
+          ],
+          "token_count": 59,
+          "line_count": 10
+        },
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 149,
+              "end_line": 159,
+              "start_col": 100,
+              "end_col": 23,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm64') {\n      try {\n        return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 200,
+              "end_line": 210,
+              "start_col": 95,
+              "end_col": 23,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm64') {\n      try {\n        return require("
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 236,
+              "end_line": 246,
+              "start_col": 96,
+              "end_col": 23,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'arm64') {\n      try {\n        return require("
+            }
+          ],
+          "token_count": 66,
+          "line_count": 11
+        },
+        {
+          "instances": [
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 442,
+              "end_line": 450,
+              "start_col": 100,
+              "end_col": 39,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 's390x'"
+            },
+            {
+              "file": "crates/napi/index.js",
+              "start_line": 478,
+              "end_line": 486,
+              "start_col": 102,
+              "end_col": 37,
+              "fragment": ").version\n        if (bindingPackageVersion !== '2.54.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {\n          throw new Error(`Native binding package version mismatch, expected 2.54.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)\n        }\n        return binding\n      } catch (e) {\n        loadErrors.push(e)\n      }\n    } else if (process.arch === 'x64'"
+            }
+          ],
+          "token_count": 58,
+          "line_count": 9
+        }
+      ],
+      "total_duplicated_lines": 72,
+      "total_duplicated_tokens": 435,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 7 shared clone groups (72 lines) from index.js into crates/napi",
+          "estimated_savings": 395
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 7 duplicated code blocks (72 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 7 shared clone groups (72 lines) from index.js into crates/napi"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/benchmark-corpus/src/type1-exact/cache-manager-a.ts",
+        "tests/benchmark-corpus/src/type1-exact/cache-manager-b.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type1-exact/cache-manager-a.ts",
+              "start_line": 2,
+              "end_line": 133,
+              "start_col": 0,
+              "end_col": 26,
+              "fragment": "interface CacheEntry<T> {\n  value: T;\n  expiresAt: number;\n  createdAt: number;\n  accessCount: number;\n}\n\ninterface CacheStats {\n  hits: number;\n  misses: number;\n  evictions: number;\n  size: number;\n}\n\nexport class LRUCache<T> {\n  private cache = new Map<string, CacheEntry<T>>();\n  private readonly maxSize: number;\n  private readonly defaultTTL: number;\n  private stats: CacheStats = { hits: 0, misses: 0, evictions: 0, size: 0 };\n\n  constructor(maxSize = 500, defaultTTL = 300000) {\n    this.maxSize = maxSize;\n    this.defaultTTL = defaultTTL;\n  }\n\n  get(key: string): T | undefined {\n    const entry = this.cache.get(key);\n    if (!entry) {\n      this.stats.misses++;\n      return undefined;\n    }\n\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.misses++;\n      this.stats.size--;\n      return undefined;\n    }\n\n    // Move to end (most recently used)\n    this.cache.delete(key);\n    entry.accessCount++;\n    this.cache.set(key, entry);\n    this.stats.hits++;\n    return entry.value;\n  }\n\n  set(key: string, value: T, ttl?: number): void {\n    if (this.cache.has(key)) {\n      this.cache.delete(key);\n    } else if (this.cache.size >= this.maxSize) {\n      this.evictOldest();\n    }\n\n    const entry: CacheEntry<T> = {\n      value,\n      expiresAt: Date.now() + (ttl ?? this.defaultTTL),\n      createdAt: Date.now(),\n      accessCount: 0,\n    };\n\n    this.cache.set(key, entry);\n    this.stats.size = this.cache.size;\n  }\n\n  delete(key: string): boolean {\n    const deleted = this.cache.delete(key);\n    if (deleted) {\n      this.stats.size = this.cache.size;\n    }\n    return deleted;\n  }\n\n  clear(): void {\n    this.cache.clear();\n    this.stats.size = 0;\n  }\n\n  has(key: string): boolean {\n    const entry = this.cache.get(key);\n    if (!entry) return false;\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.size--;\n      return false;\n    }\n    return true;\n  }\n\n  private evictOldest(): void {\n    const firstKey = this.cache.keys().next().value;\n    if (firstKey !== undefined) {\n      this.cache.delete(firstKey);\n      this.stats.evictions++;\n      this.stats.size--;\n    }\n  }\n\n  getStats(): CacheStats {\n    return { ...this.stats };\n  }\n\n  prune(): number {\n    let pruned = 0;\n    const now = Date.now();\n    for (const [key, entry] of this.cache) {\n      if (now > entry.expiresAt) {\n        this.cache.delete(key);\n        pruned++;\n      }\n    }\n    this.stats.size = this.cache.size;\n    return pruned;\n  }\n\n  keys(): string[] {\n    return Array.from(this.cache.keys());\n  }\n\n  values(): T[] {\n    const result: T[] = [];\n    const now = Date.now();\n    for (const entry of this.cache.values()) {\n      if (now <= entry.expiresAt) {\n        result.push(entry.value);\n      }\n    }\n    return result;\n  }\n\n  get size(): number {\n    return this.cache.size"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type1-exact/cache-manager-b.ts",
+              "start_line": 2,
+              "end_line": 133,
+              "start_col": 0,
+              "end_col": 26,
+              "fragment": "interface CacheEntry<T> {\n  value: T;\n  expiresAt: number;\n  createdAt: number;\n  accessCount: number;\n}\n\ninterface CacheStats {\n  hits: number;\n  misses: number;\n  evictions: number;\n  size: number;\n}\n\nexport class LRUCache<T> {\n  private cache = new Map<string, CacheEntry<T>>();\n  private readonly maxSize: number;\n  private readonly defaultTTL: number;\n  private stats: CacheStats = { hits: 0, misses: 0, evictions: 0, size: 0 };\n\n  constructor(maxSize = 500, defaultTTL = 300000) {\n    this.maxSize = maxSize;\n    this.defaultTTL = defaultTTL;\n  }\n\n  get(key: string): T | undefined {\n    const entry = this.cache.get(key);\n    if (!entry) {\n      this.stats.misses++;\n      return undefined;\n    }\n\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.misses++;\n      this.stats.size--;\n      return undefined;\n    }\n\n    // Move to end (most recently used)\n    this.cache.delete(key);\n    entry.accessCount++;\n    this.cache.set(key, entry);\n    this.stats.hits++;\n    return entry.value;\n  }\n\n  set(key: string, value: T, ttl?: number): void {\n    if (this.cache.has(key)) {\n      this.cache.delete(key);\n    } else if (this.cache.size >= this.maxSize) {\n      this.evictOldest();\n    }\n\n    const entry: CacheEntry<T> = {\n      value,\n      expiresAt: Date.now() + (ttl ?? this.defaultTTL),\n      createdAt: Date.now(),\n      accessCount: 0,\n    };\n\n    this.cache.set(key, entry);\n    this.stats.size = this.cache.size;\n  }\n\n  delete(key: string): boolean {\n    const deleted = this.cache.delete(key);\n    if (deleted) {\n      this.stats.size = this.cache.size;\n    }\n    return deleted;\n  }\n\n  clear(): void {\n    this.cache.clear();\n    this.stats.size = 0;\n  }\n\n  has(key: string): boolean {\n    const entry = this.cache.get(key);\n    if (!entry) return false;\n    if (Date.now() > entry.expiresAt) {\n      this.cache.delete(key);\n      this.stats.size--;\n      return false;\n    }\n    return true;\n  }\n\n  private evictOldest(): void {\n    const firstKey = this.cache.keys().next().value;\n    if (firstKey !== undefined) {\n      this.cache.delete(firstKey);\n      this.stats.evictions++;\n      this.stats.size--;\n    }\n  }\n\n  getStats(): CacheStats {\n    return { ...this.stats };\n  }\n\n  prune(): number {\n    let pruned = 0;\n    const now = Date.now();\n    for (const [key, entry] of this.cache) {\n      if (now > entry.expiresAt) {\n        this.cache.delete(key);\n        pruned++;\n      }\n    }\n    this.stats.size = this.cache.size;\n    return pruned;\n  }\n\n  keys(): string[] {\n    return Array.from(this.cache.keys());\n  }\n\n  values(): T[] {\n    const result: T[] = [];\n    const now = Date.now();\n    for (const entry of this.cache.values()) {\n      if (now <= entry.expiresAt) {\n        result.push(entry.value);\n      }\n    }\n    return result;\n  }\n\n  get size(): number {\n    return this.cache.size"
+            }
+          ],
+          "token_count": 692,
+          "line_count": 132
+        }
+      ],
+      "total_duplicated_lines": 132,
+      "total_duplicated_tokens": 692,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 1 shared clone group (132 lines) from cache-manager-a.ts, cache-manager-b.ts into tests/benchmark-corpus/src/type1-exact",
+          "estimated_savings": 132
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (132 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 1 shared clone group (132 lines) from cache-manager-a.ts, cache-manager-b.ts into tests/benchmark-corpus/src/type1-exact"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/benchmark-corpus/src/type1-exact/data-processor-a.ts",
+        "tests/benchmark-corpus/src/type1-exact/data-processor-b.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type1-exact/data-processor-a.ts",
+              "start_line": 2,
+              "end_line": 144,
+              "start_col": 0,
+              "end_col": 30,
+              "fragment": "import { EventEmitter } from 'events';\n\ninterface DataRecord {\n  id: string;\n  timestamp: number;\n  payload: Record<string, unknown>;\n  metadata: {\n    source: string;\n    version: number;\n    tags: string[];\n  };\n}\n\ninterface ProcessingResult {\n  processed: number;\n  failed: number;\n  skipped: number;\n  duration: number;\n}\n\nexport class DataProcessor extends EventEmitter {\n  private buffer: DataRecord[] = [];\n  private readonly maxBufferSize: number;\n  private readonly flushInterval: number;\n  private timer: ReturnType<typeof setInterval> | null = null;\n  private isProcessing = false;\n\n  constructor(maxBufferSize = 1000, flushInterval = 5000) {\n    super();\n    this.maxBufferSize = maxBufferSize;\n    this.flushInterval = flushInterval;\n  }\n\n  async start(): Promise<void> {\n    if (this.timer) {\n      throw new Error('Processor already started');\n    }\n    this.timer = setInterval(() => this.flush(), this.flushInterval);\n    this.emit('started');\n  }\n\n  async stop(): Promise<void> {\n    if (this.timer) {\n      clearInterval(this.timer);\n      this.timer = null;\n    }\n    await this.flush();\n    this.emit('stopped');\n  }\n\n  async ingest(record: DataRecord): Promise<void> {\n    if (!this.validateRecord(record)) {\n      this.emit('invalid', record);\n      return;\n    }\n\n    this.buffer.push(record);\n\n    if (this.buffer.length >= this.maxBufferSize) {\n      await this.flush();\n    }\n  }\n\n  async flush(): Promise<ProcessingResult> {\n    if (this.isProcessing || this.buffer.length === 0) {\n      return { processed: 0, failed: 0, skipped: 0, duration: 0 };\n    }\n\n    this.isProcessing = true;\n    const batch = this.buffer.splice(0);\n    const startTime = Date.now();\n\n    let processed = 0;\n    let failed = 0;\n    let skipped = 0;\n\n    for (const record of batch) {\n      try {\n        if (this.shouldSkip(record)) {\n          skipped++;\n          continue;\n        }\n\n        const transformed = this.transform(record);\n        await this.persist(transformed);\n        processed++;\n      } catch (error) {\n        failed++;\n        this.emit('error', { record, error });\n      }\n    }\n\n    const duration = Date.now() - startTime;\n    this.isProcessing = false;\n\n    const result: ProcessingResult = { processed, failed, skipped, duration };\n    this.emit('flushed', result);\n    return result;\n  }\n\n  private validateRecord(record: DataRecord): boolean {\n    if (!record.id || typeof record.id !== 'string') return false;\n    if (!record.timestamp || record.timestamp <= 0) return false;\n    if (!record.payload || typeof record.payload !== 'object') return false;\n    if (!record.metadata?.source) return false;\n    return true;\n  }\n\n  private shouldSkip(record: DataRecord): boolean {\n    const age = Date.now() - record.timestamp;\n    const maxAge = 24 * 60 * 60 * 1000; // 24 hours\n    if (age > maxAge) return true;\n    if (record.metadata.tags.includes('test')) return true;\n    return false;\n  }\n\n  private transform(record: DataRecord): DataRecord {\n    return {\n      ...record,\n      payload: {\n        ...record.payload,\n        processedAt: Date.now(),\n        processorVersion: '2.0',\n      },\n      metadata: {\n        ...record.metadata,\n        version: record.metadata.version + 1,\n      },\n    };\n  }\n\n  private async persist(record: DataRecord): Promise<void> {\n    // Simulate async persistence\n    await new Promise((resolve) => setTimeout(resolve, 1));\n    this.emit('persisted', record.id);\n  }\n\n  getBufferSize(): number {\n    return this.buffer.length;\n  }\n\n  isRunning(): boolean {\n    return this.timer !== null"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type1-exact/data-processor-b.ts",
+              "start_line": 2,
+              "end_line": 144,
+              "start_col": 0,
+              "end_col": 30,
+              "fragment": "import { EventEmitter } from 'events';\n\ninterface DataRecord {\n  id: string;\n  timestamp: number;\n  payload: Record<string, unknown>;\n  metadata: {\n    source: string;\n    version: number;\n    tags: string[];\n  };\n}\n\ninterface ProcessingResult {\n  processed: number;\n  failed: number;\n  skipped: number;\n  duration: number;\n}\n\nexport class DataProcessor extends EventEmitter {\n  private buffer: DataRecord[] = [];\n  private readonly maxBufferSize: number;\n  private readonly flushInterval: number;\n  private timer: ReturnType<typeof setInterval> | null = null;\n  private isProcessing = false;\n\n  constructor(maxBufferSize = 1000, flushInterval = 5000) {\n    super();\n    this.maxBufferSize = maxBufferSize;\n    this.flushInterval = flushInterval;\n  }\n\n  async start(): Promise<void> {\n    if (this.timer) {\n      throw new Error('Processor already started');\n    }\n    this.timer = setInterval(() => this.flush(), this.flushInterval);\n    this.emit('started');\n  }\n\n  async stop(): Promise<void> {\n    if (this.timer) {\n      clearInterval(this.timer);\n      this.timer = null;\n    }\n    await this.flush();\n    this.emit('stopped');\n  }\n\n  async ingest(record: DataRecord): Promise<void> {\n    if (!this.validateRecord(record)) {\n      this.emit('invalid', record);\n      return;\n    }\n\n    this.buffer.push(record);\n\n    if (this.buffer.length >= this.maxBufferSize) {\n      await this.flush();\n    }\n  }\n\n  async flush(): Promise<ProcessingResult> {\n    if (this.isProcessing || this.buffer.length === 0) {\n      return { processed: 0, failed: 0, skipped: 0, duration: 0 };\n    }\n\n    this.isProcessing = true;\n    const batch = this.buffer.splice(0);\n    const startTime = Date.now();\n\n    let processed = 0;\n    let failed = 0;\n    let skipped = 0;\n\n    for (const record of batch) {\n      try {\n        if (this.shouldSkip(record)) {\n          skipped++;\n          continue;\n        }\n\n        const transformed = this.transform(record);\n        await this.persist(transformed);\n        processed++;\n      } catch (error) {\n        failed++;\n        this.emit('error', { record, error });\n      }\n    }\n\n    const duration = Date.now() - startTime;\n    this.isProcessing = false;\n\n    const result: ProcessingResult = { processed, failed, skipped, duration };\n    this.emit('flushed', result);\n    return result;\n  }\n\n  private validateRecord(record: DataRecord): boolean {\n    if (!record.id || typeof record.id !== 'string') return false;\n    if (!record.timestamp || record.timestamp <= 0) return false;\n    if (!record.payload || typeof record.payload !== 'object') return false;\n    if (!record.metadata?.source) return false;\n    return true;\n  }\n\n  private shouldSkip(record: DataRecord): boolean {\n    const age = Date.now() - record.timestamp;\n    const maxAge = 24 * 60 * 60 * 1000; // 24 hours\n    if (age > maxAge) return true;\n    if (record.metadata.tags.includes('test')) return true;\n    return false;\n  }\n\n  private transform(record: DataRecord): DataRecord {\n    return {\n      ...record,\n      payload: {\n        ...record.payload,\n        processedAt: Date.now(),\n        processorVersion: '2.0',\n      },\n      metadata: {\n        ...record.metadata,\n        version: record.metadata.version + 1,\n      },\n    };\n  }\n\n  private async persist(record: DataRecord): Promise<void> {\n    // Simulate async persistence\n    await new Promise((resolve) => setTimeout(resolve, 1));\n    this.emit('persisted', record.id);\n  }\n\n  getBufferSize(): number {\n    return this.buffer.length;\n  }\n\n  isRunning(): boolean {\n    return this.timer !== null"
+            }
+          ],
+          "token_count": 721,
+          "line_count": 143
+        }
+      ],
+      "total_duplicated_lines": 143,
+      "total_duplicated_tokens": 721,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 1 shared clone group (143 lines) from data-processor-a.ts, data-processor-b.ts into tests/benchmark-corpus/src/type1-exact",
+          "estimated_savings": 143
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (143 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 1 shared clone group (143 lines) from data-processor-a.ts, data-processor-b.ts into tests/benchmark-corpus/src/type1-exact"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/benchmark-corpus/src/type2-renamed/event-bus-a.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-a.ts",
+              "start_line": 29,
+              "end_line": 37,
+              "start_col": 6,
+              "end_col": 13,
+              "fragment": "priority,\n    };\n\n    const existing = this.subscriptions.get(event) ?? [];\n    existing.push(subscription);\n    existing.sort((a, b) => b.priority - a.priority);\n    this.subscriptions.set(event, existing);\n\n    return id"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-a.ts",
+              "start_line": 47,
+              "end_line": 55,
+              "start_col": 6,
+              "end_col": 13,
+              "fragment": "priority,\n    };\n\n    const existing = this.subscriptions.get(event) ?? [];\n    existing.push(subscription);\n    existing.sort((a, b) => b.priority - a.priority);\n    this.subscriptions.set(event, existing);\n\n    return id"
+            }
+          ],
+          "token_count": 66,
+          "line_count": 9
+        }
+      ],
+      "total_duplicated_lines": 9,
+      "total_duplicated_tokens": 66,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from event-bus-a.ts, event-bus-a.ts",
+          "estimated_savings": 9
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (9 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from event-bus-a.ts, event-bus-a.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/benchmark-corpus/src/type2-renamed/event-bus-b.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-b.ts",
+              "start_line": 29,
+              "end_line": 37,
+              "start_col": 6,
+              "end_col": 14,
+              "fragment": "weight,\n    };\n\n    const current = this.registrations.get(channel) ?? [];\n    current.push(registration);\n    current.sort((a, b) => b.weight - a.weight);\n    this.registrations.set(channel, current);\n\n    return uid"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type2-renamed/event-bus-b.ts",
+              "start_line": 47,
+              "end_line": 55,
+              "start_col": 6,
+              "end_col": 14,
+              "fragment": "weight,\n    };\n\n    const current = this.registrations.get(channel) ?? [];\n    current.push(registration);\n    current.sort((a, b) => b.weight - a.weight);\n    this.registrations.set(channel, current);\n\n    return uid"
+            }
+          ],
+          "token_count": 66,
+          "line_count": 9
+        }
+      ],
+      "total_duplicated_lines": 9,
+      "total_duplicated_tokens": 66,
+      "suggestions": [
+        {
+          "kind": "ExtractFunction",
+          "description": "Extract shared function (9 lines) from event-bus-b.ts, event-bus-b.ts",
+          "estimated_savings": 9
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 1 duplicated code block (9 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract shared function (9 lines) from event-bus-b.ts, event-bus-b.ts"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+        "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+              "start_line": 15,
+              "end_line": 39,
+              "start_col": 31,
+              "end_col": 35,
+              "fragment": "{\n      data,\n      priority,\n      addedAt: Date.now(),\n      id,\n    };\n\n    // Binary search for insertion point\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > priority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return id;\n  }\n\n  dequeue(): T | undefined {\n    const item = this.items.shift()"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+              "start_line": 17,
+              "end_line": 42,
+              "start_col": 31,
+              "end_col": 35,
+              "fragment": "{\n      data,\n      priority,\n      addedAt: Date.now(),\n      id,\n      retryCount: 0,\n    };\n\n    // Binary search for insertion point\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > priority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return id;\n  }\n\n  dequeue(): T | undefined {\n    const item = this.items.shift()"
+            }
+          ],
+          "token_count": 95,
+          "line_count": 26
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+              "start_line": 47,
+              "end_line": 51,
+              "start_col": 2,
+              "end_col": 15,
+              "fragment": "remove(id: string): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n    this.items.splice(index, 1);\n    return true"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+              "start_line": 57,
+              "end_line": 61,
+              "start_col": 2,
+              "end_col": 15,
+              "fragment": "remove(id: string): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n    this.items.splice(index, 1);\n    return true"
+            }
+          ],
+          "token_count": 58,
+          "line_count": 5
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+              "start_line": 56,
+              "end_line": 74,
+              "start_col": 4,
+              "end_col": 17,
+              "fragment": "this.nextId = 0;\n  }\n\n  get size(): number {\n    return this.items.length;\n  }\n\n  isEmpty(): boolean {\n    return this.items.length === 0;\n  }\n\n  toArray(): T[] {\n    return this.items.map((item) => item.data);\n  }\n\n  drain(): T[] {\n    const result = this.items.map((item) => item.data);\n    this.items = [];\n    return result"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+              "start_line": 88,
+              "end_line": 106,
+              "start_col": 4,
+              "end_col": 17,
+              "fragment": "this.processedCount = 0;\n  }\n\n  get size(): number {\n    return this.items.length;\n  }\n\n  isEmpty(): boolean {\n    return this.items.length === 0;\n  }\n\n  toArray(): T[] {\n    return this.items.map((item) => item.data);\n  }\n\n  drain(): T[] {\n    const result = this.items.map((item) => item.data);\n    this.items = [];\n    return result"
+            }
+          ],
+          "token_count": 91,
+          "line_count": 19
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-a.ts",
+              "start_line": 77,
+              "end_line": 98,
+              "start_col": 2,
+              "end_col": 15,
+              "fragment": "updatePriority(id: string, newPriority: number): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n\n    const item = this.items[index];\n    this.items.splice(index, 1);\n\n    item.priority = newPriority;\n\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > newPriority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return true"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/queue-b.ts",
+              "start_line": 113,
+              "end_line": 134,
+              "start_col": 2,
+              "end_col": 15,
+              "fragment": "updatePriority(id: string, newPriority: number): boolean {\n    const index = this.items.findIndex((item) => item.id === id);\n    if (index === -1) return false;\n\n    const item = this.items[index];\n    this.items.splice(index, 1);\n\n    item.priority = newPriority;\n\n    let low = 0;\n    let high = this.items.length;\n    while (low < high) {\n      const mid = (low + high) >>> 1;\n      if (this.items[mid].priority > newPriority) {\n        low = mid + 1;\n      } else {\n        high = mid;\n      }\n    }\n\n    this.items.splice(low, 0, item);\n    return true"
+            }
+          ],
+          "token_count": 152,
+          "line_count": 22
+        }
+      ],
+      "total_duplicated_lines": 72,
+      "total_duplicated_tokens": 396,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 4 shared clone groups (72 lines) from queue-a.ts, queue-b.ts into tests/benchmark-corpus/src/type3-near-miss",
+          "estimated_savings": 72
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 4 duplicated code blocks (72 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 4 shared clone groups (72 lines) from queue-a.ts, queue-b.ts into tests/benchmark-corpus/src/type3-near-miss"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    },
+    {
+      "files": [
+        "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+        "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts"
+      ],
+      "groups": [
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+              "start_line": 34,
+              "end_line": 43,
+              "start_col": 10,
+              "end_col": 9,
+              "fragment": "errors: ValidationError[] = [];\n\n    for (const [field, rules] of this.rules) {\n      const value = data[field];\n\n      for (const rule of rules) {\n        const error = this.checkRule(field, value, rule);\n        if (error) {\n          errors.push(error);\n        }"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts",
+              "start_line": 43,
+              "end_line": 56,
+              "start_col": 10,
+              "end_col": 9,
+              "fragment": "warnings: ValidationError[] = [];\n\n    for (const [field, rules] of this.rules) {\n      const value = data[field];\n\n      for (const rule of rules) {\n        const error = this.checkRule(field, value, rule);\n        if (error) {\n          if (error.severity === 'warning') {\n            warnings.push(error);\n          } else {\n            errors.push(error);\n          }\n        }"
+            }
+          ],
+          "token_count": 53,
+          "line_count": 14
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+              "start_line": 47,
+              "end_line": 54,
+              "start_col": 11,
+              "end_col": 65,
+              "fragment": "{ valid: errors.length === 0, errors };\n  }\n\n  private checkRule(field: string, value: unknown, rule: ValidationRule): ValidationError | null {\n    switch (rule.type) {\n      case 'required':\n        if (value === undefined || value === null || value === '') {\n          return { field, rule: 'required', message: rule.message"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts",
+              "start_line": 60,
+              "end_line": 67,
+              "start_col": 11,
+              "end_col": 65,
+              "fragment": "{ valid: errors.length === 0, errors, warnings, validatedAt: Date.now() };\n  }\n\n  private checkRule(field: string, value: unknown, rule: ValidationRule): ValidationError | null {\n    switch (rule.type) {\n      case 'required':\n        if (value === undefined || value === null || value === '') {\n          return { field, rule: 'required', message: rule.message"
+            }
+          ],
+          "token_count": 56,
+          "line_count": 8
+        },
+        {
+          "instances": [
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/validator-a.ts",
+              "start_line": 78,
+              "end_line": 109,
+              "start_col": 17,
+              "end_col": 16,
+              "fragment": "{ field, rule: 'custom', message: rule.message };\n        }\n        break;\n    }\n\n    return null;\n  }\n\n  validateField(field: string, value: unknown): ValidationError[] {\n    const rules = this.rules.get(field);\n    if (!rules) return [];\n\n    const errors: ValidationError[] = [];\n    for (const rule of rules) {\n      const error = this.checkRule(field, value, rule);\n      if (error) {\n        errors.push(error);\n      }\n    }\n    return errors;\n  }\n\n  hasRules(field: string): boolean {\n    return this.rules.has(field) && (this.rules.get(field)?.length ?? 0) > 0;\n  }\n\n  getRuleCount(): number {\n    let count = 0;\n    for (const rules of this.rules.values()) {\n      count += rules.length;\n    }\n    return count"
+            },
+            {
+              "file": "tests/benchmark-corpus/src/type3-near-miss/validator-b.ts",
+              "start_line": 107,
+              "end_line": 138,
+              "start_col": 17,
+              "end_col": 16,
+              "fragment": "{ field, rule: 'custom', message: rule.message, severity: 'error', timestamp: Date.now() };\n        }\n        break;\n    }\n\n    return null;\n  }\n\n  validateField(field: string, value: unknown): ValidationError[] {\n    const rules = this.rules.get(field);\n    if (!rules) return [];\n\n    const errors: ValidationError[] = [];\n    for (const rule of rules) {\n      const error = this.checkRule(field, value, rule);\n      if (error) {\n        errors.push(error);\n      }\n    }\n    return errors;\n  }\n\n  hasRules(field: string): boolean {\n    return this.rules.has(field) && (this.rules.get(field)?.length ?? 0) > 0;\n  }\n\n  getRuleCount(): number {\n    let count = 0;\n    for (const rules of this.rules.values()) {\n      count += rules.length;\n    }\n    return count"
+            }
+          ],
+          "token_count": 162,
+          "line_count": 32
+        }
+      ],
+      "total_duplicated_lines": 54,
+      "total_duplicated_tokens": 271,
+      "suggestions": [
+        {
+          "kind": "ExtractModule",
+          "description": "Extract 3 shared clone groups (54 lines) from validator-a.ts, validator-b.ts into tests/benchmark-corpus/src/type3-near-miss",
+          "estimated_savings": 54
+        }
+      ],
+      "actions": [
+        {
+          "type": "extract-shared",
+          "auto_fixable": false,
+          "description": "Extract 3 duplicated code blocks (54 lines) into a shared module",
+          "note": "These clone groups share the same files, indicating a structural relationship — refactor together"
+        },
+        {
+          "type": "apply-suggestion",
+          "auto_fixable": false,
+          "description": "Extract 3 shared clone groups (54 lines) from validator-a.ts, validator-b.ts into tests/benchmark-corpus/src/type3-near-miss"
+        },
+        {
+          "type": "suppress-line",
+          "auto_fixable": false,
+          "description": "Suppress with an inline comment above the duplicated code",
+          "comment": "// fallow-ignore-next-line code-duplication"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "total_files": 58,
+    "files_with_clones": 20,
+    "total_lines": 9287,
+    "duplicated_lines": 2520,
+    "total_tokens": 53072,
+    "duplicated_tokens": 10106,
+    "clone_groups": 39,
+    "clone_instances": 124,
+    "duplication_percentage": 27.134704425541077
+  }
+}

--- a/refactor/artifacts/dupes-2026-04-28/initial-dupes.txt
+++ b/refactor/artifacts/dupes-2026-04-28/initial-dupes.txt
@@ -1,0 +1,75 @@
+● Duplicates (39 clone groups)
+
+    363 lines  2 instances
+    crates/napi/index.d.ts:1-363
+    crates/napi/types/index.d.ts:1-363
+
+    143 lines  2 instances
+    tests/benchmark-corpus/src/type1-exact/data-processor-a.ts:2-144
+    tests/benchmark-corpus/src/type1-exact/data-processor-b.ts:2-144
+
+    132 lines  2 instances
+    tests/benchmark-corpus/src/type1-exact/cache-manager-a.ts:2-133
+    tests/benchmark-corpus/src/type1-exact/cache-manager-b.ts:2-133
+
+    114 lines  3 instances
+    benchmarks/bench-circular.mjs:117-230
+    benchmarks/bench-dupes.mjs:124-199
+    benchmarks/bench.mjs:133-149
+
+     54 lines  2 instances
+    benchmarks/bench-circular.mjs:44-97
+    benchmarks/bench-dupes.mjs:30-72
+
+     38 lines  2 instances
+    benchmarks/bench-circular.mjs:71-104
+    benchmarks/bench-dupes.mjs:74-111
+
+     32 lines  2 instances
+    tests/benchmark-corpus/src/type3-near-miss/validator-a.ts:78-109
+    tests/benchmark-corpus/src/type3-near-miss/validator-b.ts:107-138
+
+     26 lines  2 instances
+    tests/benchmark-corpus/src/type3-near-miss/queue-a.ts:15-39
+    tests/benchmark-corpus/src/type3-near-miss/queue-b.ts:17-42
+
+     22 lines  2 instances
+    tests/benchmark-corpus/src/type3-near-miss/queue-a.ts:77-98
+    tests/benchmark-corpus/src/type3-near-miss/queue-b.ts:113-134
+
+     21 lines  3 instances
+    benchmarks/bench-circular.mjs:3-23
+    benchmarks/bench-dupes.mjs:3-21
+    benchmarks/bench.mjs:3-21
+
+  ... and 29 more clone groups
+  Identical code blocks detected via suffix-array analysis — https://docs.fallow.tools/explanations/duplication#clone-groups
+
+● Clone families (7 with multiple groups)
+
+  3 groups, 112 lines across benchmarks/bench-circular.mjs, benchmarks/bench-dupes.mjs
+    → Extract 3 shared clone groups (112 lines) from bench-circular.mjs, bench-dupes.mjs into benchmarks
+
+  6 groups, 189 lines across benchmarks/bench-circular.mjs, benchmarks/bench-dupes.mjs, benchmarks/bench.mjs
+    → Extract 6 shared clone groups (189 lines) from bench-circular.mjs, bench-dupes.mjs, bench.mjs into benchmarks
+
+  4 groups, 60 lines across benchmarks/bench-dupes.mjs, benchmarks/bench.mjs
+    → Extract 4 shared clone groups (60 lines) from bench-dupes.mjs, bench.mjs into benchmarks
+
+  4 groups, 34 lines across benchmarks/generate-circular-fixtures.mjs, benchmarks/generate-dupes-fixtures.mjs, benchmarks/generate-fixtures.mjs
+    → Extract shared function (13 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs
+    → Extract shared function (9 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs
+    → Extract shared function (6 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs
+    → Extract shared function (6 lines) from generate-circular-fixtures.mjs, generate-dupes-fixtures.mjs, generate-fixtures.mjs
+
+  7 groups, 72 lines across crates/napi/index.js
+    → Extract 7 shared clone groups (72 lines) from index.js into crates/napi
+
+  4 groups, 72 lines across tests/benchmark-corpus/src/type3-near-miss/queue-a.ts, tests/benchmark-corpus/src/type3-near-miss/queue-b.ts
+    → Extract 4 shared clone groups (72 lines) from queue-a.ts, queue-b.ts into tests/benchmark-corpus/src/type3-near-miss
+
+  3 groups, 54 lines across tests/benchmark-corpus/src/type3-near-miss/validator-a.ts, tests/benchmark-corpus/src/type3-near-miss/validator-b.ts
+    → Extract 3 shared clone groups (54 lines) from validator-a.ts, validator-b.ts into tests/benchmark-corpus/src/type3-near-miss
+
+  Groups of related clones across the same files — https://docs.fallow.tools/explanations/duplication#clone-families
+


### PR DESCRIPTION
## Summary

- Resolve all current `fallow dupes` findings from 39 clone groups / 2,520 duplicated lines to a clean duplicate scan.
- Add duplicate-only ignores for intentional benchmark corpus and generated NAPI outputs.
- Extract shared benchmark runner and fixture-generator helpers, and remove the local parser clone in `benchmarks/compare.mjs`.

## Validation

- `fallow dupes --top 100`
- `node --check` on all touched benchmark scripts/helpers
- `cargo fmt --all -- --check`
- `cargo test -p fallow-config duplicates --lib`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
