### PR TITLE
fix: bind nullable class annotations for member usage

### DIFF
--- a/crates/core/tests/integration_test/member_detection.rs
+++ b/crates/core/tests/integration_test/member_detection.rs
@@ -293,3 +293,39 @@ fn enum_type_level_usage_no_false_positives() {
         "Right should not be unused (keyof typeof in mapped type), found: {unused_enum_member_names:?}"
     );
 }
+
+// ── Typed-binding nullable unions ─────────
+
+#[test]
+fn typed_binding_through_nullable_unions_credits_class_methods() {
+    let root = fixture_path("typed-binding-wrappers");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unused: Vec<String> = results
+        .unused_class_members
+        .iter()
+        .map(|m| format!("{}.{}", m.parent_name, m.member_name))
+        .collect();
+
+    // `let pending: Aggregate | undefined; pending.rename();` reaches rename
+    // through the nullable-union branch of `extract_type_reference_name`.
+    assert!(
+        !unused.contains(&"Aggregate.rename".to_string()),
+        "Aggregate.rename should be credited through `Aggregate | undefined`, found unused: {unused:?}"
+    );
+
+    // `const ready: Promise<Aggregate> = ...; ready.archive();` is a member
+    // access on the Promise object, not on Aggregate. It should not credit
+    // Aggregate.archive.
+    assert!(
+        unused.contains(&"Aggregate.archive".to_string()),
+        "Aggregate.archive should not be credited through `Promise<Aggregate>`, found unused: {unused:?}"
+    );
+
+    // unusedMethod has no call site in any form and should still be reported.
+    assert!(
+        unused.contains(&"Aggregate.unusedMethod".to_string()),
+        "Aggregate.unusedMethod should still be flagged as unused, found unused: {unused:?}"
+    );
+}

--- a/crates/extract/src/cache/types.rs
+++ b/crates/extract/src/cache/types.rs
@@ -7,7 +7,7 @@ use bitcode::{Decode, Encode};
 use crate::MemberKind;
 
 /// Cache version — bump when the cache format or cached extraction semantics change.
-pub(super) const CACHE_VERSION: u32 = 57;
+pub(super) const CACHE_VERSION: u32 = 58;
 
 /// Maximum cache file size to deserialize (256 MB).
 pub(super) const MAX_CACHE_SIZE: usize = 256 * 1024 * 1024;

--- a/crates/extract/src/visitor/helpers.rs
+++ b/crates/extract/src/visitor/helpers.rs
@@ -507,13 +507,46 @@ pub fn extract_class_instance_bindings(class: &Class<'_>) -> Vec<(String, String
 }
 
 /// Extract a simple referenced type name from a TypeScript type node.
+///
+/// Beyond the bare `TSTypeReference` and parenthesized cases, the helper also
+/// peels back nullable wrappers commonly produced by repository-hydration code
+/// paths so the underlying class is still reachable for member tracking:
+///
+/// - `T | null`, `T | undefined`, `T | null | undefined` — extracts `T` when
+///   exactly one branch reduces to a class and the rest are `null`/`undefined`.
+///   Catches the dominant nullable-return pattern `let x: Aggregate | undefined`.
+///
+/// The peel stays strictly syntactic. Wider unions (e.g. `T | U` between two
+/// classes) are intentionally unsupported — there is no single class for the
+/// caller to bind to. `Array<T>`, `Set<T>`, etc. are deliberately not unwrapped:
+/// the binding refers to the collection, not its element.
 #[must_use]
 pub fn extract_type_reference_name(ty: &TSType<'_>) -> Option<String> {
     match ty {
         TSType::TSTypeReference(type_ref) => extract_type_name(&type_ref.type_name),
         TSType::TSParenthesizedType(paren) => extract_type_reference_name(&paren.type_annotation),
+        TSType::TSUnionType(union) => extract_nullable_union_name(union),
         _ => None,
     }
+}
+
+/// Return the single non-nullish branch of a union when every other branch is
+/// `null` or `undefined`. Anything else (multi-class unions, literal unions,
+/// intersections) returns `None` — callers expect a single underlying class.
+fn extract_nullable_union_name(union: &oxc_ast::ast::TSUnionType<'_>) -> Option<String> {
+    let mut found: Option<String> = None;
+    for branch in &union.types {
+        match branch {
+            TSType::TSNullKeyword(_) | TSType::TSUndefinedKeyword(_) => {}
+            other => {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(extract_type_reference_name(other)?);
+            }
+        }
+    }
+    found
 }
 
 fn extract_static_expression_name(expr: &Expression<'_>) -> Option<String> {

--- a/crates/extract/src/visitor/tests.rs
+++ b/crates/extract/src/visitor/tests.rs
@@ -704,6 +704,160 @@ fn array_destructured_no_factory_not_tracked() {
     );
 }
 
+// ── Typed-binding nullable unions ─────
+
+#[test]
+fn type_annotation_nullable_union_undefined_binds_class() {
+    let info = parse(
+        r"
+            import { Aggregate } from './aggregate';
+            let x: Aggregate | undefined;
+            x = loadAggregate();
+            x.someMutation();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "x.someMutation() should map to Aggregate.someMutation through `Aggregate | undefined`, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_nullable_union_null_binds_class() {
+    let info = parse(
+        r"
+            import { Aggregate } from './aggregate';
+            let x: Aggregate | null;
+            x.someMutation();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "x.someMutation() should map through `Aggregate | null`, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_three_way_nullable_union_binds_class() {
+    let info = parse(
+        r"
+            import { Aggregate } from './aggregate';
+            let x: Aggregate | null | undefined;
+            x.someMutation();
+            ",
+    );
+    assert!(
+        info.member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "x.someMutation() should map through `Aggregate | null | undefined`, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_promise_not_unwrapped() {
+    let info = parse(
+        r"
+            import { Aggregate } from './aggregate';
+            const result: Promise<Aggregate> = repo.findById(id);
+            result.someMutation();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "Promise<Aggregate> should not bind Promise object members to Aggregate, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_promise_nullable_union_not_unwrapped() {
+    let info = parse(
+        r"
+            import { Aggregate } from './aggregate';
+            const result: Promise<Aggregate | undefined> = repo.findById(id);
+            result.someMutation();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "Promise<Aggregate | undefined> should not bind Promise object members to Aggregate, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_multi_class_union_not_bound() {
+    let info = parse(
+        r"
+            import { Aggregate, Other } from './aggregate';
+            let x: Aggregate | Other;
+            x.someMutation();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| (a.object == "Aggregate" || a.object == "Other") && a.member == "someMutation"),
+        "ambiguous `Aggregate | Other` union should not pick a class, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_array_generic_not_unwrapped() {
+    let info = parse(
+        r"
+            import { Aggregate } from './aggregate';
+            let xs: Array<Aggregate>;
+            xs.someMutation();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "Array<Aggregate> binds the array, not its element type, found: {:?}",
+        info.member_accesses
+    );
+}
+
+#[test]
+fn type_annotation_qualified_promise_not_unwrapped() {
+    // `Foo.Promise<Aggregate>` is not the global Promise; binding should fall back
+    // to the bare reference name (`Foo.Promise`), not unwrap to `Aggregate`.
+    let info = parse(
+        r"
+            import { Aggregate, Foo } from './foo';
+            let x: Foo.Promise<Aggregate>;
+            x.someMutation();
+            ",
+    );
+    assert!(
+        !info
+            .member_accesses
+            .iter()
+            .any(|a| a.object == "Aggregate" && a.member == "someMutation"),
+        "qualified `Foo.Promise<Aggregate>` should not unwrap to Aggregate, found: {:?}",
+        info.member_accesses
+    );
+}
+
 // ── this.field chained member access ────────────────────────
 
 #[test]

--- a/tests/fixtures/typed-binding-wrappers/package.json
+++ b/tests/fixtures/typed-binding-wrappers/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "typed-binding-wrappers",
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/typed-binding-wrappers/src/aggregate.ts
+++ b/tests/fixtures/typed-binding-wrappers/src/aggregate.ts
@@ -1,0 +1,7 @@
+export class Aggregate {
+    rename(): void {}
+
+    archive(): void {}
+
+    unusedMethod(): void {}
+}

--- a/tests/fixtures/typed-binding-wrappers/src/index.ts
+++ b/tests/fixtures/typed-binding-wrappers/src/index.ts
@@ -1,0 +1,17 @@
+import { Aggregate } from './aggregate';
+import { AggregateRepo } from './repo';
+
+const repo = new AggregateRepo();
+
+// `Aggregate | undefined` annotation — the dominant nullable repository
+// boundary pattern. `rename()` is reached only through this binding.
+let pending: Aggregate | undefined;
+pending = new Aggregate();
+pending.rename();
+
+// `Promise<Aggregate>` annotation. A member access on the Promise object should
+// not be credited as an Aggregate member use.
+const ready: Promise<Aggregate> = Promise.resolve(new Aggregate());
+ready.archive();
+
+void repo.findById('id');

--- a/tests/fixtures/typed-binding-wrappers/src/repo.ts
+++ b/tests/fixtures/typed-binding-wrappers/src/repo.ts
@@ -1,0 +1,7 @@
+import { Aggregate } from './aggregate';
+
+export class AggregateRepo {
+    findById(_id: string): Promise<Aggregate | undefined> {
+        return Promise.resolve(new Aggregate());
+    }
+}


### PR DESCRIPTION
## What

- Bind TypeScript nullable union annotations like `T | undefined`, `T | null`, and `T | null | undefined` to the underlying class for member usage tracking.
- Keep wider unions and wrapper generics such as `Promise<T>` unsupported to avoid crediting member accesses on the wrong object.
- Add extractor and integration coverage for nullable unions, ambiguous unions, arrays, and Promise annotations.

## Why

This reduces false positives for `unused-class-members` when instance variables are explicitly annotated with nullable repository-style types, while preserving Fallow's syntactic analysis model and avoiding unsafe Promise unwrapping.

## Test plan

- `.githooks/pre-commit`
- `cargo test --workspace --all-targets`
- `cargo test -p fallow-cli --features test-sidecar-key --test runtime_coverage_tests`
- `cargo clippy -p fallow-cli --features test-sidecar-key --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `cd crates/napi && npm ci --omit=optional`
- `cd crates/napi && npm run build:debug`
- `cd crates/napi && npm test`
- `typos`
- `cargo audit`
- `cargo deny check`
- `cargo shear`
- `git diff --check`