### PR TITLE
feat(vitest): recognize __mocks__ specifiers as virtual

### DIFF
--- a/crates/core/src/analyze/unused_deps.rs
+++ b/crates/core/src/analyze/unused_deps.rs
@@ -704,6 +704,16 @@ pub fn find_unlisted_dependencies(
         })
         .unwrap_or_default();
 
+    // Collect virtual package suffixes from active plugins (e.g., Vitest /__mocks__)
+    let virtual_suffixes: Vec<&str> = plugin_result
+        .map(|pr| {
+            pr.virtual_package_suffixes
+                .iter()
+                .map(String::as_str)
+                .collect()
+        })
+        .unwrap_or_default();
+
     // Collect tooling dependencies from active plugins — these are framework-provided
     // packages (e.g., Nuxt provides `ofetch`, `h3`, `vue-router` at runtime) that may
     // be imported in user code without being listed in package.json.
@@ -754,6 +764,15 @@ pub fn find_unlisted_dependencies(
                     .strip_suffix('/')
                     .is_some_and(|base| package_name == base)
         }) {
+            continue;
+        }
+        // Plain `ends_with` is sufficient for suffixes; unlike prefixes, suffix
+        // entries always include the leading boundary character (e.g. `/__mocks__`)
+        // so there is no bare-equality case to special-case.
+        if virtual_suffixes
+            .iter()
+            .any(|suffix| package_name.ends_with(suffix))
+        {
             continue;
         }
         // Quick check: if an external dependency is listed in any root or workspace

--- a/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
+++ b/crates/core/src/analyze/unused_deps_tests/unlisted_deps.rs
@@ -407,6 +407,68 @@ fn unlisted_dep_detected_across_multiple_files() {
     );
 }
 
+// ---- virtual_package_suffixes suppression ----
+
+#[test]
+fn vitest_mocks_package_not_reported_as_unlisted_via_suffix() {
+    // Imports like `@aws-sdk/__mocks__` should not be flagged when Vitest plugin
+    // contributes `/__mocks__` as a virtual package suffix.
+    let (graph, resolved_modules) = build_graph_with_npm_imports(&[("@aws-sdk/__mocks__", false)]);
+    let pkg = make_pkg(&[], &["vitest"], &[]);
+    let config = test_config(PathBuf::from("/project"));
+    let line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+
+    let mut plugin_result = AggregatedPluginResult::default();
+    plugin_result
+        .virtual_package_suffixes
+        .push("/__mocks__".to_string());
+
+    let unlisted = find_unlisted_dependencies(
+        &graph,
+        &pkg,
+        &config,
+        &[],
+        Some(&plugin_result),
+        &resolved_modules,
+        &line_offsets,
+    );
+
+    assert!(
+        unlisted.is_empty(),
+        "no unlisted deps expected when /__mocks__ suffix matches; got: {:?}",
+        unlisted.iter().map(|d| &d.package_name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn plain_mocks_package_not_reported_as_unlisted_via_suffix() {
+    let (graph, resolved_modules) = build_graph_with_npm_imports(&[("some-pkg/__mocks__", false)]);
+    let pkg = make_pkg(&[], &[], &[]);
+    let config = test_config(PathBuf::from("/project"));
+    let line_offsets: LineOffsetsMap<'_> = FxHashMap::default();
+
+    let mut plugin_result = AggregatedPluginResult::default();
+    plugin_result
+        .virtual_package_suffixes
+        .push("/__mocks__".to_string());
+
+    let unlisted = find_unlisted_dependencies(
+        &graph,
+        &pkg,
+        &config,
+        &[],
+        Some(&plugin_result),
+        &resolved_modules,
+        &line_offsets,
+    );
+
+    assert!(
+        unlisted.is_empty(),
+        "no unlisted deps expected when /__mocks__ suffix matches unscoped; got: {:?}",
+        unlisted.iter().map(|d| &d.package_name).collect::<Vec<_>>()
+    );
+}
+
 // ---- Additional coverage: find_unlisted_dependencies with optional dep listed ----
 
 #[test]

--- a/crates/core/src/analyze/unused_exports.rs
+++ b/crates/core/src/analyze/unused_exports.rs
@@ -1371,6 +1371,7 @@ mod tests {
             tooling_dependencies: vec![],
             script_used_packages: FxHashSet::default(),
             virtual_module_prefixes: vec![],
+            virtual_package_suffixes: vec![],
             generated_import_patterns: vec![],
             path_aliases: vec![],
             active_plugins: vec![],

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1064,6 +1064,20 @@ fn run_plugins(
         result.virtual_module_prefixes.iter().cloned().collect();
     let mut seen_generated: rustc_hash::FxHashSet<String> =
         result.generated_import_patterns.iter().cloned().collect();
+    let mut seen_suffixes: rustc_hash::FxHashSet<String> =
+        result.virtual_package_suffixes.iter().cloned().collect();
+
+    fn extend_unique(
+        target: &mut Vec<String>,
+        seen: &mut rustc_hash::FxHashSet<String>,
+        items: Vec<String>,
+    ) {
+        for item in items {
+            if seen.insert(item.clone()) {
+                target.push(item);
+            }
+        }
+    }
     for (ws_result, ws_prefix) in ws_results {
         // Prefix helper: workspace-relative patterns need the workspace prefix
         // to be matchable from the monorepo root. But patterns that are already
@@ -1118,22 +1132,25 @@ fn run_plugins(
         result
             .tooling_dependencies
             .extend(ws_result.tooling_dependencies);
-        // Virtual module prefixes (e.g., Docusaurus @theme/, @site/) are
-        // package-name prefixes, not file paths — no workspace prefix needed.
-        for prefix in ws_result.virtual_module_prefixes {
-            if !seen_prefixes.contains(&prefix) {
-                seen_prefixes.insert(prefix.clone());
-                result.virtual_module_prefixes.push(prefix);
-            }
-        }
-        // Generated import patterns (e.g., SvelteKit /$types) are suffix
-        // matches on specifiers, not file paths — no workspace prefix needed.
-        for pattern in ws_result.generated_import_patterns {
-            if !seen_generated.contains(&pattern) {
-                seen_generated.insert(pattern.clone());
-                result.generated_import_patterns.push(pattern);
-            }
-        }
+        // Virtual import boundaries — prefixes (e.g., Docusaurus `@theme/`),
+        // generated import patterns (e.g., SvelteKit `/$types`), and package-name
+        // suffixes (e.g., Vitest `/__mocks__`) — match against import specifiers
+        // or package names, never file paths, so no workspace prefix is applied.
+        extend_unique(
+            &mut result.virtual_module_prefixes,
+            &mut seen_prefixes,
+            ws_result.virtual_module_prefixes,
+        );
+        extend_unique(
+            &mut result.generated_import_patterns,
+            &mut seen_generated,
+            ws_result.generated_import_patterns,
+        );
+        extend_unique(
+            &mut result.virtual_package_suffixes,
+            &mut seen_suffixes,
+            ws_result.virtual_package_suffixes,
+        );
         // Path aliases from workspace plugins (e.g., SvelteKit $lib/ → src/lib).
         // Prefix the replacement directory so it resolves from the monorepo root.
         for (prefix, replacement) in ws_result.path_aliases {

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -633,6 +633,15 @@ pub trait Plugin: Send + Sync {
         &[]
     }
 
+    /// Package name suffixes that are virtual modules provided by this framework
+    /// at build time (e.g., test runner mock conventions).
+    /// Imports matching these suffixes should not be flagged as unlisted dependencies.
+    /// Each entry is matched as a suffix against the extracted package name
+    /// (e.g., `"/__mocks__"` matches `@aws-sdk/__mocks__` and `some-pkg/__mocks__`).
+    fn virtual_package_suffixes(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Import suffixes for build-time generated relative imports.
     ///
     /// Unresolved relative imports whose specifier ends with one of these suffixes
@@ -1149,6 +1158,7 @@ mod tests {
             plugin.tooling_dependencies().is_empty() || !plugin.tooling_dependencies().is_empty()
         );
         assert!(plugin.virtual_module_prefixes().is_empty());
+        assert!(plugin.virtual_package_suffixes().is_empty());
         assert!(plugin.path_aliases(Path::new("/project")).is_empty());
         assert!(
             plugin.package_json_config_key().is_none()
@@ -1236,6 +1246,11 @@ mod tests {
     #[test]
     fn default_virtual_module_prefixes_is_empty() {
         assert!(MinimalPlugin.virtual_module_prefixes().is_empty());
+    }
+
+    #[test]
+    fn default_virtual_package_suffixes_is_empty() {
+        assert!(MinimalPlugin.virtual_package_suffixes().is_empty());
     }
 
     #[test]

--- a/crates/core/src/plugins/registry/helpers.rs
+++ b/crates/core/src/plugins/registry/helpers.rs
@@ -49,6 +49,9 @@ pub fn process_static_patterns(
     for prefix in plugin.virtual_module_prefixes() {
         result.virtual_module_prefixes.push((*prefix).to_string());
     }
+    for suffix in plugin.virtual_package_suffixes() {
+        result.virtual_package_suffixes.push((*suffix).to_string());
+    }
     for pattern in plugin.generated_import_patterns() {
         result
             .generated_import_patterns

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -58,6 +58,9 @@ pub struct AggregatedPluginResult {
     /// Import prefixes for virtual modules provided by active frameworks.
     /// Imports matching these prefixes should not be flagged as unlisted dependencies.
     pub virtual_module_prefixes: Vec<String>,
+    /// Package name suffixes that identify virtual or convention-based specifiers.
+    /// Extracted package names ending with any of these suffixes are not flagged as unlisted.
+    pub virtual_package_suffixes: Vec<String>,
     /// Import suffixes for build-time generated relative imports.
     /// Unresolved imports ending with these suffixes are suppressed.
     pub generated_import_patterns: Vec<String>,

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -487,6 +487,19 @@ fn nuxt_contributes_virtual_module_prefixes() {
     );
 }
 
+#[test]
+fn vitest_contributes_mocks_virtual_package_suffix() {
+    let registry = PluginRegistry::default();
+    let pkg = make_pkg_dev(&["vitest"]);
+    let result = registry.run(&pkg, Path::new("/project"), &[]);
+    assert!(
+        result
+            .virtual_package_suffixes
+            .contains(&"/__mocks__".to_string()),
+        "vitest should contribute '/__mocks__' virtual package suffix"
+    );
+}
+
 // ── process_static_patterns: always_used aggregation ─────────
 
 #[test]
@@ -2431,6 +2444,7 @@ fn aggregated_result_default_is_empty() {
     assert!(result.tooling_dependencies.is_empty());
     assert!(result.script_used_packages.is_empty());
     assert!(result.virtual_module_prefixes.is_empty());
+    assert!(result.virtual_package_suffixes.is_empty());
     assert!(result.path_aliases.is_empty());
     assert!(result.active_plugins.is_empty());
 }

--- a/crates/core/src/plugins/vitest.rs
+++ b/crates/core/src/plugins/vitest.rs
@@ -43,6 +43,14 @@ const FIXTURE_PATTERNS: &[&str] = &[
     "**/fixtures/**/*.{ts,tsx,js,jsx,json}",
 ];
 
+/// Package name suffixes that identify Vitest manual-mock virtual paths.
+///
+/// Vitest's manual-mock convention places mock factories at `<package>/__mocks__/<module>.ts`
+/// and test setups sometimes import from `@<scope>/__mocks__` paths (via package.json `imports`
+/// aliases or workspace virtual paths). These specifiers do not exist on npm and must not be
+/// flagged as unlisted dependencies.
+const VIRTUAL_PACKAGE_SUFFIXES: &[&str] = &["/__mocks__"];
+
 /// Built-in Vitest reporter names that should not be treated as dependencies.
 const BUILTIN_REPORTERS: &[&str] = &[
     "default",
@@ -111,6 +119,10 @@ impl Plugin for VitestPlugin {
 
     fn fixture_glob_patterns(&self) -> &'static [&'static str] {
         FIXTURE_PATTERNS
+    }
+
+    fn virtual_package_suffixes(&self) -> &'static [&'static str] {
+        VIRTUAL_PACKAGE_SUFFIXES
     }
 
     fn resolve_config(&self, config_path: &Path, source: &str, root: &Path) -> PluginResult {
@@ -261,6 +273,55 @@ mod tests {
             source,
             std::path::Path::new("/project"),
         )
+    }
+
+    #[test]
+    fn mocks_path_suffix_is_present() {
+        let suffixes = VitestPlugin.virtual_package_suffixes();
+        assert!(
+            suffixes.contains(&"/__mocks__"),
+            "VitestPlugin should declare /__mocks__ as a virtual package suffix"
+        );
+    }
+
+    #[test]
+    fn scoped_mocks_package_matches_suffix() {
+        let suffixes = VitestPlugin.virtual_package_suffixes();
+        let candidates = [
+            "@aws-sdk/__mocks__",
+            "@sentry/__mocks__",
+            "@supabase/__mocks__",
+            "@mapbox/__mocks__",
+            "@ai-sdk/__mocks__",
+            "some-pkg/__mocks__",
+        ];
+        for candidate in &candidates {
+            assert!(
+                suffixes.iter().any(|s| candidate.ends_with(s)),
+                "{candidate} should be matched by a virtual package suffix"
+            );
+        }
+    }
+
+    #[test]
+    fn non_mocks_package_does_not_match_suffix() {
+        let suffixes = VitestPlugin.virtual_package_suffixes();
+        // Includes adversarial cases that share the substring `__mocks__` but
+        // don't end with `/__mocks__`, plus a package whose own name contains it.
+        let non_mocks = [
+            "@aws-sdk/client-s3",
+            "vitest",
+            "@vitest/coverage-v8",
+            "__mocks__-helper",
+            "my__mocks__pkg",
+            "@scope/__mocks__-utils",
+        ];
+        for candidate in &non_mocks {
+            assert!(
+                !suffixes.iter().any(|s| candidate.ends_with(s)),
+                "{candidate} should NOT be matched by a virtual package suffix"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/tests/integration_test/dependencies.rs
+++ b/crates/core/tests/integration_test/dependencies.rs
@@ -2,6 +2,56 @@ use fallow_config::{FallowConfig, OutputFormat, RulesConfig};
 
 use super::common::{create_config, fixture_path};
 
+// ── Vitest __mocks__ virtual specifiers ───────────────────────
+
+#[test]
+fn vitest_mocks_specifiers_not_flagged_as_unlisted_dep() {
+    let root = fixture_path("vitest-mocks-virtual");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unlisted_names: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|d| d.package_name.as_str())
+        .collect();
+
+    assert!(
+        !unlisted_names.contains(&"@aws-sdk/__mocks__"),
+        "@aws-sdk/__mocks__ should not be flagged as an unlisted dependency, got: {unlisted_names:?}"
+    );
+}
+
+// ── Vitest __mocks__ virtual specifiers in monorepo workspace ─────
+
+#[test]
+fn vitest_mocks_scoped_specifiers_not_flagged_in_workspace_monorepo() {
+    // Vitest is only in apps/mrv/package.json (workspace), not root package.json.
+    // The virtual_package_suffixes contributed by VitestPlugin must be merged from
+    // the workspace plugin result into the root aggregated result, otherwise
+    // @scope/__mocks__ specifiers are still flagged as unlisted dependencies.
+    let root = fixture_path("vitest-mocks-workspace");
+    let config = create_config(root);
+    let results = fallow_core::analyze(&config).expect("analysis should succeed");
+
+    let unlisted_names: Vec<&str> = results
+        .unlisted_dependencies
+        .iter()
+        .map(|d| d.package_name.as_str())
+        .collect();
+
+    for specifier in &[
+        "@aws-sdk/__mocks__",
+        "@supabase/__mocks__",
+        "@sentry/__mocks__",
+    ] {
+        assert!(
+            !unlisted_names.contains(specifier),
+            "{specifier} should not be flagged as an unlisted dependency in workspace monorepo, got: {unlisted_names:?}"
+        );
+    }
+}
+
 // ── Unlisted dependencies integration ──────────────────────────
 
 #[test]

--- a/tests/fixtures/vitest-mocks-virtual/__mocks__/index.ts
+++ b/tests/fixtures/vitest-mocks-virtual/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export const mockS3Send = () => undefined;

--- a/tests/fixtures/vitest-mocks-virtual/package.json
+++ b/tests/fixtures/vitest-mocks-virtual/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "vitest-mocks-virtual",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/tests/fixtures/vitest-mocks-virtual/src/index.ts
+++ b/tests/fixtures/vitest-mocks-virtual/src/index.ts
@@ -1,0 +1,1 @@
+export const appName = 'vitest-mocks-virtual';

--- a/tests/fixtures/vitest-mocks-virtual/src/upload.test.ts
+++ b/tests/fixtures/vitest-mocks-virtual/src/upload.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { mockS3Send } from '@aws-sdk/__mocks__';
+
+describe('upload', () => {
+  it('uses the manual mock', () => {
+    expect(mockS3Send).toBeDefined();
+  });
+});

--- a/tests/fixtures/vitest-mocks-workspace/apps/mrv/package.json
+++ b/tests/fixtures/vitest-mocks-workspace/apps/mrv/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@sagri/mrv",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "vitest": "^4.0.0"
+  }
+}

--- a/tests/fixtures/vitest-mocks-workspace/apps/mrv/src/index.ts
+++ b/tests/fixtures/vitest-mocks-workspace/apps/mrv/src/index.ts
@@ -1,0 +1,1 @@
+export const appName = 'vitest-mocks-workspace';

--- a/tests/fixtures/vitest-mocks-workspace/apps/mrv/tests/upload.test.ts
+++ b/tests/fixtures/vitest-mocks-workspace/apps/mrv/tests/upload.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { mockS3Send } from '@aws-sdk/__mocks__';
+import { mockSend } from '@supabase/__mocks__';
+import { mockCapture } from '@sentry/__mocks__';
+
+describe('upload', () => {
+  it('uses scoped manual mocks', () => {
+    expect(mockS3Send).toBeDefined();
+    expect(mockSend).toBeDefined();
+    expect(mockCapture).toBeDefined();
+  });
+});

--- a/tests/fixtures/vitest-mocks-workspace/package.json
+++ b/tests/fixtures/vitest-mocks-workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "vitest-mocks-workspace",
+  "private": true,
+  "workspaces": ["apps/*"]
+}


### PR DESCRIPTION
## Problem

Vitest's manual-mock convention places mock factories at `<package>/__mocks__/<module>.ts` and triggers them via `vi.mock('<module>')`. Some test setups also import directly from `@<scope>/__mocks__` paths via `package.json#imports` aliases or workspace virtual paths:

\`\`\`ts
import { mockS3Send } from '@aws-sdk/__mocks__';
\`\`\`

Fallow flags these as `unlisted-dep`, and the auto-fix suggests "install `@aws-sdk/__mocks__`" — a package that doesn't exist on npm. Same for `@sentry/__mocks__`, `@supabase/__mocks__`, `@mapbox/__mocks__`, etc.

## Fix

Adds a sibling abstraction to the existing `virtual_module_prefixes` (prefix-based matching used by Nuxt, Docusaurus, etc.):

| | Existing | New |
| --- | --- | --- |
| Trait method | `virtual_module_prefixes()` | `virtual_package_suffixes()` |
| Default | `&[]` | `&[]` |
| Match shape | starts_with on package name | ends_with on package name |
| Example user | Nuxt: `"#"` | Vitest: `"/__mocks__"` |

`VitestPlugin::virtual_package_suffixes` returns `&["/__mocks__"]`. The `find_unlisted_dependencies` filter skips any `package_name` ending with a registered suffix.

## Workspace aggregation

Critical detail: the suffix list must be merged from per-workspace plugin runs into the root `AggregatedPluginResult`. When Vitest is in a workspace's `package.json` (not the root) — common in monorepos — the suffix gets registered locally and would be dropped before the analyzer reads it. `run_plugins` in `lib.rs` now merges `virtual_package_suffixes` alongside `virtual_module_prefixes` and `generated_import_patterns` via a small `extend_unique` helper that consolidates the three identical dedup loops.

## Tests

- 2 unit tests on `VitestPlugin::virtual_package_suffixes`: scoped/unscoped match plus 6-case adversarial negative (`__mocks__-helper`, `my__mocks__pkg`, `@scope/__mocks__-utils` etc.).
- 2 unit tests on `find_unlisted_dependencies`: `@aws-sdk/__mocks__` and `some-pkg/__mocks__` fully suppressed.
- Registry test asserting Vitest contributes the suffix when active.
- 2 integration tests with fixtures:
  - `tests/fixtures/vitest-mocks-virtual/`: single-package, Vitest at root.
  - `tests/fixtures/vitest-mocks-workspace/`: monorepo, Vitest only in `apps/mrv/package.json`. Reproduces the workspace-aggregation case the unit tests alone cannot catch.

## API surface

`Plugin::virtual_package_suffixes(&self) -> &'static [&'static str]` with default `&[]`. Backwards-compatible: existing plugins inherit the default. New `AggregatedPluginResult.virtual_package_suffixes: Vec<String>` field flows through the existing aggregation path.

## Verified on

`cargo test --workspace` (1909 lib + 299 integration tests passing), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`. Real-world: this fork-pinned binary running in a Turborepo monorepo CI cleared all 5 `@*/__mocks__` false positives.