### PR TITLE
refactor(scripts): share could_be_file_path with parse_scripts

### DIFF
--- a/crates/core/src/discover/parse_scripts.rs
+++ b/crates/core/src/discover/parse_scripts.rs
@@ -72,6 +72,9 @@ pub fn extract_script_file_refs(script: &str) -> Vec<String> {
 /// Check if a token looks like a file path argument (has a directory separator or a
 /// JS/TS file extension).
 pub fn looks_like_file_path(token: &str) -> bool {
+    if !crate::scripts::could_be_file_path(token) {
+        return false;
+    }
     let extensions = [".js", ".ts", ".mjs", ".cjs", ".mts", ".cts", ".jsx", ".tsx"];
     if extensions.iter().any(|ext| token.ends_with(ext)) {
         return true;
@@ -86,6 +89,9 @@ pub fn looks_like_file_path(token: &str) -> bool {
 /// Check if a token looks like a standalone script file reference (must have a
 /// JS/TS extension and a path-like structure, not a bare command name).
 pub fn looks_like_script_file(token: &str) -> bool {
+    if !crate::scripts::could_be_file_path(token) {
+        return false;
+    }
     let extensions = [".js", ".ts", ".mjs", ".cjs", ".mts", ".cts", ".jsx", ".tsx"];
     if !extensions.iter().any(|ext| token.ends_with(ext)) {
         return false;
@@ -188,6 +194,36 @@ mod tests {
         // Bare names without path separator should not match
         assert!(!looks_like_script_file("webpack.js"));
         assert!(!looks_like_script_file("build"));
+    }
+
+    // Negative-guard tests (shared with scripts::could_be_file_path):
+    // tokens whose syntax precludes a Unix path must not be classified as
+    // script file references, even when their suffix matches a known
+    // extension.
+
+    #[test]
+    fn looks_like_file_path_rejects_gha_fragments() {
+        assert!(!looks_like_file_path("${{ env.URL }}/api.ts"));
+        assert!(!looks_like_file_path("}}/api/health.ts"));
+    }
+
+    #[test]
+    fn looks_like_file_path_rejects_backslash_and_bracket_class() {
+        assert!(!looks_like_file_path(r"path\to\file.ts"));
+        assert!(!looks_like_file_path(".[]"));
+        assert!(!looks_like_file_path("prefix/[^unclosed.ts"));
+    }
+
+    #[test]
+    fn looks_like_file_path_passes_nextjs_dynamic_route() {
+        assert!(looks_like_file_path("app/[id]/page.tsx"));
+        assert!(looks_like_file_path("pages/[...slug].ts"));
+    }
+
+    #[test]
+    fn looks_like_script_file_rejects_gha_and_regex_fragments() {
+        assert!(!looks_like_script_file("${{ env.X }}/path.ts"));
+        assert!(!looks_like_script_file(r"path\file.ts"));
     }
 
     mod proptests {

--- a/crates/core/src/scripts/mod.rs
+++ b/crates/core/src/scripts/mod.rs
@@ -343,9 +343,10 @@ fn is_env_assignment(token: &str) -> bool {
 
 /// Reject tokens whose syntax precludes a Unix path (GHA expressions,
 /// backslash escapes, malformed `[...]`). Used as a pre-filter before
-/// globset compilation. Lenient: passes bare names without extensions
-/// (e.g. `deploy.log`, `Makefile`).
-fn could_be_file_path(token: &str) -> bool {
+/// globset compilation and as a shared single-source-of-truth negative
+/// guard for sibling script extractors. Lenient: passes bare names
+/// without extensions (e.g. `deploy.log`, `Makefile`).
+pub fn could_be_file_path(token: &str) -> bool {
     // GitHub Actions expressions split on whitespace into chunks like
     // `}}/path"`. Reject any token containing `${{`, or a stray `}}` that
     // is not balanced by `{{` (which would be a Mustache/Handlebars


### PR DESCRIPTION
## Summary

Follow-up to #262. PR #262 added `could_be_file_path` in `crates/core/src/scripts/mod.rs` as a negative-only guard that rejects tokens whose syntax precludes a Unix path (GHA expressions, backslash escapes, malformed `[...]`). The sibling classifiers in `crates/core/src/discover/parse_scripts.rs` (`looks_like_file_path`, `looks_like_script_file`) classify the same kinds of tokens for package.json / Dockerfile / Procfile / fly.toml extraction.

These discover-side classifiers do **not** feed globset (they feed `resolve_entry_path_with_tracking`'s real-fs `is_file()` check), so no `invalid entry pattern` warning was ever emitted from this path. There is no behavioral bug today.

But maintaining two near-identical classifiers invites drift, so promote `could_be_file_path` from private to `pub` and call it as a pre-filter from the discover-side classifiers. Single source of truth, micro perf win (skip `Path::join` + `is_file` syscalls on tokens that cannot be paths), zero behavioral change for users.

## Changes

- `crates/core/src/scripts/mod.rs`: `fn could_be_file_path` → `pub fn`, doc comment updated to mention shared use.
- `crates/core/src/discover/parse_scripts.rs`: both `looks_like_file_path` and `looks_like_script_file` call `crate::scripts::could_be_file_path` first.
- 4 new unit tests mirroring those in `scripts/mod.rs` (GHA fragments, backslash, bracket-class, Next.js dynamic-route positive cases).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p fallow-core -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `typos crates/core/src/{scripts,discover/parse_scripts.rs}` clean
- [x] `cargo test -p fallow-core --lib` 1917/1917
- [x] `cargo test -p fallow-core --tests` 297/297
- [x] `cargo test --workspace` all green
- [x] Behavioral parity on `benchmarks/fixtures/real-world/next.js`: `total_issues=24825` matches PR #262 baseline; 0 `invalid entry pattern` warnings (unchanged).