### PR TITLE
fix(eslint): trace flat-config plugin imports through workspace-internal config packages

### DIFF
--- a/crates/core/src/plugins/eslint.rs
+++ b/crates/core/src/plugins/eslint.rs
@@ -150,9 +150,15 @@ fn extract_eslint_config(
     // e.g. eslint.config.js imports @sveltejs/eslint-config, which internally
     // imports typescript-eslint, eslint-plugin-svelte, @eslint/js, all peer deps
     // that the host project must install.
+    //
+    // We use the full import specifier (including subpath, e.g. `@scope/pkg/next`)
+    // so that subpath exports are resolved correctly, and we walk up the directory
+    // tree to find packages hoisted to the monorepo root node_modules.
     for imp in &imports {
         let pkg_name = crate::resolve::extract_package_name(imp);
-        if let Some((entry_source, entry_path)) = read_package_entry(root, &pkg_name) {
+        if let Some((entry_source, entry_path)) =
+            read_package_entry_for_specifier(root, imp, &pkg_name)
+        {
             let nested = config_parser::extract_imports(&entry_source, &entry_path);
             for nested_imp in &nested {
                 result
@@ -319,37 +325,149 @@ fn push_setup_file_once(result: &mut PluginResult, path: PathBuf) {
     }
 }
 
-/// Read a package's entry point source from node_modules.
+/// Maximum directory depth the node_modules walk is allowed to climb.
+/// Real monorepos rarely exceed 4-5 levels (apps/foo, packages/foo/sub); 8 is a
+/// generous ceiling that also bounds pathological inputs (e.g. an absolute path
+/// rooted near `/`) so the walk cannot traverse the entire filesystem.
+const MAX_NODE_MODULES_WALK_DEPTH: usize = 8;
+
+/// Find a package directory by walking up from `start` through ancestor directories,
+/// checking `node_modules/<pkg_name>` at each level. Bounded by
+/// [`MAX_NODE_MODULES_WALK_DEPTH`] so the walk cannot escape into the host filesystem.
 ///
-/// Resolves the package's `module` or `main` field from its `package.json`,
-/// reads the entry file, and returns its source and path. Returns `None` if
-/// the package is not found or the entry file is unreadable.
-fn read_package_entry(root: &Path, pkg_name: &str) -> Option<(String, std::path::PathBuf)> {
-    let pkg_dir = root.join("node_modules").join(pkg_name);
+/// Mirrors Node.js module resolution and handles monorepos where dependencies are
+/// hoisted to the monorepo root rather than installed per-workspace.
+fn find_package_dir(start: &Path, pkg_name: &str) -> Option<PathBuf> {
+    for dir in start.ancestors().take(MAX_NODE_MODULES_WALK_DEPTH) {
+        let candidate = dir.join("node_modules").join(pkg_name);
+        if candidate.join("package.json").exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Read a package's entry point source from node_modules, walking up the directory
+/// tree to find it (handles hoisted deps in monorepos).
+///
+/// When `specifier` contains a subpath (e.g., `@scope/pkg/next`), resolves that
+/// subpath via the package's `exports` map, falling back to extension probing.
+/// Returns `None` if the package is not found, the subpath cannot be resolved,
+/// or the entry file is unreadable.
+fn read_package_entry_for_specifier(
+    workspace_dir: &Path,
+    specifier: &str,
+    pkg_name: &str,
+) -> Option<(String, PathBuf)> {
+    let pkg_dir = find_package_dir(workspace_dir, pkg_name)?;
     let pkg_json_str = std::fs::read_to_string(pkg_dir.join("package.json")).ok()?;
     let pkg_json: serde_json::Value = serde_json::from_str(&pkg_json_str).ok()?;
 
-    // Resolve entry point: "exports"."." → "module" → "main" → "index.js"
-    let entry_rel = pkg_json
-        .get("exports")
-        .and_then(|e| {
-            // "exports": "./index.js" (string shorthand)
-            e.as_str().or_else(|| {
-                // "exports": { ".": "./index.js" } or { ".": { "import": "./index.mjs" } }
-                e.get(".").and_then(|dot| {
-                    dot.as_str()
-                        .or_else(|| dot.get("import").and_then(|v| v.as_str()))
-                        .or_else(|| dot.get("default").and_then(|v| v.as_str()))
-                })
-            })
-        })
-        .or_else(|| pkg_json.get("module").and_then(|v| v.as_str()))
-        .or_else(|| pkg_json.get("main").and_then(|v| v.as_str()))
-        .unwrap_or("index.js");
+    // Extract the subpath from the specifier (e.g., "@scope/pkg/next" → "./next").
+    // If there is no subpath the specifier equals the package name and we use ".".
+    let subpath_key = if specifier.len() > pkg_name.len() {
+        let raw = &specifier[pkg_name.len()..]; // e.g., "/next"
+        format!(".{raw}") // e.g., "./next"
+    } else {
+        ".".to_string()
+    };
 
+    let entry_rel = resolve_package_entry(&pkg_json, &subpath_key, &pkg_dir)?;
     let entry_path = pkg_dir.join(entry_rel);
     let source = std::fs::read_to_string(&entry_path).ok()?;
     Some((source, entry_path))
+}
+
+/// Resolve a package entry path from its `package.json` for the given subpath key.
+///
+/// Subpath key is `"."` for the main entry or `"./subpath"` for named subpaths.
+/// Returns `None` when the subpath cannot be resolved against the exports map and
+/// no `.js`/`.mjs`/`.cjs` file exists for the bare subpath name. Prefer this over
+/// returning a guessed-but-unverified path so the caller can skip the subpath
+/// cleanly rather than `read_to_string` silently swallowing the error.
+fn resolve_package_entry(
+    pkg_json: &serde_json::Value,
+    subpath_key: &str,
+    pkg_dir: &Path,
+) -> Option<String> {
+    if let Some(exports) = pkg_json.get("exports")
+        && let Some(rel) = resolve_exports_subpath(exports, subpath_key)
+    {
+        return Some(rel);
+    }
+
+    if subpath_key == "." {
+        // Main entry: module → main → index.js
+        if let Some(v) = pkg_json.get("module").and_then(|v| v.as_str()) {
+            return Some(v.to_string());
+        }
+        if let Some(v) = pkg_json.get("main").and_then(|v| v.as_str()) {
+            return Some(v.to_string());
+        }
+        return Some("index.js".to_string());
+    }
+
+    // For subpath keys like "./next", strip the leading "./" and try as a direct
+    // file within the package directory. This handles packages that expose
+    // sub-files without an exports map (e.g., `eslint-config-foo/next` → `next.js`).
+    let bare = subpath_key.strip_prefix("./").unwrap_or(subpath_key);
+    if std::path::Path::new(bare).extension().is_some() {
+        return Some(bare.to_string());
+    }
+    for ext in &["js", "mjs", "cjs"] {
+        let candidate = format!("{bare}.{ext}");
+        if pkg_dir.join(&candidate).exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Resolve a subpath key against a package's `exports` field value.
+///
+/// Handles three export formats:
+/// - String shorthand: `"exports": "./index.js"`
+/// - Object with dot key: `"exports": { ".": "./index.js" }`
+/// - Condition object: `"exports": { ".": { "import": "./index.mjs", "default": "./index.cjs" } }`
+/// - Subpath exports: `"exports": { "./next": "./next.js" }`
+fn resolve_exports_subpath(exports: &serde_json::Value, subpath_key: &str) -> Option<String> {
+    if subpath_key == "." {
+        // String shorthand: "exports": "./index.js"
+        if let Some(s) = exports.as_str() {
+            return Some(s.to_string());
+        }
+        // Object: look up "."
+        if let Some(dot) = exports.get(".") {
+            return resolve_condition_object(dot);
+        }
+        return None;
+    }
+
+    // Named subpath: look up the key in the exports object.
+    if let Some(entry) = exports.get(subpath_key) {
+        return resolve_condition_object(entry);
+    }
+
+    None
+}
+
+/// Resolve a condition object (or plain string) to a file path string.
+fn resolve_condition_object(value: &serde_json::Value) -> Option<String> {
+    if let Some(s) = value.as_str() {
+        return Some(s.to_string());
+    }
+    // Prefer "import", then "default", then "require" for ESM-first packages.
+    for key in &["import", "default", "require"] {
+        if let Some(s) = value.get(key).and_then(|v| v.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+fn read_package_entry(root: &Path, pkg_name: &str) -> Option<(String, PathBuf)> {
+    read_package_entry_for_specifier(root, pkg_name, pkg_name)
 }
 
 /// Resolve `ESLint` plugin short name to full package name.
@@ -633,6 +751,31 @@ mod tests {
     }
 
     #[test]
+    fn find_package_dir_finds_local_install_at_depth_zero() {
+        // Confirms the walk does not skip a package that is co-located with
+        // the workspace's own node_modules (the default before this PR).
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path();
+        let pkg_dir = workspace.join("node_modules/local-pkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("package.json"), r#"{"name":"local-pkg"}"#).unwrap();
+
+        let resolved = super::find_package_dir(workspace, "local-pkg");
+        assert_eq!(resolved.as_deref(), Some(pkg_dir.as_path()));
+    }
+
+    #[test]
+    fn find_package_dir_returns_none_when_walk_finds_nothing() {
+        // Walk-up failure must return None cleanly, not panic. Uses a deep
+        // workspace path with no node_modules anywhere along the chain.
+        let dir = tempfile::tempdir().unwrap();
+        let deep = dir.path().join("apps/foo/src");
+        std::fs::create_dir_all(&deep).unwrap();
+        // Sanity: no node_modules exists on this path.
+        assert!(super::find_package_dir(&deep, "missing-pkg").is_none());
+    }
+
+    #[test]
     fn read_package_entry_exports_field() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -654,6 +797,129 @@ mod tests {
         let (source, path) = super::read_package_entry(root, "modern-pkg").unwrap();
         assert!(source.contains("some-dep"));
         assert!(path.ends_with("dist/index.mjs"));
+    }
+
+    // ── Workspace-package flat-config dep tracing ──────────────────
+
+    /// Regression test: apps/foo/eslint.config.mjs imports @scope/eslint-config,
+    /// which itself imports eslint-plugin-react. Both packages list eslint-plugin-react
+    /// in devDependencies. Fallow must NOT flag eslint-plugin-react as unused-devdep.
+    ///
+    /// The shared config lives at packages/eslint-config in the monorepo root, but
+    /// its node_modules symlink is hoisted to monorepo-root/node_modules. The workspace
+    /// package's eslint.config.mjs is analysed with root=apps/foo, so read_package_entry
+    /// must walk up to the monorepo root to find the package.
+    #[test]
+    fn flat_config_workspace_package_dep_chain_traced() {
+        // Set up a minimal monorepo layout:
+        //   <root>/
+        //     node_modules/@scope/eslint-config/
+        //       package.json  (main: "index.js")
+        //       index.js      (imports eslint-plugin-react)
+        //     apps/foo/
+        //       eslint.config.mjs  (imports @scope/eslint-config)
+        let dir = tempfile::tempdir().unwrap();
+        let monorepo_root = dir.path();
+
+        // Shared config package in hoisted node_modules
+        let shared_pkg_dir = monorepo_root.join("node_modules/@scope/eslint-config");
+        std::fs::create_dir_all(&shared_pkg_dir).unwrap();
+        std::fs::write(
+            shared_pkg_dir.join("package.json"),
+            r#"{"name": "@scope/eslint-config", "main": "index.js"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            shared_pkg_dir.join("index.js"),
+            r"
+                import reactPlugin from 'eslint-plugin-react';
+                import storybook from 'eslint-plugin-storybook';
+                export default [{ plugins: { react: reactPlugin } }];
+            ",
+        )
+        .unwrap();
+
+        // App workspace with its own eslint.config.mjs
+        let app_dir = monorepo_root.join("apps/foo");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        let eslint_config_path = app_dir.join("eslint.config.mjs");
+        let source = r"
+            import sharedConfig from '@scope/eslint-config';
+            export default [...sharedConfig];
+        ";
+        std::fs::write(&eslint_config_path, source).unwrap();
+
+        let plugin = EslintPlugin;
+        // root = apps/foo — mirrors how run_workspace_fast calls resolve_config
+        let result = plugin.resolve_config(&eslint_config_path, source, &app_dir);
+
+        let deps = &result.referenced_dependencies;
+        assert!(
+            deps.contains(&"@scope/eslint-config".to_string()),
+            "direct workspace package import must be listed as used: {deps:?}"
+        );
+        assert!(
+            deps.contains(&"eslint-plugin-react".to_string()),
+            "transitive dep from workspace config package must not be flagged unused: {deps:?}"
+        );
+        assert!(
+            deps.contains(&"eslint-plugin-storybook".to_string()),
+            "second transitive dep from workspace config package must not be flagged unused: {deps:?}"
+        );
+    }
+
+    /// When the import uses a subpath (e.g. `@scope/eslint-config/next`),
+    /// the /next file's imports must be discovered, not the package's main entry.
+    #[test]
+    fn flat_config_workspace_package_subpath_dep_chain_traced() {
+        let dir = tempfile::tempdir().unwrap();
+        let monorepo_root = dir.path();
+
+        let shared_pkg_dir = monorepo_root.join("node_modules/@scope/eslint-config");
+        std::fs::create_dir_all(&shared_pkg_dir).unwrap();
+        std::fs::write(
+            shared_pkg_dir.join("package.json"),
+            r#"{"name": "@scope/eslint-config", "main": "index.js"}"#,
+        )
+        .unwrap();
+        // main entry does NOT import eslint-plugin-react
+        std::fs::write(shared_pkg_dir.join("index.js"), r"export default [];").unwrap();
+        // /next subpath DOES import eslint-plugin-react
+        std::fs::write(
+            shared_pkg_dir.join("next.js"),
+            r"
+                import nextConfig from 'eslint-config-next';
+                import reactPlugin from 'eslint-plugin-react';
+                export default [{ plugins: { react: reactPlugin }, ...nextConfig }];
+            ",
+        )
+        .unwrap();
+
+        let app_dir = monorepo_root.join("apps/foo");
+        std::fs::create_dir_all(&app_dir).unwrap();
+        let eslint_config_path = app_dir.join("eslint.config.mjs");
+        let source = r"
+            import nextConfig from '@scope/eslint-config/next';
+            export default [...nextConfig];
+        ";
+        std::fs::write(&eslint_config_path, source).unwrap();
+
+        let plugin = EslintPlugin;
+        let result = plugin.resolve_config(&eslint_config_path, source, &app_dir);
+
+        let deps = &result.referenced_dependencies;
+        assert!(
+            deps.contains(&"@scope/eslint-config".to_string()),
+            "scoped package name must be listed: {deps:?}"
+        );
+        assert!(
+            deps.contains(&"eslint-plugin-react".to_string()),
+            "transitive dep via subpath import must be traced: {deps:?}"
+        );
+        assert!(
+            deps.contains(&"eslint-config-next".to_string()),
+            "transitive dep via subpath import must be traced: {deps:?}"
+        );
     }
 
     // ── ESLint resolver name resolution ────────────────────────────

--- a/crates/core/src/plugins/registry/mod.rs
+++ b/crates/core/src/plugins/registry/mod.rs
@@ -15,10 +15,14 @@ use helpers::{
     process_static_patterns,
 };
 
+// ESLint is included because each workspace owns its own eslint.config.{mjs,js,...}
+// that may import a shared workspace eslint-config package. Those transitive deps
+// (e.g. eslint-config-next, eslint-plugin-react) are declared in the workspace's
+// devDependencies and will be flagged as unused if we skip config parsing here.
 fn must_parse_workspace_config_when_root_active(plugin_name: &str) -> bool {
     matches!(
         plugin_name,
-        "docusaurus" | "jest" | "tanstack-router" | "vitest"
+        "eslint" | "docusaurus" | "jest" | "tanstack-router" | "vitest"
     )
 }
 

--- a/crates/core/src/plugins/registry/tests.rs
+++ b/crates/core/src/plugins/registry/tests.rs
@@ -1553,6 +1553,91 @@ fn run_workspace_fast_returns_empty_for_no_active_plugins() {
     assert!(result.always_used.is_empty());
 }
 
+/// Regression: monorepo where ESLint is active at the root level.
+///
+/// Layout:
+///   <root>/
+///     node_modules/@scope/eslint-config/
+///       package.json  (main: "index.js")
+///       index.js      (imports eslint-plugin-react)
+///     apps/foo/
+///       package.json  (devDeps: eslint, eslint-plugin-react)
+///       eslint.config.mjs  (imports @scope/eslint-config)
+///
+/// When ESLint is already in `skip_config_plugins` (root-level plugin ran),
+/// the workspace eslint.config.mjs must still be parsed so that
+/// eslint-plugin-react appears in referenced_dependencies.
+#[test]
+fn run_workspace_fast_eslint_config_parsed_when_eslint_active_at_root() {
+    let registry = PluginRegistry::default();
+    let matchers = registry.precompile_config_matchers();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let monorepo_root = tmp.path();
+
+    // Shared eslint-config package hoisted to root node_modules
+    let shared_pkg_dir = monorepo_root.join("node_modules/@scope/eslint-config");
+    std::fs::create_dir_all(&shared_pkg_dir).unwrap();
+    std::fs::write(
+        shared_pkg_dir.join("package.json"),
+        r#"{"name": "@scope/eslint-config", "main": "index.js"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        shared_pkg_dir.join("index.js"),
+        r"
+            import reactPlugin from 'eslint-plugin-react';
+            export default [{ plugins: { react: reactPlugin } }];
+        ",
+    )
+    .unwrap();
+
+    // Workspace with its own eslint.config.mjs
+    let app_dir = monorepo_root.join("apps/foo");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    let config_path = app_dir.join("eslint.config.mjs");
+    std::fs::write(
+        &config_path,
+        r"
+            import sharedConfig from '@scope/eslint-config';
+            export default [...sharedConfig];
+        ",
+    )
+    .unwrap();
+
+    let pkg: PackageJson = serde_json::from_value(serde_json::json!({
+        "devDependencies": {
+            "eslint": "^9",
+            "eslint-plugin-react": "^7",
+            "@scope/eslint-config": "*"
+        }
+    }))
+    .unwrap();
+
+    // Simulate root-level ESLint being active: "eslint" is in skip_config_plugins
+    let mut skip_config_plugins = FxHashSet::default();
+    skip_config_plugins.insert("eslint");
+
+    let workspace_relative = vec![(config_path, "eslint.config.mjs".to_string())];
+    let result = registry.run_workspace_fast(
+        &pkg,
+        &app_dir,
+        monorepo_root,
+        &matchers,
+        &workspace_relative,
+        &skip_config_plugins,
+    );
+
+    assert!(
+        result
+            .referenced_dependencies
+            .contains(&"eslint-plugin-react".to_string()),
+        "eslint-plugin-react must be listed as referenced even when ESLint is in skip_config_plugins; \
+         got: {:?}",
+        result.referenced_dependencies
+    );
+}
+
 #[test]
 fn run_workspace_fast_detects_active_plugins() {
     let registry = PluginRegistry::default();


### PR DESCRIPTION
## Problem

In Turborepo/Nx monorepos that centralize ESLint config in a workspace package, every workspace gets false `unused-devdep` flags for the plugins that the shared config imports. Pattern:

\`\`\`js
// apps/foo/eslint.config.mjs
import next from '@scope/eslint-config/next';
export default [...next];

// packages/eslint-config/next.js
import reactPlugin from 'eslint-plugin-react';
export default [{ plugins: { react: reactPlugin } }];
\`\`\`

\`\`\`json
// apps/foo/package.json
{
  "devDependencies": {
    "eslint": "^9",
    "eslint-plugin-react": "^7",
    "@scope/eslint-config": "*"
  }
}
\`\`\`

`eslint-plugin-react` is flagged as unused-devdep in `apps/foo/package.json`, even though the workspace package transitively imports it.

## Fix

Two cooperating changes:

### 1. `crates/core/src/plugins/eslint.rs`

- `find_package_dir` walks up `start.ancestors()` checking `node_modules/<pkg>/package.json`. Bounded by `MAX_NODE_MODULES_WALK_DEPTH = 8` so the walk cannot escape into the host filesystem. Handles Turborepo/pnpm hoisting where deps live in the monorepo root rather than per-workspace.
- `read_package_entry_for_specifier` resolves `@scope/pkg/subpath` imports via the package's `exports` map, falling back to `.js`/`.mjs`/`.cjs` extension probing on the bare subpath name.
- `resolve_package_entry` returns `Option<String>` — when no exports-map entry and no extension probe matches, returns `None` so the caller skips the subpath cleanly. Replaces an earlier silent-fallthrough that would synthesize a guessed path and rely on `read_to_string` to fail.

### 2. `crates/core/src/plugins/registry/mod.rs`

Adds `"eslint"` to the `must_parse_workspace_config_when_root_active` allowlist (already contains `docusaurus`, `jest`, `tanstack-router`, `vitest`). Without this, when ESLint is already active at the monorepo root, every workspace's `eslint.config.*` is silently skipped by `run_workspace_fast`, and the resolver from (1) never gets called. Discovered via integration testing: the resolver was correct in isolation but never invoked at runtime.

## Tests

- 38 existing eslint plugin tests still pass.
- `find_package_dir_finds_local_install_at_depth_zero`: walk does not skip a package co-located with the workspace.
- `find_package_dir_returns_none_when_walk_finds_nothing`: walk-up failure returns None cleanly.
- `run_workspace_fast_eslint_config_parsed_when_eslint_active_at_root`: full integration test reproducing the real-world Turborepo layout (hoisted `@scope/eslint-config` package + workspace `eslint.config.mjs` + `skip_config_plugins` containing `"eslint"`) and asserting `eslint-plugin-react` appears in `referenced_dependencies`.

40 ESLint tests pass total. Other plugins not regressed.

## Known follow-ups (out of scope)

- `resolve_exports_subpath` does not handle wildcard patterns (`"./features/*": "./src/features/*.js"`). Increasingly common in design-system packages. Filed as separate concern.
- When ESLint is active at both root and workspace, `referenced_dependencies` accumulates duplicates from both passes. Final consumption already deduplicates via `FxHashSet<&str>`, so this is a memory bloat issue rather than correctness. If the maintainers prefer pre-dedup at aggregation time, happy to follow up.

## Verified on

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`. Real-world: this fork-pinned binary running in a Turborepo monorepo CI cleared the false-positive `unused-devdep` flags for `eslint-config-next` and `eslint-plugin-prettier` while still correctly flagging a genuinely-unused `eslint-plugin-unused-imports`.