### PR TITLE
feat: support TanStack virtual route configs

### DIFF
--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -1,8 +1,4 @@
 //! Plugin registry: discovers active plugins, collects patterns, parses configs.
-#![expect(
-    clippy::excessive_nesting,
-    reason = "plugin config parsing requires deep AST matching"
-)]
 
 use rustc_hash::FxHashSet;
 use std::path::{Path, PathBuf};
@@ -198,22 +194,20 @@ impl PluginRegistry {
 
             for (plugin, matchers) in &config_matchers {
                 for (abs_path, rel_path) in &relative_files {
-                    if matchers.iter().any(|m| m.is_match(rel_path.as_str())) {
-                        // Mark as resolved regardless of result to prevent Phase 3b
-                        // from re-parsing a JSON config for the same plugin.
-                        resolved_plugins.insert(plugin.name());
-                        if let Ok(source) = std::fs::read_to_string(abs_path) {
-                            let plugin_result = plugin.resolve_config(abs_path, &source, root);
-                            if !plugin_result.is_empty() {
-                                tracing::debug!(
-                                    plugin = plugin.name(),
-                                    config = rel_path.as_str(),
-                                    entries = plugin_result.entry_patterns.len(),
-                                    deps = plugin_result.referenced_dependencies.len(),
-                                    "resolved config"
-                                );
-                                process_config_result(plugin.name(), plugin_result, &mut result);
-                            }
+                    if matchers.iter().any(|m| m.is_match(rel_path.as_str()))
+                        && let Ok(source) = std::fs::read_to_string(abs_path)
+                    {
+                        let plugin_result = plugin.resolve_config(abs_path, &source, root);
+                        if !plugin_result.is_empty() {
+                            resolved_plugins.insert(plugin.name());
+                            tracing::debug!(
+                                plugin = plugin.name(),
+                                config = rel_path.as_str(),
+                                entries = plugin_result.entry_patterns.len(),
+                                deps = plugin_result.referenced_dependencies.len(),
+                                "resolved config"
+                            );
+                            process_config_result(plugin.name(), plugin_result, &mut result);
                         }
                     }
                 }
@@ -342,11 +336,9 @@ impl PluginRegistry {
                     if matchers.iter().any(|m| m.is_match(rel_path.as_str()))
                         && let Ok(source) = std::fs::read_to_string(abs_path)
                     {
-                        // Mark resolved regardless of result to prevent Phase 3b
-                        // from re-parsing a JSON config for the same plugin.
-                        resolved_ws_plugins.insert(plugin.name());
                         let plugin_result = plugin.resolve_config(abs_path, &source, root);
                         if !plugin_result.is_empty() {
+                            resolved_ws_plugins.insert(plugin.name());
                             tracing::debug!(
                                 plugin = plugin.name(),
                                 config = rel_path.as_str(),

--- a/crates/core/src/plugins/tanstack_router.rs
+++ b/crates/core/src/plugins/tanstack_router.rs
@@ -9,7 +9,10 @@ use std::path::{Path, PathBuf};
 
 use super::{PathRule, Plugin, PluginResult, UsedExportRule, config_parser};
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, CallExpression, Expression, ImportDeclaration};
+use oxc_ast::ast::{
+    Argument, BindingPattern, CallExpression, Expression, ImportDeclaration, ObjectExpression,
+    Program, Statement,
+};
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -41,7 +44,18 @@ const ENTRY_PATTERNS: &[&str] = &[
     "src/routeTree.gen.js",
 ];
 
-const CONFIG_PATTERNS: &[&str] = &["tsr.config.json"];
+const CONFIG_PATTERNS: &[&str] = &[
+    "tsr.config.json",
+    "vite.config.{ts,js,mts,mjs}",
+    "rsbuild.config.{ts,js,mts,mjs}",
+    "rspack.config.{ts,js,mts,mjs}",
+    "webpack.config.{ts,js,mts,mjs,cjs}",
+];
+const ROUTER_PLUGIN_IMPORTS: &[&str] = &[
+    "@tanstack/router-plugin/vite",
+    "@tanstack/router-plugin/rspack",
+    "@tanstack/router-plugin/webpack",
+];
 
 const ALWAYS_USED: &[&str] = &["tsr.config.json", "app.config.{ts,js}"];
 
@@ -166,59 +180,109 @@ impl Plugin for TanstackRouterPlugin {
     }
 
     fn resolve_config(&self, config_path: &Path, source: &str, root: &Path) -> PluginResult {
-        let mut result = PluginResult {
-            replace_entry_patterns: true,
-            replace_used_export_rules: true,
-            ..PluginResult::default()
-        };
-
-        let route_dir =
-            config_parser::extract_config_string(source, config_path, &["routesDirectory"])
-                .as_deref()
-                .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root))
-                .unwrap_or_else(|| "src/routes".to_string());
-        let route_file_prefix =
-            config_parser::extract_config_string(source, config_path, &["routeFilePrefix"])
-                .unwrap_or_default();
-        let route_file_ignore_prefix =
-            config_parser::extract_config_string(source, config_path, &["routeFileIgnorePrefix"])
-                .unwrap_or_else(|| DEFAULT_ROUTE_FILE_IGNORE_PREFIX.to_string());
-        let route_file_ignore_pattern =
-            config_parser::extract_config_string(source, config_path, &["routeFileIgnorePattern"]);
-
-        let virtual_route_config =
-            resolve_virtual_route_config(config_path, source, root, &route_dir);
-        if virtual_route_config.is_empty() {
-            add_route_dir_patterns(
-                &mut result,
-                &route_dir,
-                &route_file_prefix,
-                &route_file_ignore_prefix,
-                route_file_ignore_pattern.as_deref(),
-            );
-        } else {
-            apply_virtual_route_config(
-                &mut result,
-                virtual_route_config,
-                &route_file_prefix,
-                &route_file_ignore_prefix,
-                route_file_ignore_pattern.as_deref(),
-            );
+        if !is_tsr_config(config_path) {
+            return resolve_bundler_config(config_path, source, root).unwrap_or_default();
         }
 
-        let generated_route_tree =
-            config_parser::extract_config_string(source, config_path, &["generatedRouteTree"])
-                .as_deref()
-                .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root));
-        if let Some(route_tree) = generated_route_tree {
-            result.push_entry_pattern(route_tree);
-        } else {
-            result.extend_entry_patterns(DEFAULT_GENERATED_ROUTE_TREE_PATTERNS.iter().copied());
-        }
-        result.extend_entry_patterns(SUPPORTING_ENTRY_PATTERNS.iter().copied());
-
-        result
+        resolve_tsr_config(config_path, source, root)
     }
+}
+
+fn resolve_tsr_config(config_path: &Path, source: &str, root: &Path) -> PluginResult {
+    let route_dir = config_parser::extract_config_string(source, config_path, &["routesDirectory"])
+        .as_deref()
+        .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root))
+        .unwrap_or_else(|| "src/routes".to_string());
+
+    resolve_route_options(RouteOptions {
+        route_dir: route_dir.clone(),
+        route_file_prefix: config_parser::extract_config_string(
+            source,
+            config_path,
+            &["routeFilePrefix"],
+        )
+        .unwrap_or_default(),
+        route_file_ignore_prefix: config_parser::extract_config_string(
+            source,
+            config_path,
+            &["routeFileIgnorePrefix"],
+        )
+        .unwrap_or_else(|| DEFAULT_ROUTE_FILE_IGNORE_PREFIX.to_string()),
+        route_file_ignore_pattern: config_parser::extract_config_string(
+            source,
+            config_path,
+            &["routeFileIgnorePattern"],
+        ),
+        generated_route_tree: config_parser::extract_config_string(
+            source,
+            config_path,
+            &["generatedRouteTree"],
+        )
+        .as_deref()
+        .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root)),
+        virtual_route_config: resolve_virtual_route_config(config_path, source, root, &route_dir),
+    })
+}
+
+fn resolve_bundler_config(config_path: &Path, source: &str, root: &Path) -> Option<PluginResult> {
+    let source_type = SourceType::from_path(config_path).unwrap_or_default();
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    let options = collect_router_plugin_route_options(&parsed.program, config_path, root)
+        .into_iter()
+        .next()?;
+
+    Some(resolve_route_options(options))
+}
+
+#[derive(Debug, Default)]
+struct RouteOptions {
+    route_dir: String,
+    route_file_prefix: String,
+    route_file_ignore_prefix: String,
+    route_file_ignore_pattern: Option<String>,
+    generated_route_tree: Option<String>,
+    virtual_route_config: VirtualRouteConfig,
+}
+
+fn resolve_route_options(options: RouteOptions) -> PluginResult {
+    let mut result = PluginResult {
+        replace_entry_patterns: true,
+        replace_used_export_rules: true,
+        ..PluginResult::default()
+    };
+
+    if options.virtual_route_config.is_empty() {
+        add_route_dir_patterns(
+            &mut result,
+            &options.route_dir,
+            &options.route_file_prefix,
+            &options.route_file_ignore_prefix,
+            options.route_file_ignore_pattern.as_deref(),
+        );
+    } else {
+        apply_virtual_route_config(
+            &mut result,
+            options.virtual_route_config,
+            &options.route_file_prefix,
+            &options.route_file_ignore_prefix,
+            options.route_file_ignore_pattern.as_deref(),
+        );
+    }
+
+    if let Some(route_tree) = options.generated_route_tree {
+        result.push_entry_pattern(route_tree);
+    } else {
+        result.extend_entry_patterns(DEFAULT_GENERATED_ROUTE_TREE_PATTERNS.iter().copied());
+    }
+    result.extend_entry_patterns(SUPPORTING_ENTRY_PATTERNS.iter().copied());
+
+    result
+}
+
+fn is_tsr_config(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|file_name| file_name == "tsr.config.json")
 }
 
 #[derive(Debug, Default)]
@@ -247,27 +311,7 @@ fn resolve_virtual_route_config(
             .as_deref()
             .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root))
     {
-        push_unique(&mut config.config_files, config_file.clone());
-
-        let file_path = root.join(&config_file);
-        if let Ok(source) = fs::read_to_string(&file_path) {
-            let base_dir = Path::new(&config_file)
-                .parent()
-                .map_or_else(String::new, |parent| {
-                    parent.to_string_lossy().replace('\\', "/")
-                });
-            let refs = collect_virtual_route_call_refs(&source, &file_path);
-            for file in refs.route_files {
-                if let Some(path) = normalize_project_relative(&base_dir, &file) {
-                    push_unique(&mut config.route_files, path);
-                }
-            }
-            for dir in refs.physical_dirs {
-                if let Some(path) = normalize_project_relative(&base_dir, &dir) {
-                    push_unique(&mut config.physical_dirs, path);
-                }
-            }
-        }
+        add_virtual_route_config_file(&mut config, root, &config_file);
     }
 
     for file in collect_inline_virtual_route_files(source) {
@@ -277,6 +321,96 @@ fn resolve_virtual_route_config(
     }
 
     config
+}
+
+fn resolve_bundler_route_options(
+    program: &Program,
+    options: &ObjectExpression,
+    config_path: &Path,
+    root: &Path,
+) -> RouteOptions {
+    let route_dir = extract_option_string(options, "routesDirectory")
+        .as_deref()
+        .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root))
+        .unwrap_or_else(|| "src/routes".to_string());
+
+    RouteOptions {
+        route_dir: route_dir.clone(),
+        route_file_prefix: extract_option_string(options, "routeFilePrefix").unwrap_or_default(),
+        route_file_ignore_prefix: extract_option_string(options, "routeFileIgnorePrefix")
+            .unwrap_or_else(|| DEFAULT_ROUTE_FILE_IGNORE_PREFIX.to_string()),
+        route_file_ignore_pattern: extract_option_string(options, "routeFileIgnorePattern"),
+        generated_route_tree: extract_option_string(options, "generatedRouteTree")
+            .as_deref()
+            .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root)),
+        virtual_route_config: resolve_bundler_virtual_route_config(
+            program,
+            options,
+            &route_dir,
+            config_path,
+            root,
+        ),
+    }
+}
+
+fn resolve_bundler_virtual_route_config(
+    program: &Program,
+    options: &ObjectExpression,
+    route_dir: &str,
+    config_path: &Path,
+    root: &Path,
+) -> VirtualRouteConfig {
+    let mut config = VirtualRouteConfig::default();
+    let Some(prop) = config_parser::find_property(options, "virtualRouteConfig") else {
+        return config;
+    };
+
+    if let Some(config_file) = config_parser::expression_to_string(&prop.value)
+        .as_deref()
+        .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root))
+    {
+        add_virtual_route_config_file(&mut config, root, &config_file);
+        return config;
+    }
+
+    let refs = if let Expression::Identifier(identifier) = &prop.value {
+        find_variable_init_expression(program, identifier.name.as_str())
+            .map(|expr| collect_virtual_route_expression_refs(program, expr))
+            .unwrap_or_default()
+    } else {
+        collect_virtual_route_expression_refs(program, &prop.value)
+    };
+    add_virtual_route_refs(&mut config, refs, route_dir);
+    config
+}
+
+fn add_virtual_route_config_file(config: &mut VirtualRouteConfig, root: &Path, config_file: &str) {
+    push_unique(&mut config.config_files, config_file.to_string());
+
+    let file_path = root.join(config_file);
+    let Ok(source) = fs::read_to_string(&file_path) else {
+        return;
+    };
+    let base_dir = Path::new(config_file)
+        .parent()
+        .map_or_else(String::new, |parent| {
+            parent.to_string_lossy().replace('\\', "/")
+        });
+    let refs = collect_virtual_route_call_refs(&source, &file_path);
+    add_virtual_route_refs(config, refs, &base_dir);
+}
+
+fn add_virtual_route_refs(config: &mut VirtualRouteConfig, refs: VirtualRouteRefs, base_dir: &str) {
+    for file in refs.route_files {
+        if let Some(path) = normalize_project_relative(base_dir, &file) {
+            push_unique(&mut config.route_files, path);
+        }
+    }
+    for dir in refs.physical_dirs {
+        if let Some(path) = normalize_project_relative(base_dir, &dir) {
+            push_unique(&mut config.physical_dirs, path);
+        }
+    }
 }
 
 fn apply_virtual_route_config(
@@ -381,11 +515,140 @@ fn collect_virtual_route_call_refs(source: &str, path: &Path) -> VirtualRouteRef
     collector.refs
 }
 
+fn collect_virtual_route_expression_refs(program: &Program, expr: &Expression) -> VirtualRouteRefs {
+    let mut collector = VirtualRouteCallCollector::from_imports(program);
+    collector.visit_expression(expr);
+    collector.refs
+}
+
+fn collect_router_plugin_route_options(
+    program: &Program,
+    config_path: &Path,
+    root: &Path,
+) -> Vec<RouteOptions> {
+    let mut collector = RouterPluginCallCollector {
+        route_options: Vec::new(),
+        local_names: Vec::new(),
+        namespaces: Vec::new(),
+        program,
+        config_path,
+        root,
+    };
+    collector.visit_program(program);
+    collector.route_options
+}
+
+fn extract_option_string(options: &ObjectExpression, key: &str) -> Option<String> {
+    config_parser::find_property(options, key)
+        .and_then(|prop| config_parser::expression_to_string(&prop.value))
+}
+
+fn find_variable_init_expression<'a>(
+    program: &'a Program<'a>,
+    name: &str,
+) -> Option<&'a Expression<'a>> {
+    for stmt in &program.body {
+        let Statement::VariableDeclaration(decl) = stmt else {
+            continue;
+        };
+        for declarator in &decl.declarations {
+            if let BindingPattern::BindingIdentifier(identifier) = &declarator.id
+                && identifier.name == name
+                && let Some(init) = &declarator.init
+            {
+                return Some(init);
+            }
+        }
+    }
+    None
+}
+
+struct RouterPluginCallCollector<'a> {
+    route_options: Vec<RouteOptions>,
+    local_names: Vec<String>,
+    namespaces: Vec<String>,
+    program: &'a Program<'a>,
+    config_path: &'a Path,
+    root: &'a Path,
+}
+
+impl<'a> Visit<'a> for RouterPluginCallCollector<'a> {
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        if !ROUTER_PLUGIN_IMPORTS
+            .iter()
+            .any(|source| decl.source.value == *source)
+        {
+            return;
+        }
+
+        if let Some(specifiers) = &decl.specifiers {
+            for specifier in specifiers {
+                match specifier {
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(specifier)
+                        if specifier.imported.name() == "tanstackRouter" =>
+                    {
+                        push_unique(&mut self.local_names, specifier.local.name.to_string());
+                    }
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+                        specifier,
+                    ) => {
+                        push_unique(&mut self.namespaces, specifier.local.name.to_string());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        if self.is_router_plugin_call(call)
+            && let Some(Expression::ObjectExpression(options)) =
+                call.arguments.first().and_then(Argument::as_expression)
+        {
+            self.route_options.push(resolve_bundler_route_options(
+                self.program,
+                options,
+                self.config_path,
+                self.root,
+            ));
+        }
+
+        walk::walk_call_expression(self, call);
+    }
+}
+
+impl RouterPluginCallCollector<'_> {
+    fn is_router_plugin_call(&self, call: &CallExpression<'_>) -> bool {
+        match &call.callee {
+            Expression::Identifier(identifier) => self
+                .local_names
+                .iter()
+                .any(|name| name == identifier.name.as_str()),
+            Expression::StaticMemberExpression(member) if matches!(&member.object, Expression::Identifier(object) if self.namespaces.iter().any(|name| name == object.name.as_str())) => {
+                member.property.name == "tanstackRouter"
+            }
+            _ => false,
+        }
+    }
+}
+
 #[derive(Default)]
 struct VirtualRouteCallCollector {
     refs: VirtualRouteRefs,
     helper_bindings: Vec<(String, String)>,
     namespaces: Vec<String>,
+}
+
+impl VirtualRouteCallCollector {
+    fn from_imports(program: &Program) -> Self {
+        let mut collector = Self::default();
+        for stmt in &program.body {
+            if let Statement::ImportDeclaration(decl) = stmt {
+                collector.visit_import_declaration(decl);
+            }
+        }
+        collector
+    }
 }
 
 impl<'a> Visit<'a> for VirtualRouteCallCollector {

--- a/crates/core/src/plugins/tanstack_router.rs
+++ b/crates/core/src/plugins/tanstack_router.rs
@@ -11,7 +11,7 @@ use super::{PathRule, Plugin, PluginResult, UsedExportRule, config_parser};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Expression, ImportDeclaration, ObjectExpression,
-    Program, Statement,
+    Program, Statement, VariableDeclaration,
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
@@ -615,6 +615,41 @@ impl<'a> Visit<'a> for RouterPluginCallCollector<'a> {
 
         walk::walk_call_expression(self, call);
     }
+
+    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
+        for declarator in &decl.declarations {
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+            let Some(source) = require_source(init) else {
+                continue;
+            };
+            if !ROUTER_PLUGIN_IMPORTS.iter().any(|import| source == *import) {
+                continue;
+            }
+
+            match &declarator.id {
+                BindingPattern::BindingIdentifier(identifier) => {
+                    push_unique(&mut self.namespaces, identifier.name.to_string());
+                }
+                BindingPattern::ObjectPattern(object) => {
+                    for prop in &object.properties {
+                        if prop
+                            .key
+                            .static_name()
+                            .is_some_and(|name| name == "tanstackRouter")
+                            && let BindingPattern::BindingIdentifier(identifier) = &prop.value
+                        {
+                            push_unique(&mut self.local_names, identifier.name.to_string());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        walk::walk_variable_declaration(self, decl);
+    }
 }
 
 impl RouterPluginCallCollector<'_> {
@@ -710,6 +745,45 @@ impl<'a> Visit<'a> for VirtualRouteCallCollector {
 
         walk::walk_call_expression(self, call);
     }
+
+    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
+        for declarator in &decl.declarations {
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+            let Some(source) = require_source(init) else {
+                continue;
+            };
+            if source != "@tanstack/virtual-file-routes" {
+                continue;
+            }
+
+            match &declarator.id {
+                BindingPattern::BindingIdentifier(identifier) => {
+                    push_unique(&mut self.namespaces, identifier.name.to_string());
+                }
+                BindingPattern::ObjectPattern(object) => {
+                    for prop in &object.properties {
+                        let Some(helper) = prop.key.static_name() else {
+                            continue;
+                        };
+                        if is_virtual_route_helper(&helper)
+                            && let BindingPattern::BindingIdentifier(identifier) = &prop.value
+                        {
+                            push_unique_pair(
+                                &mut self.helper_bindings,
+                                identifier.name.to_string(),
+                                helper.to_string(),
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        walk::walk_variable_declaration(self, decl);
+    }
 }
 
 impl VirtualRouteCallCollector {
@@ -754,6 +828,16 @@ fn string_arg(call: &CallExpression<'_>, index: usize) -> Option<String> {
                 .map(|quasi| quasi.value.raw.to_string()),
             _ => None,
         })
+}
+
+fn require_source(expr: &Expression<'_>) -> Option<String> {
+    let Expression::CallExpression(call) = expr else {
+        return None;
+    };
+    if !matches!(&call.callee, Expression::Identifier(identifier) if identifier.name == "require") {
+        return None;
+    }
+    string_arg(call, 0)
 }
 
 fn normalize_project_relative(base_dir: &str, raw: &str) -> Option<String> {

--- a/crates/core/src/plugins/tanstack_router.rs
+++ b/crates/core/src/plugins/tanstack_router.rs
@@ -1,12 +1,18 @@
 //! `TanStack` Router plugin.
 //!
 //! Detects `TanStack` Router projects and marks route files as entry points.
-//! Parses `tsr.config.json` to support custom route directories and generated
-//! route-tree locations.
+//! Parses `tsr.config.json` to support custom route directories, generated
+//! route-tree locations, and virtual route config.
 
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use super::{PathRule, Plugin, PluginResult, UsedExportRule, config_parser};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Argument, CallExpression, Expression, ImportDeclaration};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 
 const ENABLERS: &[&str] = &[
     "@tanstack/react-router",
@@ -14,6 +20,7 @@ const ENABLERS: &[&str] = &[
     "@tanstack/start",
     "@tanstack/react-start",
     "@tanstack/solid-start",
+    "@tanstack/virtual-file-routes",
 ];
 
 const DEFAULT_ROUTE_DIRS: &[&str] = &["src/routes", "app/routes"];
@@ -47,7 +54,9 @@ const TOOLING_DEPENDENCIES: &[&str] = &[
     "@tanstack/react-start",
     "@tanstack/solid-start",
     "@tanstack/router-cli",
+    "@tanstack/router-plugin",
     "@tanstack/router-vite-plugin",
+    "@tanstack/virtual-file-routes",
 ];
 
 const ROUTE_EXPORTS: &[&str] = &[
@@ -60,6 +69,7 @@ const ROUTE_EXPORTS: &[&str] = &[
     "pendingComponent",
     "notFoundComponent",
     "beforeLoad",
+    "ServerRoute",
 ];
 const LAZY_ROUTE_EXPORTS: &[&str] = &[
     "Route",
@@ -176,13 +186,25 @@ impl Plugin for TanstackRouterPlugin {
         let route_file_ignore_pattern =
             config_parser::extract_config_string(source, config_path, &["routeFileIgnorePattern"]);
 
-        add_route_dir_patterns(
-            &mut result,
-            &route_dir,
-            &route_file_prefix,
-            &route_file_ignore_prefix,
-            route_file_ignore_pattern.as_deref(),
-        );
+        let virtual_route_config =
+            resolve_virtual_route_config(config_path, source, root, &route_dir);
+        if virtual_route_config.is_empty() {
+            add_route_dir_patterns(
+                &mut result,
+                &route_dir,
+                &route_file_prefix,
+                &route_file_ignore_prefix,
+                route_file_ignore_pattern.as_deref(),
+            );
+        } else {
+            apply_virtual_route_config(
+                &mut result,
+                virtual_route_config,
+                &route_file_prefix,
+                &route_file_ignore_prefix,
+                route_file_ignore_pattern.as_deref(),
+            );
+        }
 
         let generated_route_tree =
             config_parser::extract_config_string(source, config_path, &["generatedRouteTree"])
@@ -196,6 +218,319 @@ impl Plugin for TanstackRouterPlugin {
         result.extend_entry_patterns(SUPPORTING_ENTRY_PATTERNS.iter().copied());
 
         result
+    }
+}
+
+#[derive(Debug, Default)]
+struct VirtualRouteConfig {
+    config_files: Vec<String>,
+    route_files: Vec<String>,
+    physical_dirs: Vec<String>,
+}
+
+impl VirtualRouteConfig {
+    fn is_empty(&self) -> bool {
+        self.config_files.is_empty() && self.route_files.is_empty() && self.physical_dirs.is_empty()
+    }
+}
+
+fn resolve_virtual_route_config(
+    config_path: &Path,
+    source: &str,
+    root: &Path,
+    route_dir: &str,
+) -> VirtualRouteConfig {
+    let mut config = VirtualRouteConfig::default();
+
+    if let Some(config_file) =
+        config_parser::extract_config_string(source, config_path, &["virtualRouteConfig"])
+            .as_deref()
+            .and_then(|raw| config_parser::normalize_config_path(raw, config_path, root))
+    {
+        push_unique(&mut config.config_files, config_file.clone());
+
+        let file_path = root.join(&config_file);
+        if let Ok(source) = fs::read_to_string(&file_path) {
+            let base_dir = Path::new(&config_file)
+                .parent()
+                .map_or_else(String::new, |parent| {
+                    parent.to_string_lossy().replace('\\', "/")
+                });
+            let refs = collect_virtual_route_call_refs(&source, &file_path);
+            for file in refs.route_files {
+                if let Some(path) = normalize_project_relative(&base_dir, &file) {
+                    push_unique(&mut config.route_files, path);
+                }
+            }
+            for dir in refs.physical_dirs {
+                if let Some(path) = normalize_project_relative(&base_dir, &dir) {
+                    push_unique(&mut config.physical_dirs, path);
+                }
+            }
+        }
+    }
+
+    for file in collect_inline_virtual_route_files(source) {
+        if let Some(path) = normalize_project_relative(route_dir, &file) {
+            push_unique(&mut config.route_files, path);
+        }
+    }
+
+    config
+}
+
+fn apply_virtual_route_config(
+    result: &mut PluginResult,
+    config: VirtualRouteConfig,
+    route_file_prefix: &str,
+    route_file_ignore_prefix: &str,
+    route_file_ignore_pattern: Option<&str>,
+) {
+    for config_file in config.config_files {
+        result.push_entry_pattern(config_file);
+    }
+    for route_file in config.route_files {
+        result.push_entry_pattern(route_file.clone());
+        result
+            .used_exports
+            .push(virtual_route_used_export_rule(&route_file));
+    }
+    for dir in config.physical_dirs {
+        result.entry_patterns.push(route_dir_rule(
+            &dir,
+            route_file_prefix,
+            route_file_ignore_prefix,
+            route_file_ignore_pattern,
+            RouteFileKind::Standard,
+        ));
+        result.entry_patterns.push(route_dir_rule(
+            &dir,
+            route_file_prefix,
+            route_file_ignore_prefix,
+            route_file_ignore_pattern,
+            RouteFileKind::Lazy,
+        ));
+        result.used_exports.push(route_dir_used_export_rule(
+            &dir,
+            route_file_prefix,
+            route_file_ignore_prefix,
+            route_file_ignore_pattern,
+        ));
+        result.used_exports.push(lazy_route_rule(
+            &dir,
+            route_file_prefix,
+            route_file_ignore_prefix,
+            route_file_ignore_pattern,
+        ));
+    }
+}
+
+fn virtual_route_used_export_rule(path: &str) -> UsedExportRule {
+    let exports = if path.contains(".lazy.") {
+        LAZY_ROUTE_EXPORTS
+    } else {
+        ROUTE_EXPORTS
+    };
+    UsedExportRule::new(path.to_string(), exports.iter().copied())
+}
+
+fn collect_inline_virtual_route_files(source: &str) -> Vec<String> {
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(source) else {
+        return Vec::new();
+    };
+    let Some(virtual_config) = json.get("virtualRouteConfig") else {
+        return Vec::new();
+    };
+
+    let mut files = Vec::new();
+    collect_json_file_properties(virtual_config, &mut files);
+    files
+}
+
+fn collect_json_file_properties(value: &serde_json::Value, files: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(object) => {
+            if let Some(serde_json::Value::String(file)) = object.get("file") {
+                push_unique(files, file.clone());
+            }
+            for child in object.values() {
+                collect_json_file_properties(child, files);
+            }
+        }
+        serde_json::Value::Array(array) => {
+            for child in array {
+                collect_json_file_properties(child, files);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[derive(Debug, Default)]
+struct VirtualRouteRefs {
+    route_files: Vec<String>,
+    physical_dirs: Vec<String>,
+}
+
+fn collect_virtual_route_call_refs(source: &str, path: &Path) -> VirtualRouteRefs {
+    let source_type = SourceType::from_path(path).unwrap_or_default();
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    let mut collector = VirtualRouteCallCollector::default();
+    collector.visit_program(&parsed.program);
+    collector.refs
+}
+
+#[derive(Default)]
+struct VirtualRouteCallCollector {
+    refs: VirtualRouteRefs,
+    helper_bindings: Vec<(String, String)>,
+    namespaces: Vec<String>,
+}
+
+impl<'a> Visit<'a> for VirtualRouteCallCollector {
+    fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
+        if decl.source.value != "@tanstack/virtual-file-routes" {
+            return;
+        }
+
+        if let Some(specifiers) = &decl.specifiers {
+            for specifier in specifiers {
+                match specifier {
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                        let helper = specifier.imported.name().to_string();
+                        if is_virtual_route_helper(&helper) {
+                            push_unique_pair(
+                                &mut self.helper_bindings,
+                                specifier.local.name.to_string(),
+                                helper,
+                            );
+                        }
+                    }
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportNamespaceSpecifier(
+                        specifier,
+                    ) => {
+                        push_unique(&mut self.namespaces, specifier.local.name.to_string());
+                    }
+                    oxc_ast::ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(_) => {}
+                }
+            }
+        }
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        if let Some(callee) = self.virtual_route_helper(call) {
+            match callee {
+                "rootRoute" | "index" => {
+                    if let Some(file) = string_arg(call, 0) {
+                        push_unique(&mut self.refs.route_files, file);
+                    }
+                }
+                "route" => {
+                    if let Some(file) = string_arg(call, 1) {
+                        push_unique(&mut self.refs.route_files, file);
+                    }
+                }
+                "layout" => {
+                    if let Some(file) = string_arg(call, 1).or_else(|| string_arg(call, 0)) {
+                        push_unique(&mut self.refs.route_files, file);
+                    }
+                }
+                "physical" => {
+                    if let Some(dir) = string_arg(call, 1).or_else(|| string_arg(call, 0)) {
+                        push_unique(&mut self.refs.physical_dirs, dir);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        walk::walk_call_expression(self, call);
+    }
+}
+
+impl VirtualRouteCallCollector {
+    fn virtual_route_helper<'a>(&'a self, call: &'a CallExpression<'a>) -> Option<&'a str> {
+        match &call.callee {
+            Expression::Identifier(identifier) => {
+                self.helper_bindings.iter().find_map(|(local, helper)| {
+                    (local == identifier.name.as_str()).then_some(helper.as_str())
+                })
+            }
+            Expression::StaticMemberExpression(member) if matches!(&member.object, Expression::Identifier(object) if self.namespaces.iter().any(|name| name == object.name.as_str())) =>
+            {
+                let helper = member.property.name.as_str();
+                is_virtual_route_helper(helper).then_some(helper)
+            }
+            _ => None,
+        }
+    }
+}
+
+fn is_virtual_route_helper(name: &str) -> bool {
+    matches!(
+        name,
+        "rootRoute" | "index" | "route" | "layout" | "physical"
+    )
+}
+
+fn push_unique_pair(values: &mut Vec<(String, String)>, local: String, helper: String) {
+    if !values.iter().any(|(existing, _)| existing == &local) {
+        values.push((local, helper));
+    }
+}
+
+fn string_arg(call: &CallExpression<'_>, index: usize) -> Option<String> {
+    call.arguments
+        .get(index)
+        .and_then(|argument| match argument {
+            Argument::StringLiteral(value) => Some(value.value.to_string()),
+            Argument::TemplateLiteral(value) if value.expressions.is_empty() => value
+                .quasis
+                .first()
+                .map(|quasi| quasi.value.raw.to_string()),
+            _ => None,
+        })
+}
+
+fn normalize_project_relative(base_dir: &str, raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.starts_with('/') || raw.contains("://") {
+        return None;
+    }
+
+    let path = Path::new(raw);
+    let joined = if path.is_absolute() {
+        PathBuf::from(path)
+    } else if base_dir.is_empty() {
+        path.to_path_buf()
+    } else {
+        Path::new(base_dir).join(path)
+    };
+
+    let normalized = lexical_normalize(&joined)
+        .to_string_lossy()
+        .replace('\\', "/");
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
     }
 }
 

--- a/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
+++ b/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
@@ -553,6 +553,107 @@ export const routes = rootRoute("root.tsx", [
 }
 
 #[test]
+fn tanstack_router_plain_vite_config_does_not_shadow_tsr_config() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_project_file(
+        root,
+        "package.json",
+        r#"{
+  "dependencies": {
+    "@tanstack/react-router": "1.0.0",
+    "vite": "1.0.0"
+  }
+}"#,
+    );
+    write_project_file(
+        root,
+        "vite.config.ts",
+        r#"import { defineConfig } from "vite";
+
+export default defineConfig({});
+"#,
+    );
+    write_project_file(
+        root,
+        "tsr.config.json",
+        r#"{
+  "routesDirectory": "./app/pages"
+}"#,
+    );
+    write_project_file(root, "app/pages/index.tsx", "export const Route = {};\n");
+    write_project_file(root, "src/routes/legacy.tsx", "export const Route = {};\n");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused_files = collect_unused_files(root, &results);
+    assert!(
+        !unused_files
+            .iter()
+            .any(|path| path == "app/pages/index.tsx"),
+        "tsr.config.json should keep custom route directory live even when a plain vite config is present, unused files: {unused_files:?}"
+    );
+    assert!(
+        unused_files
+            .iter()
+            .any(|path| path == "src/routes/legacy.tsx"),
+        "default src/routes should not stay alive after tsr.config.json moves routesDirectory, unused files: {unused_files:?}"
+    );
+}
+
+#[test]
+fn tanstack_router_webpack_cjs_config_is_covered() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_project_file(
+        root,
+        "package.json",
+        r#"{
+  "dependencies": {
+    "@tanstack/react-router": "1.0.0",
+    "@tanstack/router-plugin": "1.0.0",
+    "webpack": "1.0.0"
+  }
+}"#,
+    );
+    write_project_file(
+        root,
+        "webpack.config.cjs",
+        r#"const { tanstackRouter } = require("@tanstack/router-plugin/webpack");
+
+module.exports = {
+  plugins: [
+    tanstackRouter({
+      target: "react",
+      routesDirectory: "./app/pages"
+    })
+  ]
+};
+"#,
+    );
+    write_project_file(root, "app/pages/index.tsx", "export const Route = {};\n");
+    write_project_file(root, "src/routes/legacy.tsx", "export const Route = {};\n");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused_files = collect_unused_files(root, &results);
+    assert!(
+        !unused_files
+            .iter()
+            .any(|path| path == "app/pages/index.tsx"),
+        "CommonJS webpack tanstackRouter config should keep custom route directory live, unused files: {unused_files:?}"
+    );
+    assert!(
+        unused_files
+            .iter()
+            .any(|path| path == "src/routes/legacy.tsx"),
+        "default src/routes should not stay alive after webpack config moves routesDirectory, unused files: {unused_files:?}"
+    );
+}
+
+#[test]
 fn tanstack_router_custom_route_dir_replaces_default_used_export_rules() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();

--- a/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
+++ b/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
@@ -315,6 +315,244 @@ export const routes = rootRoute("root.tsx", [
 }
 
 #[test]
+fn tanstack_router_vite_plugin_inline_virtual_routes_are_covered() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_project_file(
+        root,
+        "package.json",
+        r#"{
+  "dependencies": {
+    "@tanstack/react-start": "1.0.0",
+    "@tanstack/router-plugin": "1.0.0",
+    "@tanstack/virtual-file-routes": "1.0.0",
+    "vite": "1.0.0"
+  }
+}"#,
+    );
+    write_project_file(
+        root,
+        "vite.config.ts",
+        r#"import { defineConfig } from "vite";
+import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import { index, layout, physical, rootRoute, route } from "@tanstack/virtual-file-routes";
+
+const routes = rootRoute("root.tsx", [
+  index("home.tsx"),
+  route("/admin", "admin/dashboard.tsx"),
+  layout("shell", "layouts/shell.tsx", [
+    route("/settings", "settings.tsx")
+  ]),
+  physical("physical")
+]);
+
+export default defineConfig({
+  plugins: [
+    tanstackRouter({
+      target: "react",
+      routesDirectory: "./src/virtual-routes",
+      generatedRouteTree: "./src/routeTree.gen.ts",
+      virtualRouteConfig: routes
+    })
+  ]
+});
+"#,
+    );
+    write_project_file(
+        root,
+        "src/routeTree.gen.ts",
+        "export const routeTree = {};\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/root.tsx",
+        "export const Route = {};\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/home.tsx",
+        "export const Route = {};\nexport function loader() {}\nexport const unusedHomeHelper = 1;\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/admin/dashboard.tsx",
+        "export const ServerRoute = {};\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/layouts/shell.tsx",
+        "export function beforeLoad() {}\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/settings.tsx",
+        "export const Route = {};\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/physical/index.tsx",
+        "export const Route = {};\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/physical/-helper.tsx",
+        "export const Route = {};\n",
+    );
+    write_project_file(
+        root,
+        "src/virtual-routes/orphan.tsx",
+        "export const Route = {};\n",
+    );
+    write_project_file(root, "src/routes/legacy.tsx", "export const Route = {};\n");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused_files = collect_unused_files(root, &results);
+    for path in [
+        "src/routeTree.gen.ts",
+        "src/virtual-routes/root.tsx",
+        "src/virtual-routes/home.tsx",
+        "src/virtual-routes/admin/dashboard.tsx",
+        "src/virtual-routes/layouts/shell.tsx",
+        "src/virtual-routes/settings.tsx",
+        "src/virtual-routes/physical/index.tsx",
+    ] {
+        assert!(
+            !unused_files.iter().any(|unused| unused == path),
+            "{path} should be reachable through vite tanstackRouter virtualRouteConfig, unused files: {unused_files:?}"
+        );
+    }
+    for path in [
+        "src/virtual-routes/physical/-helper.tsx",
+        "src/virtual-routes/orphan.tsx",
+        "src/routes/legacy.tsx",
+    ] {
+        assert!(
+            unused_files.iter().any(|unused| unused == path),
+            "{path} should not be treated as a configured virtual route, unused files: {unused_files:?}"
+        );
+    }
+
+    let unused_exports = collect_unused_exports(root, &results);
+    for (path, export) in [
+        ("src/virtual-routes/home.tsx", "loader"),
+        ("src/virtual-routes/admin/dashboard.tsx", "ServerRoute"),
+        ("src/virtual-routes/layouts/shell.tsx", "beforeLoad"),
+    ] {
+        assert!(
+            !has_unused_export(&unused_exports, path, export),
+            "{path}:{export} should be framework-used through vite tanstackRouter config, found: {unused_exports:?}"
+        );
+    }
+    assert!(
+        has_unused_export(
+            &unused_exports,
+            "src/virtual-routes/home.tsx",
+            "unusedHomeHelper"
+        ),
+        "ordinary helpers in virtual route files should still be reported, found: {unused_exports:?}"
+    );
+}
+
+#[test]
+fn tanstack_router_webpack_plugin_virtual_route_file_is_covered() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_project_file(
+        root,
+        "package.json",
+        r#"{
+  "dependencies": {
+    "@tanstack/react-router": "1.0.0",
+    "@tanstack/router-plugin": "1.0.0",
+    "@tanstack/virtual-file-routes": "1.0.0",
+    "webpack": "1.0.0"
+  }
+}"#,
+    );
+    write_project_file(
+        root,
+        "webpack.config.ts",
+        r#"import { tanstackRouter } from "@tanstack/router-plugin/webpack";
+
+export default {
+  plugins: [
+    tanstackRouter({
+      target: "react",
+      routesDirectory: "./app/pages",
+      generatedRouteTree: "./app/routeTree.gen.ts",
+      virtualRouteConfig: "./routes.ts"
+    })
+  ]
+};
+"#,
+    );
+    write_project_file(
+        root,
+        "routes.ts",
+        r#"import { index, rootRoute, route } from "@tanstack/virtual-file-routes";
+
+export const routes = rootRoute("root.tsx", [
+  index("home.tsx"),
+  route("/admin", "admin/dashboard.tsx")
+]);
+"#,
+    );
+    write_project_file(
+        root,
+        "app/routeTree.gen.ts",
+        "export const routeTree = {};\n",
+    );
+    write_project_file(root, "root.tsx", "export const Route = {};\n");
+    write_project_file(root, "home.tsx", "export const Route = {};\n");
+    write_project_file(
+        root,
+        "admin/dashboard.tsx",
+        "export const ServerRoute = {};\nexport const unusedDashboardHelper = 1;\n",
+    );
+    write_project_file(root, "app/pages/legacy.tsx", "export const Route = {};\n");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused_files = collect_unused_files(root, &results);
+    for path in [
+        "webpack.config.ts",
+        "routes.ts",
+        "app/routeTree.gen.ts",
+        "root.tsx",
+        "home.tsx",
+        "admin/dashboard.tsx",
+    ] {
+        assert!(
+            !unused_files.iter().any(|unused| unused == path),
+            "{path} should be reachable through webpack tanstackRouter virtualRouteConfig, unused files: {unused_files:?}"
+        );
+    }
+    assert!(
+        unused_files
+            .iter()
+            .any(|unused| unused == "app/pages/legacy.tsx"),
+        "virtualRouteConfig should replace the default route directory walk, unused files: {unused_files:?}"
+    );
+
+    let unused_exports = collect_unused_exports(root, &results);
+    assert!(
+        !has_unused_export(&unused_exports, "admin/dashboard.tsx", "ServerRoute"),
+        "ServerRoute export should be framework-used through webpack tanstackRouter config, found: {unused_exports:?}"
+    );
+    assert!(
+        has_unused_export(
+            &unused_exports,
+            "admin/dashboard.tsx",
+            "unusedDashboardHelper"
+        ),
+        "non-framework exports should still be reported, found: {unused_exports:?}"
+    );
+}
+
+#[test]
 fn tanstack_router_custom_route_dir_replaces_default_used_export_rules() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();

--- a/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
+++ b/crates/core/tests/integration_test/framework_convention_coverage_expo_tanstack.rs
@@ -169,6 +169,152 @@ fn tanstack_router_prefix_and_ignore_patterns_stay_strict() {
 }
 
 #[test]
+fn tanstack_router_inline_virtual_route_config_is_covered() {
+    let root = fixture_path("tanstack-router-virtual-routes");
+    let config = create_config(root.clone());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused_files = collect_unused_files(&root, &results);
+    for path in [
+        "src/routeTree.gen.ts",
+        "src/virtual-routes/root.tsx",
+        "src/virtual-routes/home.tsx",
+        "src/virtual-routes/admin/dashboard.tsx",
+        "src/virtual-routes/layouts/shell.tsx",
+        "src/virtual-routes/settings.tsx",
+    ] {
+        assert!(
+            !unused_files.iter().any(|unused| unused == path),
+            "{path} should be reachable through inline virtualRouteConfig, unused files: {unused_files:?}"
+        );
+    }
+    assert!(
+        unused_files
+            .iter()
+            .any(|unused| unused == "src/virtual-routes/orphan.tsx"),
+        "virtualRouteConfig should not keep unlisted route files alive, unused files: {unused_files:?}"
+    );
+
+    let unused_exports = collect_unused_exports(&root, &results);
+    for (path, export) in [
+        ("src/virtual-routes/root.tsx", "Route"),
+        ("src/virtual-routes/home.tsx", "Route"),
+        ("src/virtual-routes/home.tsx", "loader"),
+        ("src/virtual-routes/admin/dashboard.tsx", "ServerRoute"),
+        ("src/virtual-routes/layouts/shell.tsx", "beforeLoad"),
+    ] {
+        assert!(
+            !has_unused_export(&unused_exports, path, export),
+            "{path}:{export} should be framework-used through virtualRouteConfig, found: {unused_exports:?}"
+        );
+    }
+    assert!(
+        has_unused_export(
+            &unused_exports,
+            "src/virtual-routes/home.tsx",
+            "unusedHomeHelper"
+        ),
+        "ordinary helpers in virtual route files should still be reported, found: {unused_exports:?}"
+    );
+}
+
+#[test]
+fn tanstack_router_virtual_route_config_file_is_covered() {
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path();
+
+    write_project_file(
+        root,
+        "package.json",
+        r#"{
+  "dependencies": {
+    "@tanstack/react-start": "1.0.0",
+    "@tanstack/virtual-file-routes": "1.0.0"
+  }
+}"#,
+    );
+    write_project_file(
+        root,
+        "tsr.config.json",
+        r#"{
+  "virtualRouteConfig": "./routes.ts",
+  "generatedRouteTree": "./routeTree.gen.ts"
+}"#,
+    );
+    write_project_file(
+        root,
+        "routes.ts",
+        r#"import { index, layout, physical, rootRoute, route } from "@tanstack/virtual-file-routes";
+
+export const routes = rootRoute("root.tsx", [
+  index("home.tsx"),
+  route("/admin", "admin/dashboard.tsx"),
+  layout("shell", "layouts/shell.tsx", [
+    route("/settings", "settings.tsx")
+  ]),
+  physical("physical")
+]);
+"#,
+    );
+    write_project_file(root, "routeTree.gen.ts", "export const routeTree = {};\n");
+    write_project_file(root, "root.tsx", "export const Route = {};\n");
+    write_project_file(root, "home.tsx", "export const Route = {};\n");
+    write_project_file(
+        root,
+        "admin/dashboard.tsx",
+        "export const ServerRoute = {};\nexport const unusedDashboardHelper = 1;\n",
+    );
+    write_project_file(
+        root,
+        "layouts/shell.tsx",
+        "export function beforeLoad() {}\n",
+    );
+    write_project_file(root, "settings.tsx", "export const Route = {};\n");
+    write_project_file(root, "physical/index.tsx", "export const Route = {};\n");
+    write_project_file(root, "physical/-helper.tsx", "export const Route = {};\n");
+    write_project_file(root, "src/routes/orphan.tsx", "export const Route = {};\n");
+
+    let config = create_config(root.to_path_buf());
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+    let unused_files = collect_unused_files(root, &results);
+    for path in [
+        "routes.ts",
+        "routeTree.gen.ts",
+        "root.tsx",
+        "home.tsx",
+        "admin/dashboard.tsx",
+        "layouts/shell.tsx",
+        "settings.tsx",
+        "physical/index.tsx",
+    ] {
+        assert!(
+            !unused_files.iter().any(|unused| unused == path),
+            "{path} should be reachable through virtual route config file, unused files: {unused_files:?}"
+        );
+    }
+    for path in ["physical/-helper.tsx", "src/routes/orphan.tsx"] {
+        assert!(
+            unused_files.iter().any(|unused| unused == path),
+            "{path} should not be treated as a configured virtual route, unused files: {unused_files:?}"
+        );
+    }
+
+    let unused_exports = collect_unused_exports(root, &results);
+    assert!(
+        !has_unused_export(&unused_exports, "admin/dashboard.tsx", "ServerRoute"),
+        "Start ServerRoute export should be framework-used, found: {unused_exports:?}"
+    );
+    assert!(
+        has_unused_export(
+            &unused_exports,
+            "admin/dashboard.tsx",
+            "unusedDashboardHelper"
+        ),
+        "non-framework exports should still be reported, found: {unused_exports:?}"
+    );
+}
+
+#[test]
 fn tanstack_router_custom_route_dir_replaces_default_used_export_rules() {
     let temp = tempdir().expect("create temp dir");
     let root = temp.path();

--- a/tests/fixtures/tanstack-router-virtual-routes/package.json
+++ b/tests/fixtures/tanstack-router-virtual-routes/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tanstack-router-virtual-routes",
+  "dependencies": {
+    "@tanstack/react-start": "1.0.0",
+    "@tanstack/virtual-file-routes": "1.0.0"
+  }
+}

--- a/tests/fixtures/tanstack-router-virtual-routes/src/routeTree.gen.ts
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/routeTree.gen.ts
@@ -1,0 +1,1 @@
+export const routeTree = {};

--- a/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/admin/dashboard.tsx
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/admin/dashboard.tsx
@@ -1,0 +1,3 @@
+export const ServerRoute = {};
+
+export const unusedDashboardHelper = "unused";

--- a/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/home.tsx
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/home.tsx
@@ -1,0 +1,7 @@
+export const Route = {};
+
+export async function loader() {
+    return { ok: true };
+}
+
+export const unusedHomeHelper = "unused";

--- a/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/layouts/shell.tsx
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/layouts/shell.tsx
@@ -1,0 +1,3 @@
+export const Route = {};
+
+export function beforeLoad() {}

--- a/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/orphan.tsx
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/orphan.tsx
@@ -1,0 +1,1 @@
+export const Route = {};

--- a/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/root.tsx
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/root.tsx
@@ -1,0 +1,3 @@
+export const Route = {};
+
+export const unusedRootHelper = "unused";

--- a/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/settings.tsx
+++ b/tests/fixtures/tanstack-router-virtual-routes/src/virtual-routes/settings.tsx
@@ -1,0 +1,1 @@
+export const Route = {};

--- a/tests/fixtures/tanstack-router-virtual-routes/tsr.config.json
+++ b/tests/fixtures/tanstack-router-virtual-routes/tsr.config.json
@@ -1,0 +1,31 @@
+{
+  "routesDirectory": "./src/virtual-routes",
+  "generatedRouteTree": "./src/routeTree.gen.ts",
+  "virtualRouteConfig": {
+    "type": "root",
+    "file": "root.tsx",
+    "children": [
+      {
+        "type": "index",
+        "file": "home.tsx"
+      },
+      {
+        "type": "route",
+        "path": "/admin",
+        "file": "admin/dashboard.tsx"
+      },
+      {
+        "type": "layout",
+        "id": "shell",
+        "file": "layouts/shell.tsx",
+        "children": [
+          {
+            "type": "route",
+            "path": "/settings",
+            "file": "settings.tsx"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds deeper TanStack Router support for virtual file routes.

This covers tsr.config.json plus Vite, Rspack/Rsbuild, and Webpack tanstackRouter configs. It handles custom route dirs, generated route trees, virtualRouteConfig files, inline virtual route trees, physical routes, and Start ServerRoute exports.

Validation:
cargo fmt
cargo clippy -p fallow-core --tests -- -D warnings
cargo test -p fallow-core --test integration_test framework_convention_coverage_expo_tanstack
cargo test -p fallow-core --lib plugins::tanstack_router